### PR TITLE
feat(listing-selector): support trading provider lookups

### DIFF
--- a/apps/tradinggoose/blocks/blocks/trading_action.ts
+++ b/apps/tradinggoose/blocks/blocks/trading_action.ts
@@ -290,6 +290,7 @@ export const TradingActionBlock: BlockConfig<TradingActionResponse> = {
       title: 'Listing',
       type: 'market-selector',
       layout: 'full',
+      providerType: 'trading',
       required: true,
     },
     {

--- a/apps/tradinggoose/blocks/types.ts
+++ b/apps/tradinggoose/blocks/types.ts
@@ -226,6 +226,9 @@ export interface SubBlockConfig {
   serviceId?: string
   requiredScopes?: string[]
   supportsCredentialSets?: boolean
+  // Market selector provider override
+  providerType?: 'market' | 'trading'
+  providerFieldId?: string
   // File selector specific properties
   mimeType?: string
   // File upload specific properties

--- a/apps/tradinggoose/components/listing-selector/selector/combo.tsx
+++ b/apps/tradinggoose/components/listing-selector/selector/combo.tsx
@@ -11,6 +11,7 @@ export interface ListingSelectorProps {
   blockId?: string
   className?: string
   disabled?: boolean
+  providerType?: 'market' | 'trading'
   onListingChange?: (listing: ListingOption | null) => void
   onListingValueChange?: (value: string | null) => void
   onListingTagSelect?: (value: string) => void
@@ -22,6 +23,7 @@ export function ListingSelector({
   blockId,
   className,
   disabled,
+  providerType = 'market',
   onListingChange,
   onListingValueChange,
   onListingTagSelect,
@@ -44,6 +46,7 @@ export function ListingSelector({
           instanceId={instanceId}
           blockId={blockId}
           disabled={disabled}
+          providerType={providerType}
           onListingChange={onListingChange}
           onListingValueChange={onListingValueChange}
           onListingTagSelect={onListingTagSelect}

--- a/apps/tradinggoose/components/listing-selector/selector/input.tsx
+++ b/apps/tradinggoose/components/listing-selector/selector/input.tsx
@@ -33,6 +33,7 @@ export interface StockSelectorProps {
   blockId?: string
   disabled?: boolean
   className?: string
+  providerType?: 'market' | 'trading'
   onListingChange?: (listing: ListingOption | null) => void
   onListingValueChange?: (value: string | null) => void
   onListingTagSelect?: (value: string) => void
@@ -52,6 +53,7 @@ export function StockSelector({
   blockId,
   disabled,
   className,
+  providerType = 'market',
   onListingChange,
   onListingValueChange,
   onListingTagSelect,
@@ -125,6 +127,7 @@ export function StockSelector({
     open,
     query,
     providerId,
+    providerType,
     instanceId,
     updateInstance,
     isVariableInput: isVariableListingInput,

--- a/apps/tradinggoose/components/listing-selector/selector/use-listing-search.ts
+++ b/apps/tradinggoose/components/listing-selector/selector/use-listing-search.ts
@@ -3,7 +3,10 @@ import { useDebounce } from '@/hooks/use-debounce'
 import { fetchListings } from '@/components/listing-selector/fetchers'
 import type { ListingSelectorInstance } from '@/stores/market/selector/store'
 import { buildMarketSearchRequest } from '@/components/listing-selector/selector/search-request'
-import { useMarketProviderSearchConfig } from '@/components/listing-selector/selector/use-provider-config'
+import {
+  useMarketProviderSearchConfig,
+  useTradingProviderSearchConfig,
+} from '@/components/listing-selector/selector/use-provider-config'
 
 type UpdateInstance = (id: string, patch: Partial<ListingSelectorInstance>) => void
 
@@ -11,6 +14,7 @@ type UseMarketListingSearchOptions = {
   open: boolean
   query: string
   providerId?: string
+  providerType?: 'market' | 'trading'
   instanceId: string
   updateInstance: UpdateInstance
   isVariableInput: (value: string) => boolean
@@ -20,6 +24,7 @@ export function useMarketListingSearch({
   open,
   query,
   providerId,
+  providerType = 'market',
   instanceId,
   updateInstance,
   isVariableInput,
@@ -27,7 +32,10 @@ export function useMarketListingSearch({
   const debouncedQuery = useDebounce(query, 400)
   const requestKeyRef = useRef<string>('')
   const abortRef = useRef<AbortController | null>(null)
-  const providerConfig = useMarketProviderSearchConfig(providerId)
+  const marketProviderConfig = useMarketProviderSearchConfig(providerId)
+  const tradingProviderConfig = useTradingProviderSearchConfig(providerId)
+  const providerConfig =
+    providerType === 'trading' ? tradingProviderConfig : marketProviderConfig
 
   useEffect(() => {
     const effectiveQuery = open && !query.trim() ? query : debouncedQuery
@@ -84,6 +92,7 @@ export function useMarketListingSearch({
     query,
     debouncedQuery,
     providerId,
+    providerType,
     providerConfig,
     instanceId,
     updateInstance,

--- a/apps/tradinggoose/components/listing-selector/selector/use-provider-config.ts
+++ b/apps/tradinggoose/components/listing-selector/selector/use-provider-config.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { getMarketProviderConfig } from '@/providers/market/providers'
+import { getTradingProviderConfig } from '@/providers/trading/providers'
 import { uniqueStrings } from '@/components/listing-selector/search-utils'
 
 export type ProviderSearchConfig = {
@@ -13,6 +14,50 @@ export type ProviderSearchConfig = {
 export function useMarketProviderSearchConfig(providerId?: string): ProviderSearchConfig {
   const providerConfig = useMemo(
     () => (providerId ? getMarketProviderConfig(providerId) : null),
+    [providerId]
+  )
+
+  const assetClasses = useMemo(() => {
+    const values = providerConfig?.availability.assetClass ?? []
+    return uniqueStrings(values)
+  }, [providerConfig])
+
+  const equityQuoteCodes = useMemo(() => {
+    const availability = providerConfig?.availability
+    return uniqueStrings(availability?.availableEquityQuote ?? [])
+  }, [providerConfig])
+
+  const currencyQuoteCodes = useMemo(() => {
+    const availability = providerConfig?.availability
+    return uniqueStrings(availability?.availableCurrencyQuote ?? [])
+  }, [providerConfig])
+
+  const cryptoQuoteCodes = useMemo(() => {
+    const availability = providerConfig?.availability
+    return uniqueStrings(availability?.availableCryptoQuote ?? [])
+  }, [providerConfig])
+
+  const micCodes = useMemo(() => {
+    const map = providerConfig?.exchangeCodeToMic ?? {}
+    const codes = Object.values(map).flat()
+    return uniqueStrings(codes)
+  }, [providerConfig])
+
+  return useMemo(
+    () => ({
+      assetClasses,
+      micCodes,
+      equityQuoteCodes,
+      cryptoQuoteCodes,
+      currencyQuoteCodes,
+    }),
+    [assetClasses, micCodes, equityQuoteCodes, cryptoQuoteCodes, currencyQuoteCodes]
+  )
+}
+
+export function useTradingProviderSearchConfig(providerId?: string): ProviderSearchConfig {
+  const providerConfig = useMemo(
+    () => (providerId ? getTradingProviderConfig(providerId) : null),
     [providerId]
   )
 

--- a/apps/tradinggoose/providers/trading/alpaca/config.ts
+++ b/apps/tradinggoose/providers/trading/alpaca/config.ts
@@ -2,12 +2,111 @@ import type { TradingProviderConfig } from '@/providers/trading/providers'
 import { alpacaTradingSymbolRules } from '@/providers/trading/alpaca/rules'
 import type { AssetClass } from '@/providers/market/types'
 
-const availableAssetClasses: AssetClass[] = ['stock', 'etf', 'crypto']
+const availableAssetClasses: AssetClass[] = ['stock']
+const supportsCrypto = availableAssetClasses.includes('crypto')
+const availableCryptoQuoteCodes = ['USD', 'USDC', 'USDT', 'BTC']
+const availableCryptoBaseCodes = [
+  'AAVE',
+  'AVAX',
+  'BAT',
+  'BCH',
+  'BTC',
+  'CRV',
+  'DOGE',
+  'DOT',
+  'ETH',
+  'GRT',
+  'LINK',
+  'LTC',
+  'SHIB',
+  'SKY',
+  'SUSHI',
+  'UNI',
+  'USDC',
+  'USDT',
+  'XRP',
+  'XTZ',
+  'YFI',
+]
+
+const exchangeCodesList: TradingProviderConfig['exchangeCodes'] = [
+  'A',
+  'B',
+  'C',
+  'D',
+  'G',
+  'H',
+  'I',
+  'J',
+  'K',
+  'L',
+  'M',
+  'N',
+  'P',
+  'Q',
+  'U',
+  'V',
+  'W',
+  'X',
+  'Y',
+  'Z',
+]
+
+const exchangeCodeToMicMap: TradingProviderConfig['exchangeCodeToMic'] = {
+  A: ['XASE'],
+  B: ['XBOS'],
+  C: ['XCIS'],
+  D: ['FINR'],
+  G: ['24EQ'],
+  H: ['MRPL'],
+  I: ['XISE'],
+  J: ['EDGA'],
+  K: ['EDGX'],
+  L: ['LTSE'],
+  M: ['XCHI'],
+  N: ['XNYS'],
+  P: ['ARCX'],
+  Q: ['XNAS'],
+  U: ['MEMX'],
+  V: ['IEXG'],
+  W: ['CBSX'],
+  X: ['XPSX'],
+  Y: ['BATY'],
+  Z: ['BATS'],
+}
+
+const micToExchangeCodeMap: TradingProviderConfig['micToExchangeCode'] = {
+  XASE: 'A',
+  XBOS: 'B',
+  XCIS: 'C',
+  FINR: 'D',
+  '24EQ': 'G',
+  MRPL: 'H',
+  XISE: 'I',
+  EDGA: 'J',
+  EDGX: 'K',
+  LTSE: 'L',
+  XCHI: 'M',
+  XNYS: 'N',
+  ARCX: 'P',
+  XNAS: 'Q',
+  MEMX: 'U',
+  IEXG: 'V',
+  CBSX: 'W',
+  XPSX: 'X',
+  BATY: 'Y',
+  BATS: 'Z',
+}
+
 
 const availability: TradingProviderConfig['availability'] = {
   assetClass: availableAssetClasses,
   order: true,
   holdings: true,
+  availableCurrencyBase: [],
+  availableCurrencyQuote: [],
+  availableCryptoBase: supportsCrypto ? availableCryptoBaseCodes : [],
+  availableCryptoQuote: supportsCrypto ? availableCryptoQuoteCodes : [],
 }
 
 const params: TradingProviderConfig['params'] = {
@@ -87,8 +186,6 @@ const params: TradingProviderConfig['params'] = {
   ],
 }
 
-const exchangeCodeToMicMap: TradingProviderConfig['exchangeCodeToMic'] = {}
-const micToExchangeCodeMap: TradingProviderConfig['micToExchangeCode'] = {}
 
 export const alpacaTradingProviderConfig: TradingProviderConfig = {
   id: 'alpaca',
@@ -123,6 +220,6 @@ export const alpacaTradingProviderConfig: TradingProviderConfig = {
   },
   exchangeCodeToMic: exchangeCodeToMicMap,
   micToExchangeCode: micToExchangeCodeMap,
-  exchangeCodes: [],
+  exchangeCodes: exchangeCodesList,
   rules: alpacaTradingSymbolRules,
 }

--- a/apps/tradinggoose/providers/trading/providers.ts
+++ b/apps/tradinggoose/providers/trading/providers.ts
@@ -23,6 +23,11 @@ export interface TradingProviderAvailability {
   assetClass: AssetClass[]
   order: boolean
   holdings: boolean
+  availableEquityQuote?: string[]
+  availableCurrencyBase?: string[]
+  availableCurrencyQuote?: string[]
+  availableCryptoBase?: string[]
+  availableCryptoQuote?: string[]
 }
 
 export interface TradingOrderInputCapabilities {

--- a/apps/tradinggoose/widgets/widgets/components/listing-selector.tsx
+++ b/apps/tradinggoose/widgets/widgets/components/listing-selector.tsx
@@ -28,6 +28,7 @@ interface ListingSelectorProps {
   blockId?: string
   disabled?: boolean
   className?: string
+  providerType?: 'market' | 'trading'
   onListingChange?: (listing: ListingOption | null) => void
   onListingValueChange?: (value: string | null) => void
   onListingTagSelect?: (value: string) => void
@@ -125,6 +126,7 @@ export function ListingSelector({
   blockId,
   disabled,
   className,
+  providerType = 'market',
   onListingChange,
   onListingValueChange,
   onListingTagSelect,
@@ -206,6 +208,7 @@ export function ListingSelector({
     open,
     query,
     providerId,
+    providerType,
     instanceId,
     updateInstance,
     isVariableInput: isVariableListingInput,

--- a/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-block/components/sub-block/components/listing-selector/listing-selector.tsx
+++ b/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-block/components/sub-block/components/listing-selector/listing-selector.tsx
@@ -24,6 +24,8 @@ interface ListingSelectorInputProps {
   onChange?: (value: ListingInputValue) => void
   disabled?: boolean
   config?: SubBlockConfig
+  providerType?: 'market' | 'trading'
+  providerFieldId?: string
 }
 
 function isVariableListingInput(value: string): boolean {
@@ -41,9 +43,12 @@ export function ListingSelectorInput({
   onChange,
   disabled = false,
   config,
+  providerType,
+  providerFieldId,
 }: ListingSelectorInputProps) {
   const [storeValue, setStoreValue] = useSubBlockValue<ListingInputValue>(blockId, subBlockId)
-  const [providerValue] = useSubBlockValue<string | null>(blockId, 'provider')
+  const providerField = providerFieldId ?? config?.providerFieldId ?? 'provider'
+  const [providerValue] = useSubBlockValue<string | null>(blockId, providerField)
   const ensureInstance = useListingSelectorStore((state) => state.ensureInstance)
   const updateInstance = useListingSelectorStore((state) => state.updateInstance)
   const instance = useListingSelectorStore((state) => state.instances[`${blockId}-${subBlockId}`])
@@ -190,6 +195,7 @@ export function ListingSelectorInput({
       instanceId={instanceId}
       blockId={blockId}
       disabled={disabled || isPreview}
+      providerType={providerType ?? config?.providerType ?? 'market'}
       listingRequired={config?.required === true}
       onListingChange={(listing) => {
         if (isPreview || disabled) return

--- a/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-block/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-block/components/sub-block/components/tool-input/tool-input.tsx
@@ -1107,7 +1107,8 @@ export function ToolInput({
     value: string,
     onChange: (value: string) => void,
     toolIndex?: number,
-    currentToolParams?: Record<string, any>
+    currentToolParams?: Record<string, any>,
+    toolId?: string
   ) => {
     // Create unique subBlockId for tool parameters to avoid conflicts
     // Use real blockId so tag dropdown and drag-drop work correctly
@@ -1204,7 +1205,13 @@ export function ToolInput({
           />
         )
 
-      case 'market-selector':
+      case 'market-selector': {
+        const providerFieldId =
+          toolIndex !== undefined
+            ? `${subBlockId}-tool-${toolIndex}-provider`
+            : `${subBlockId}-provider`
+        const providerType = toolId?.startsWith('trading_') ? 'trading' : 'market'
+
         return (
           <ListingSelectorInput
             blockId={blockId}
@@ -1214,6 +1221,8 @@ export function ToolInput({
             value={value}
             onChange={(listing) => onChange(listing ?? null)}
             disabled={disabled}
+            providerFieldId={providerFieldId}
+            providerType={providerType}
             config={{
               id: uniqueSubBlockId,
               type: 'market-selector',
@@ -1222,6 +1231,7 @@ export function ToolInput({
             }}
           />
         )
+      }
 
       case 'channel-selector':
         return (
@@ -1793,7 +1803,8 @@ export function ToolInput({
                                     {
                                       ...tool.params,
                                       ...(tool.operation ? { operation: tool.operation } : {}),
-                                    }
+                                    },
+                                    tool.toolId
                                   )
                                 ) : (
                                   <ShortInput


### PR DESCRIPTION
## Summary
feat(listing-selector): support trading provider lookups and alpaca exchange metadata

Add providerType/providerFieldId overrides for market selectors, route listing search to trading provider configs when needed, and wire tool inputs accordingly. Expand trading provider availability fields and enrich Alpaca trading config with MIC/ exchange mappings and exchange codes.



## Type of Change
- [ ] Bug fix
- [X] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
Manually tested on Block View

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [X] No new warnings introduced
- [X] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<img width="323" height="670" alt="image" src="https://github.com/user-attachments/assets/f18c5800-0397-4e0c-b36c-8c5b126072a4" />

Note: Alpaca trading provider was configured to **not** support crypto.
