### PR TITLE
feat(trading): align tool-input ordering with provider configs

### DIFF
--- a/apps/tradinggoose/blocks/blocks/trading_action.ts
+++ b/apps/tradinggoose/blocks/blocks/trading_action.ts
@@ -1,12 +1,14 @@
 import { DollarIcon } from '@/components/icons/icons'
-import type { BlockConfig, SubBlockConfig } from '@/blocks/types'
+import type { BlockConfig, SubBlockCondition, SubBlockConfig } from '@/blocks/types'
 import { AuthMode } from '@/blocks/types'
 import { buildInputsFromToolParams } from '@/blocks/utils'
 import {
-  getProviderFields,
+  getTradingProviderParamCatalog,
+  getTradingProviderParamDefinitions,
   getTradingProviderIdsForParam,
   getTradingProviders,
 } from '@/providers/trading'
+import type { TradingProviderParamDefinition } from '@/providers/trading/providers'
 import { tradingActionTool } from '@/tools/trading'
 import type { TradingActionResponse } from '@/tools/trading/types'
 
@@ -17,6 +19,148 @@ const providerOptions = getTradingProviders().map((provider) => ({
 
 const providersWithEnvironment = getTradingProviderIdsForParam('order', 'environment')
 
+const BLOCK_RESERVED_PARAM_IDS = new Set([
+  'provider',
+  'credential',
+  'environment',
+  'side',
+  'listing',
+  'orderType',
+  'limitPrice',
+  'stopPrice',
+  'timeInForce',
+])
+
+const TOOL_RESERVED_PARAM_IDS = new Set([
+  'provider',
+  'credential',
+  'environment',
+  'side',
+  'listing',
+  'quantity',
+  'notional',
+  'orderType',
+  'limitPrice',
+  'stopPrice',
+  'timeInForce',
+])
+
+const providerParamCatalog = getTradingProviderParamCatalog('order')
+const providerParamRegistry = providerParamCatalog.registry
+const providerParamOrderIndex = new Map(
+  providerParamCatalog.order.map((paramId, index) => [paramId, index])
+)
+
+const orderedProviderParamIds = [...providerParamCatalog.order].sort((a, b) => {
+  const aOrder = providerParamRegistry[a]?.definition.displayOrder
+  const bOrder = providerParamRegistry[b]?.definition.displayOrder
+  const aHasOrder = typeof aOrder === 'number'
+  const bHasOrder = typeof bOrder === 'number'
+
+  if (aHasOrder && bHasOrder && aOrder !== bOrder) {
+    return aOrder - bOrder
+  }
+  if (aHasOrder && !bHasOrder) return -1
+  if (!aHasOrder && bHasOrder) return 1
+  return (providerParamOrderIndex.get(a) ?? 0) - (providerParamOrderIndex.get(b) ?? 0)
+})
+
+const isSensitiveParam = (paramId: string): boolean => {
+  const lowered = paramId.toLowerCase()
+  return (
+    lowered.includes('apikey') ||
+    lowered.includes('api_key') ||
+    lowered.includes('secret') ||
+    lowered.includes('token') ||
+    lowered.includes('password')
+  )
+}
+
+const formatParamTitle = (paramId: string): string => {
+  if (paramId === 'apiKey') return 'API Key'
+  if (paramId === 'apiSecret') return 'API Secret'
+
+  if (paramId.includes('_') || paramId.includes('-')) {
+    return paramId
+      .split(/[-_]/)
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ')
+  }
+
+  if (/[A-Z]/.test(paramId)) {
+    const result = paramId.replace(/([A-Z])/g, ' $1')
+    return (
+      result.charAt(0).toUpperCase() +
+      result
+        .slice(1)
+        .replace(/ Api/g, ' API')
+        .replace(/ Id/g, ' ID')
+        .replace(/ Url/g, ' URL')
+        .replace(/ Uri/g, ' URI')
+    )
+  }
+
+  return paramId.charAt(0).toUpperCase() + paramId.slice(1)
+}
+
+const shouldIncludeProviderParam = (
+  definition: TradingProviderParamDefinition,
+  reservedParams: Set<string> = BLOCK_RESERVED_PARAM_IDS
+): boolean => {
+  if (reservedParams.has(definition.id)) return false
+  if (definition.visibility === 'hidden' || definition.visibility === 'llm-only') return false
+  return true
+}
+
+const resolveParamInputType = (
+  definition: TradingProviderParamDefinition
+): SubBlockConfig['type'] => {
+  if (definition.inputType) return definition.inputType
+  if (definition.options?.length) return 'dropdown'
+
+  switch (definition.type) {
+    case 'boolean':
+      return 'switch'
+    case 'json':
+    case 'array':
+      return 'code'
+    case 'number':
+      return 'short-input'
+    default:
+      return 'short-input'
+  }
+}
+
+const normalizeConditionList = (
+  condition?: SubBlockCondition | SubBlockCondition[]
+): SubBlockCondition[] => {
+  if (!condition) return []
+  return Array.isArray(condition) ? condition : [condition]
+}
+
+const mergeParamConditions = (
+  definitionCondition?: TradingProviderParamDefinition['condition'],
+  providerCondition?: SubBlockCondition
+): SubBlockCondition | undefined => {
+  if (!definitionCondition) return providerCondition
+  if (!providerCondition) return definitionCondition as SubBlockCondition
+
+  const baseCondition = definitionCondition as SubBlockCondition
+  const baseAnd = normalizeConditionList(baseCondition.and)
+
+  if (baseAnd.length === 0) {
+    return {
+      ...baseCondition,
+      and: providerCondition,
+    }
+  }
+
+  return {
+    ...baseCondition,
+    and: [...baseAnd, providerCondition],
+  }
+}
+
 const toOptionalNumber = (value: unknown): number | undefined => {
   if (value === null || value === undefined) return undefined
   if (typeof value === 'string' && value.trim() === '') return undefined
@@ -24,23 +168,50 @@ const toOptionalNumber = (value: unknown): number | undefined => {
   return Number.isFinite(parsed) ? parsed : undefined
 }
 
-const providerFieldBlocks = (): SubBlockConfig[] => {
-  const providers = getTradingProviders()
-  return providers.flatMap((provider) =>
-    (provider.fields || []).map((field) => ({
-      id: field.id,
-      title: field.label,
-      type: field.type === 'dropdown' ? 'dropdown' : 'short-input',
-      layout: 'full',
-      required: field.required,
-      placeholder: field.placeholder,
-      description: field.description,
-      options: field.options?.map((option) => ({ label: option.label, id: option.id })),
-      condition: { field: 'provider', value: provider.id },
-      canonicalParamId: field.id,
-    }))
-  )
-}
+const providerParamBlocks = (): SubBlockConfig[] =>
+  orderedProviderParamIds
+    .map((paramId) => {
+      const entry = providerParamRegistry[paramId]
+      if (!entry) return null
+
+      const definition = entry.definition
+      if (!shouldIncludeProviderParam(definition)) return null
+
+      const inputType = resolveParamInputType(definition)
+      const numericInputType =
+        (inputType === 'short-input' || inputType === 'long-input') &&
+        definition.type === 'number'
+          ? 'number'
+          : undefined
+      const providerCondition = entry.providers.length
+        ? ({ field: 'provider', value: entry.providers } as SubBlockCondition)
+        : undefined
+      const condition = mergeParamConditions(definition.condition, providerCondition)
+
+      return {
+        id: paramId,
+        title: definition.title || formatParamTitle(paramId),
+        type: inputType,
+        layout: definition.layout || 'full',
+        required: definition.required,
+        placeholder: definition.placeholder || definition.description,
+        description: definition.description,
+        options: definition.options,
+        defaultValue: definition.defaultValue,
+        fetchOptions: definition.fetchOptions,
+        min: definition.min,
+        max: definition.max,
+        step: definition.step,
+        integer: definition.integer,
+        rows: definition.rows,
+        dependsOn: definition.dependsOn,
+        mode: definition.mode,
+        inputType: numericInputType,
+        password: definition.password ?? isSensitiveParam(paramId),
+        condition,
+      } as SubBlockConfig
+    })
+    .filter((block): block is SubBlockConfig => Boolean(block))
 
 const providerCredentialBlocks = (): SubBlockConfig[] => {
   const providers = getTradingProviders()
@@ -122,25 +293,6 @@ export const TradingActionBlock: BlockConfig<TradingActionResponse> = {
       required: true,
     },
     {
-      id: 'quantity',
-      title: 'Quantity (Shares)',
-      type: 'short-input',
-      layout: 'half',
-      placeholder: 'Number of shares',
-      required: false,
-      description: 'Required for non-Alpaca orders or when dollar amount is not provided.',
-    },
-    {
-      id: 'notional',
-      title: 'Dollar Amount (USD)',
-      type: 'short-input',
-      layout: 'half',
-      placeholder: 'e.g. 500.00',
-      required: false,
-      description: 'Alpaca only. Provide either quantity or dollar amount, not both.',
-      condition: { field: 'provider', value: 'alpaca' },
-    },
-    {
       id: 'orderType',
       title: 'Order Type',
       type: 'dropdown',
@@ -184,7 +336,7 @@ export const TradingActionBlock: BlockConfig<TradingActionResponse> = {
       ],
       placeholder: 'Defaults vary by provider',
     },
-    ...providerFieldBlocks(),
+    ...providerParamBlocks(),
   ],
   tools: {
     access: ['trading_place_order'],
@@ -203,13 +355,16 @@ export const TradingActionBlock: BlockConfig<TradingActionResponse> = {
             .find((value) => value !== undefined)
         }
         const credential = resolveCredential()
-        const extraFields = getProviderFields(provider, 'order').reduce((acc, field) => {
-          const key = `${provider}_${field.id}`
-          if (params[key] !== undefined) {
-            acc[field.id] = params[key]
-          }
-          return acc
-        }, {} as Record<string, any>)
+        const extraFields = getTradingProviderParamDefinitions(provider, 'order').reduce(
+          (acc, definition) => {
+            if (!shouldIncludeProviderParam(definition, TOOL_RESERVED_PARAM_IDS)) return acc
+            if (params[definition.id] !== undefined) {
+              acc[definition.id] = params[definition.id]
+            }
+            return acc
+          },
+          {} as Record<string, any>
+        )
 
         return {
           provider,

--- a/apps/tradinggoose/blocks/types.ts
+++ b/apps/tradinggoose/blocks/types.ts
@@ -81,6 +81,13 @@ export type SubBlockType =
 
 export type SubBlockLayout = 'full' | 'half'
 
+export interface SubBlockCondition {
+  field: string
+  value: string | number | boolean | Array<string | number | boolean>
+  not?: boolean
+  and?: SubBlockCondition | SubBlockCondition[]
+}
+
 export type ExtractToolOutput<T> = T extends ToolResponse ? T['output'] : never
 
 export type ToolOutputToValueType<T> = T extends Record<string, any>
@@ -207,26 +214,8 @@ export interface SubBlockConfig {
   maxHeight?: number
   selectAllOption?: boolean
   condition?:
-  | {
-    field: string
-    value: string | number | boolean | Array<string | number | boolean>
-    not?: boolean
-    and?: {
-      field: string
-      value: string | number | boolean | Array<string | number | boolean> | undefined
-      not?: boolean
-    }
-  }
-  | (() => {
-    field: string
-    value: string | number | boolean | Array<string | number | boolean>
-    not?: boolean
-    and?: {
-      field: string
-      value: string | number | boolean | Array<string | number | boolean> | undefined
-      not?: boolean
-    }
-  })
+  | SubBlockCondition
+  | (() => SubBlockCondition)
   // Props specific to 'code' sub-block type
   language?: 'javascript' | 'json' | 'python'
   generationType?: GenerationType

--- a/apps/tradinggoose/providers/trading/alpaca/config.ts
+++ b/apps/tradinggoose/providers/trading/alpaca/config.ts
@@ -19,7 +19,7 @@ const params: TradingProviderConfig['params'] = {
       description: 'Alpaca API key ID.',
       placeholder: 'APCA-API-KEY-ID',
       required: false,
-      visibility: 'user-only',
+      visibility: 'hidden',
       password: true,
     },
     {
@@ -29,7 +29,7 @@ const params: TradingProviderConfig['params'] = {
       description: 'Alpaca API secret key.',
       placeholder: 'APCA-API-SECRET-KEY',
       required: false,
-      visibility: 'user-only',
+      visibility: 'hidden',
       password: true,
     },
     {
@@ -55,6 +55,9 @@ const params: TradingProviderConfig['params'] = {
       required: true,
       visibility: 'user-or-llm',
       inputType: 'dropdown',
+      defaultValue: 'quantity',
+      dependsOn: ['provider'],
+      displayOrder: 0,
       options: [
         { id: 'quantity', label: 'Quantity (Shares)' },
         { id: 'notional', label: 'Dollar Amount (USD)' },
@@ -67,6 +70,8 @@ const params: TradingProviderConfig['params'] = {
       description: 'Number of shares to trade when sizing by quantity.',
       required: false,
       visibility: 'user-or-llm',
+      condition: { field: 'orderSizingMode', value: 'notional', not: true },
+      displayOrder: 20,
     },
     {
       id: 'notional',
@@ -75,6 +80,9 @@ const params: TradingProviderConfig['params'] = {
       description: 'Dollar amount to trade when sizing by notional.',
       required: false,
       visibility: 'user-or-llm',
+      condition: { field: 'orderSizingMode', value: 'notional' },
+      dependsOn: ['provider'],
+      displayOrder: 30,
     },
   ],
 }

--- a/apps/tradinggoose/providers/trading/providers.ts
+++ b/apps/tradinggoose/providers/trading/providers.ts
@@ -64,6 +64,13 @@ export interface TradingProviderParamOption {
   label: string
 }
 
+export interface TradingProviderParamCondition {
+  field: string
+  value: string | number | boolean | Array<string | number | boolean>
+  not?: boolean
+  and?: TradingProviderParamCondition | TradingProviderParamCondition[]
+}
+
 export interface TradingProviderParamDefinition {
   id: string
   type: TradingProviderParamType
@@ -89,6 +96,8 @@ export interface TradingProviderParamDefinition {
   integer?: boolean
   rows?: number
   dependsOn?: string[]
+  condition?: TradingProviderParamCondition
+  displayOrder?: number
 }
 
 export interface TradingProviderParamConfig {
@@ -403,6 +412,8 @@ function mergeParamDefinition(
     integer: current.integer ?? next.integer,
     rows: current.rows ?? next.rows,
     dependsOn: current.dependsOn ?? next.dependsOn,
+    condition: current.condition ?? next.condition,
+    displayOrder: current.displayOrder ?? next.displayOrder,
   }
 
   merged.required = Boolean(current.required) && Boolean(next.required)

--- a/apps/tradinggoose/providers/trading/robinhood/config.ts
+++ b/apps/tradinggoose/providers/trading/robinhood/config.ts
@@ -32,6 +32,14 @@ const params: TradingProviderConfig['params'] = {
   ],
   order: [
     {
+      id: 'quantity',
+      type: 'number',
+      title: 'Quantity (Shares)',
+      description: 'Number of shares to trade.',
+      required: false,
+      visibility: 'user-or-llm',
+    },
+    {
       id: 'instrumentUrl',
       type: 'string',
       title: 'Instrument URL',

--- a/apps/tradinggoose/providers/trading/tradier/config.ts
+++ b/apps/tradinggoose/providers/trading/tradier/config.ts
@@ -43,6 +43,16 @@ const params: TradingProviderConfig['params'] = {
       ],
     },
   ],
+  order: [
+    {
+      id: 'quantity',
+      type: 'number',
+      title: 'Quantity (Shares)',
+      description: 'Number of shares to trade.',
+      required: false,
+      visibility: 'user-or-llm',
+    },
+  ],
 }
 
 const exchangeCodeToMicMap: TradingProviderConfig['exchangeCodeToMic'] = {}

--- a/apps/tradinggoose/providers/trading/types.ts
+++ b/apps/tradinggoose/providers/trading/types.ts
@@ -44,6 +44,7 @@ export interface TradingOrderInput extends TradingSymbolInput {
   side: 'buy' | 'sell'
   quantity?: number
   notional?: number
+  orderSizingMode?: string
   orderType?: string
   timeInForce?: string
   limitPrice?: number

--- a/apps/tradinggoose/tools/params.ts
+++ b/apps/tradinggoose/tools/params.ts
@@ -2,6 +2,11 @@ import { createLogger } from '@/lib/logs/console/logger'
 import type { TimeFormat } from '@/lib/time-format'
 import type { ParameterVisibility, ToolConfig } from '@/tools/types'
 import { getTool } from '@/tools/utils'
+import {
+  getTradingProviderParamCatalog,
+  getTradingProviderParamDefinitions,
+} from '@/providers/trading/providers'
+import type { TradingProviderParamDefinition } from '@/providers/trading/providers'
 
 const logger = createLogger('ToolsParams')
 
@@ -12,7 +17,9 @@ export interface Option {
 
 export interface ComponentCondition {
   field: string
-  value: string
+  value: string | number | boolean | Array<string | number | boolean>
+  not?: boolean
+  and?: ComponentCondition | ComponentCondition[]
 }
 
 export interface UIComponentConfig {
@@ -149,6 +156,69 @@ export interface ToolWithParameters {
 
 let blockConfigCache: Record<string, BlockConfig> | null = null
 
+const resolveProviderInputType = (
+  definition: TradingProviderParamDefinition
+): UIComponentConfig['type'] => {
+  if (definition.inputType) return definition.inputType
+  if (definition.options?.length) return 'dropdown'
+
+  switch (definition.type) {
+    case 'boolean':
+      return 'switch'
+    case 'json':
+    case 'array':
+      return 'code'
+    case 'number':
+      return 'short-input'
+    default:
+      return 'short-input'
+  }
+}
+
+const normalizeConditionList = (
+  condition?: ComponentCondition | ComponentCondition[]
+): ComponentCondition[] => {
+  if (!condition) return []
+  return Array.isArray(condition) ? condition : [condition]
+}
+
+const combineConditions = (
+  base?: ComponentCondition,
+  extra?: ComponentCondition | ComponentCondition[]
+): ComponentCondition | undefined => {
+  if (!base) return extra as ComponentCondition | undefined
+  if (!extra) return base
+
+  const baseAnd = normalizeConditionList(base.and)
+  const extraList = normalizeConditionList(extra)
+
+  return {
+    ...base,
+    and: [...baseAnd, ...extraList],
+  }
+}
+
+const buildProviderUiComponent = (
+  definition: TradingProviderParamDefinition,
+  condition?: ComponentCondition
+): UIComponentConfig => ({
+  type: resolveProviderInputType(definition),
+  options: definition.options?.map((option) => ({ id: option.id, label: option.label })),
+  placeholder: definition.placeholder,
+  password: definition.password,
+  title: definition.title,
+  layout: definition.layout,
+  min: definition.min,
+  max: definition.max,
+  step: definition.step,
+  integer: definition.integer,
+  rows: definition.rows,
+  dependsOn: definition.dependsOn,
+  fetchOptions: definition.fetchOptions,
+  condition,
+  inputType: definition.type === 'number' ? 'number' : undefined,
+})
+
 function getBlockConfigurations(): Record<string, BlockConfig> {
   if (!blockConfigCache) {
     try {
@@ -172,7 +242,8 @@ function getBlockConfigurations(): Record<string, BlockConfig> {
  */
 export function getToolParametersConfig(
   toolId: string,
-  blockType?: string
+  blockType?: string,
+  contextValues?: Record<string, any>
 ): ToolWithParameters | null {
   try {
     const toolConfig = getTool(toolId)
@@ -194,8 +265,77 @@ export function getToolParametersConfig(
       blockConfig = blockConfigs[blockType] || null
     }
 
+    const tradingProviderContext = (() => {
+      if (toolId !== 'trading_place_order') return null
+
+      const providerId = contextValues?.provider as string | undefined
+      const providerDefinitions = providerId
+        ? getTradingProviderParamDefinitions(providerId, 'order')
+        : []
+      const providerCatalog = getTradingProviderParamCatalog('order')
+
+      return {
+        providerId,
+        providerDefinitions,
+        providerCatalog,
+      }
+    })()
+
+    const baseParamEntries = Object.entries(toolConfig.params)
+    let orderedParamEntries = baseParamEntries
+
+    if (tradingProviderContext?.providerDefinitions?.length) {
+      const baseParamIds = baseParamEntries.map(([paramId]) => paramId)
+      const providerParamIds = tradingProviderContext.providerDefinitions
+        .map((definition) => definition.id)
+        .filter((paramId) => baseParamIds.includes(paramId))
+
+      if (providerParamIds.length > 0) {
+        const providerOrder = tradingProviderContext.providerDefinitions
+          .filter((definition) => providerParamIds.includes(definition.id))
+          .map((definition, index) => ({
+            id: definition.id,
+            displayOrder: definition.displayOrder,
+            providerIndex: index,
+          }))
+          .sort((a, b) => {
+            const aHasOrder = typeof a.displayOrder === 'number'
+            const bHasOrder = typeof b.displayOrder === 'number'
+            if (aHasOrder && bHasOrder && a.displayOrder !== b.displayOrder) {
+              return (a.displayOrder as number) - (b.displayOrder as number)
+            }
+            if (aHasOrder && !bHasOrder) return -1
+            if (!aHasOrder && bHasOrder) return 1
+            return a.providerIndex - b.providerIndex
+          })
+          .map((entry) => entry.id)
+
+        const firstProviderIndex = baseParamIds.findIndex((paramId) =>
+          providerParamIds.includes(paramId)
+        )
+
+        if (firstProviderIndex >= 0) {
+          const remainingIds = baseParamIds.filter(
+            (paramId) => !providerParamIds.includes(paramId)
+          )
+          const reorderedIds = [
+            ...remainingIds.slice(0, firstProviderIndex),
+            ...providerOrder,
+            ...remainingIds.slice(firstProviderIndex),
+          ]
+          const entryMap = new Map(baseParamEntries)
+          orderedParamEntries = reorderedIds
+            .map((paramId) => {
+              const entry = entryMap.get(paramId)
+              return entry ? [paramId, entry] : undefined
+            })
+            .filter(Boolean) as Array<[string, any]>
+        }
+      }
+    }
+
     // Convert tool params to our standard format with UI component info
-    const allParameters: ToolParameterConfig[] = Object.entries(toolConfig.params).map(
+    const allParameters: ToolParameterConfig[] = orderedParamEntries.map(
       ([paramId, param]) => {
         const toolParam: ToolParameterConfig = {
           id: paramId,
@@ -287,6 +427,53 @@ export function getToolParametersConfig(
               dependsOn: subBlock.dependsOn,
               fetchOptions: subBlock.fetchOptions,
             }
+          }
+        }
+
+        if (tradingProviderContext?.providerCatalog) {
+          const providerDefinitions = tradingProviderContext.providerDefinitions ?? []
+          const providerDefinition = providerDefinitions.find(
+            (definition) => definition.id === paramId
+          )
+          const registryEntry = tradingProviderContext.providerCatalog.registry[paramId]
+          const providerCondition =
+            registryEntry?.providers?.length > 0
+              ? ({
+                  field: 'provider',
+                  value: registryEntry.providers,
+                } as ComponentCondition)
+              : undefined
+          const definitionCondition = providerDefinition?.condition as
+            | ComponentCondition
+            | undefined
+          const mergedCondition = combineConditions(definitionCondition, providerCondition)
+
+          if (providerDefinition) {
+            toolParam.description = providerDefinition.description || toolParam.description
+            if (providerDefinition.defaultValue !== undefined) {
+              toolParam.default = providerDefinition.defaultValue
+            }
+          }
+
+          if (!toolParam.uiComponent && (providerDefinition || providerCondition)) {
+            const baseDefinition =
+              providerDefinition ??
+              ({
+                id: paramId,
+                type: param.type,
+                title: undefined,
+                description: toolParam.description,
+                placeholder: undefined,
+                required: param.required,
+                visibility: param.visibility,
+              } as TradingProviderParamDefinition)
+
+            toolParam.uiComponent = buildProviderUiComponent(baseDefinition, mergedCondition)
+          } else if (toolParam.uiComponent && mergedCondition) {
+            toolParam.uiComponent.condition = combineConditions(
+              mergedCondition,
+              toolParam.uiComponent.condition
+            )
           }
         }
 

--- a/apps/tradinggoose/tools/trading/action.ts
+++ b/apps/tradinggoose/tools/trading/action.ts
@@ -102,6 +102,12 @@ export const tradingActionTool: ToolConfig<TradingActionParams, TradingActionRes
       visibility: 'user-or-llm',
       description: 'Dollar amount to trade (Alpaca only).',
     },
+    orderSizingMode: {
+      type: 'string',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Order sizing mode (quantity or notional) for Alpaca.',
+    },
     orderType: {
       type: 'string',
       required: false,
@@ -161,6 +167,18 @@ export const tradingActionTool: ToolConfig<TradingActionParams, TradingActionRes
       required: false,
       visibility: 'hidden',
       description: 'OAuth access token (injected from credential).',
+    },
+    apiKey: {
+      type: 'string',
+      required: false,
+      visibility: 'hidden',
+      description: 'Alpaca API key ID (optional if using OAuth).',
+    },
+    apiSecret: {
+      type: 'string',
+      required: false,
+      visibility: 'hidden',
+      description: 'Alpaca API secret key (optional if using OAuth).',
     },
     accountId: {
       type: 'string',

--- a/apps/tradinggoose/tools/trading/types.ts
+++ b/apps/tradinggoose/tools/trading/types.ts
@@ -19,6 +19,8 @@ export interface TradingActionParams {
   // Auth
   credential?: string
   accessToken?: string
+  apiKey?: string
+  apiSecret?: string
   tradierCredential?: string
   robinhoodCredential?: string
   alpacaCredential?: string
@@ -26,6 +28,7 @@ export interface TradingActionParams {
   accountId?: string
   accountUrl?: string
   instrumentUrl?: string
+  orderSizingMode?:string
 }
 
 export interface TradingHoldingsParams {

--- a/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-block/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-block/components/sub-block/components/tool-input/tool-input.tsx
@@ -841,7 +841,7 @@ export function ToolInput({
     }
 
     const dependentParamIds = (() => {
-      const toolParams = getToolParametersConfig(tool.toolId, tool.type)
+      const toolParams = getToolParametersConfig(tool.toolId, tool.type, tool.params)
       const params = toolParams?.userInputParameters ?? []
       const dependencyMap = new Map<string, string[]>()
 
@@ -907,7 +907,7 @@ export function ToolInput({
     }
 
     // Get parameters for the new tool
-    const toolParams = getToolParametersConfig(newToolId, tool.type)
+    const toolParams = getToolParametersConfig(newToolId, tool.type, tool.params)
 
     if (!toolParams) {
       logger.info('❌ Early return: no toolParams')
@@ -919,7 +919,7 @@ export function ToolInput({
 
     // Preserve ALL existing parameters that also exist in the new tool configuration
     // This mimics how regular blocks work - each field maintains its state independently
-    const oldToolParams = getToolParametersConfig(tool.toolId, tool.type)
+    const oldToolParams = getToolParametersConfig(tool.toolId, tool.type, tool.params)
     const oldParamIds = new Set(oldToolParams?.userInputParameters.map((p) => p.id) || [])
     const newParamIds = new Set(toolParams.userInputParameters.map((p) => p.id))
 
@@ -1072,37 +1072,33 @@ export function ToolInput({
     }
 
     const fieldValue = currentValues[condition.field]
-    let result = false
+    const andConditions = Array.isArray(condition.and)
+      ? condition.and
+      : condition.and
+        ? [condition.and]
+        : []
 
-    if (Array.isArray(condition.value)) {
-      result = condition.value.includes(fieldValue)
-    } else {
-      result = fieldValue === condition.value
+    const evaluateMatch = (
+      matchCondition: {
+        value: string | number | boolean | Array<string | number | boolean>
+        not?: boolean
+      },
+      valueToCheck: any
+    ) => {
+      const isMatch = Array.isArray(matchCondition.value)
+        ? matchCondition.value.includes(valueToCheck)
+        : valueToCheck === matchCondition.value
+      return matchCondition.not ? !isMatch : isMatch
     }
 
-    if (condition.not) {
-      result = !result
-    }
+    const baseMatch = evaluateMatch(condition, fieldValue)
+    const andMatch =
+      andConditions.length === 0 ||
+      andConditions.every((andCondition) =>
+        evaluateMatch(andCondition, currentValues[andCondition.field])
+      )
 
-    // Handle 'and' conditions
-    if (condition.and) {
-      const andFieldValue = currentValues[condition.and.field]
-      let andResult = false
-
-      if (Array.isArray(condition.and.value)) {
-        andResult = condition.and.value.includes(andFieldValue)
-      } else {
-        andResult = andFieldValue === condition.and.value
-      }
-
-      if (condition.and.not) {
-        andResult = !andResult
-      }
-
-      result = result && andResult
-    }
-
-    return result
+    return baseMatch && andMatch
   }
 
   // Render the appropriate UI component based on parameter configuration
@@ -1437,7 +1433,9 @@ export function ToolInput({
 
             // Get tool parameters using the new utility with block type for UI components
             const toolParams =
-              !isCustomTool && !isMcpTool ? getToolParametersConfig(currentToolId, tool.type) : null
+              !isCustomTool && !isMcpTool
+                ? getToolParametersConfig(currentToolId, tool.type, tool.params)
+                : null
 
             // For custom tools, extract parameters from schema
             const customToolParams =

--- a/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-block/workflow-block.tsx
+++ b/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-block/workflow-block.tsx
@@ -642,35 +642,37 @@ export const WorkflowBlock = memo(
         const normalizeValue = (value: any) =>
           value && typeof value === 'object' && 'id' in value ? (value as any).id : value
         const normalizedFieldValue = normalizeValue(stateToUse[actualCondition.field]?.value)
-        const andFieldValue = actualCondition.and
-          ? normalizeValue(stateToUse[actualCondition.and.field]?.value)
-          : undefined
+        const andConditions = Array.isArray(actualCondition.and)
+          ? actualCondition.and
+          : actualCondition.and
+            ? [actualCondition.and]
+            : []
 
-        // Check if the condition value is an array
-        const isValueMatch = Array.isArray(actualCondition.value)
-          ? normalizedFieldValue != null &&
-          (actualCondition.not
-            ? !actualCondition.value.includes(
-              normalizedFieldValue as string | number | boolean
+        const evaluateMatch = (
+          condition: {
+            value: string | number | boolean | Array<string | number | boolean>
+            not?: boolean
+          },
+          fieldValue: string | number | boolean | null | undefined
+        ) => {
+          if (Array.isArray(condition.value)) {
+            return (
+              fieldValue != null &&
+              (condition.not
+                ? !condition.value.includes(fieldValue as string | number | boolean)
+                : condition.value.includes(fieldValue as string | number | boolean))
             )
-            : actualCondition.value.includes(
-              normalizedFieldValue as string | number | boolean
-            ))
-          : actualCondition.not
-            ? normalizedFieldValue !== actualCondition.value
-            : normalizedFieldValue === actualCondition.value
+          }
+          return condition.not ? fieldValue !== condition.value : fieldValue === condition.value
+        }
 
-        // Check both conditions if 'and' is present
+        const isValueMatch = evaluateMatch(actualCondition, normalizedFieldValue)
         const isAndValueMatch =
-          !actualCondition.and ||
-          (Array.isArray(actualCondition.and.value)
-            ? andFieldValue != null &&
-            (actualCondition.and.not
-              ? !actualCondition.and.value.includes(andFieldValue as string | number | boolean)
-              : actualCondition.and.value.includes(andFieldValue as string | number | boolean))
-            : actualCondition.and.not
-              ? andFieldValue !== actualCondition.and.value
-              : andFieldValue === actualCondition.and.value)
+          andConditions.length === 0 ||
+          andConditions.every((andCondition) => {
+            const andFieldValue = normalizeValue(stateToUse[andCondition.field]?.value)
+            return evaluateMatch(andCondition, andFieldValue)
+          })
 
         return isValueMatch && isAndValueMatch
       })


### PR DESCRIPTION


## Summary
Trading Block and Tool UI can now be defined dynamically from the trading providers config file. This allows us to make custom UI block definitions for each provider without change the Block/Tool.

- add displayOrder/condition support to trading provider param defs
- merge provider UI metadata into tool params for trading_place_order
- sort tool-input params by provider-defined order with stable fallback
- move Alpaca sizing visibility/order to provider config
- add quantity params to Tradier/Robinhood to preserve non-Alpaca UX

Fixes #(issue)

## Type of Change
- [ ] Bug fix
- [X] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
Tested manually

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my changes
- [X] Tests added/updated and passing
- [X] No new warnings introduced
- [X] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
Before:
The inputs order were defined in the block, and providers can't modify the order or add conditions to the displayed inputs.
<img width="190" height="495" alt="antes" src="https://github.com/user-attachments/assets/0bdf0b99-3326-40ba-b15e-41afab8ef69c" />


Now:
The inputs are defined in the providers specific folder and its configurations are dynamically updated into the block and tool. For instance the "Order Size" input, controls the visibility of the "Quantity" and "Notional" input, this behavior is defined in the Alpaca Provider config file.
<img width="286" height="682" alt="image" src="https://github.com/user-attachments/assets/b46a7d66-42f8-41cb-a5d6-a1d9eafb33c1" />

