### PR TITLE
Trading data schema

### DIFF
--- a/apps/tradinggoose/app/api/tools/trading/order-history/route.ts
+++ b/apps/tradinggoose/app/api/tools/trading/order-history/route.ts
@@ -1,0 +1,192 @@
+import { db, orderHistoryTable } from '@tradinggoose/db'
+import { and, eq, gte, lte } from 'drizzle-orm'
+import { type NextRequest, NextResponse } from 'next/server'
+import { createLogger } from '@/lib/logs/console/logger'
+import { generateRequestId } from '@/lib/utils'
+
+const logger = createLogger('OrderHistoryAPI')
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+export async function GET(request: NextRequest) {
+  const requestId = generateRequestId()
+
+  try {
+    const url = new URL(request.url)
+    const startDate = url.searchParams.get('startDate')
+    const endDate = url.searchParams.get('endDate')
+    const workflowId = url.searchParams.get('workflowId')
+
+    if (!startDate || !endDate) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            message: 'startDate and endDate are required',
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    const start = new Date(startDate)
+    const end = new Date(endDate)
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            message: 'startDate and endDate must be valid ISO timestamps',
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    let conditions = and(
+      gte(orderHistoryTable.recordedAt, start),
+      lte(orderHistoryTable.recordedAt, end)
+    )
+
+    if (workflowId) {
+      conditions = and(conditions, eq(orderHistoryTable.workflowId, workflowId))
+    }
+
+    const history = await db
+      .select()
+      .from(orderHistoryTable)
+      .where(conditions)
+      .orderBy(orderHistoryTable.recordedAt)
+
+    return NextResponse.json(
+      {
+        success: true,
+        data: {
+          history,
+          count: history.length,
+          workflowId: workflowId || null,
+          startDate,
+          endDate,
+        },
+      },
+      { status: 200 }
+    )
+  } catch (error: any) {
+    logger.error(`[${requestId}] Failed to fetch order history`, { error })
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          message: error.message || 'Failed to fetch order history',
+        },
+      },
+      { status: 500 }
+    )
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const requestId = generateRequestId()
+
+  try {
+    const body = await request.json()
+
+    if (!body || typeof body !== 'object') {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            message: 'Request body is required',
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    const provider = body.provider
+    const orderRequest = body.request
+    const orderResponse = body.response
+    const recordedAtRaw = body.recordedAt
+
+    if (!provider) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            message: 'provider is required',
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    if (!orderRequest || !orderResponse) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            message: 'request and response are required',
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    let recordedAt: Date | undefined
+    if (recordedAtRaw) {
+      const parsed = new Date(recordedAtRaw)
+      if (Number.isNaN(parsed.getTime())) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: {
+              message: 'recordedAt must be a valid ISO timestamp',
+            },
+          },
+          { status: 400 }
+        )
+      }
+      recordedAt = parsed
+    }
+
+    const [record] = await db
+      .insert(orderHistoryTable)
+      .values({
+        provider,
+        environment: body.environment,
+        recordedAt,
+        workflowId: body.workflowId,
+        workflowExecutionId: body.workflowExecutionId,
+        listingId: body.listingId,
+        listingKey: body.listingKey,
+        listingType: body.listingType,
+        listingIdentity: body.listingIdentity,
+        request: orderRequest,
+        response: orderResponse,
+        normalizedOrder: body.normalizedOrder,
+      })
+      .returning()
+
+    return NextResponse.json(
+      {
+        success: true,
+        data: {
+          record,
+        },
+      },
+      { status: 201 }
+    )
+  } catch (error: any) {
+    logger.error(`[${requestId}] Failed to record order history`, { error })
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          message: error.message || 'Failed to record order history',
+        },
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/apps/tradinggoose/blocks/blocks/trading_action.ts
+++ b/apps/tradinggoose/blocks/blocks/trading_action.ts
@@ -8,6 +8,7 @@ import {
   getTradingProviderIdsForParam,
   getTradingProviders,
 } from '@/providers/trading'
+import { getTradingOrderTypeOptions } from '@/providers/trading/order-types'
 import type { TradingProviderParamDefinition } from '@/providers/trading/providers'
 import { tradingActionTool } from '@/tools/trading'
 import type { TradingActionResponse } from '@/tools/trading/types'
@@ -28,6 +29,8 @@ const BLOCK_RESERVED_PARAM_IDS = new Set([
   'orderType',
   'limitPrice',
   'stopPrice',
+  'trailPrice',
+  'trailPercent',
   'timeInForce',
 ])
 
@@ -42,6 +45,8 @@ const TOOL_RESERVED_PARAM_IDS = new Set([
   'orderType',
   'limitPrice',
   'stopPrice',
+  'trailPrice',
+  'trailPercent',
   'timeInForce',
 ])
 
@@ -298,22 +303,27 @@ export const TradingActionBlock: BlockConfig<TradingActionResponse> = {
       title: 'Order Type',
       type: 'dropdown',
       layout: 'half',
-      options: [
-        { label: 'Market', id: 'market' },
-        { label: 'Limit', id: 'limit' },
-        { label: 'Stop', id: 'stop' },
-        { label: 'Stop Limit', id: 'stop_limit' },
-      ],
       required: true,
       value: () => 'market',
+      dependsOn: ['provider'],
+      fetchOptions: async (_blockId, _subBlockId, contextValues) => {
+        const providerId = contextValues?.provider as string | undefined
+        const orderClass =
+          (contextValues?.orderClass as string | undefined) ??
+          (contextValues?.class as string | undefined)
+        return getTradingOrderTypeOptions(providerId, {
+          listing: contextValues?.listing,
+          orderClass,
+        })
+      },
     },
     {
       id: 'limitPrice',
       title: 'Limit Price',
       type: 'short-input',
       layout: 'half',
-      placeholder: 'Required for limit orders',
-      condition: { field: 'orderType', value: ['limit', 'stop_limit'] },
+      placeholder: 'Required for limit/stop-limit and debit/credit/even orders',
+      condition: { field: 'orderType', value: ['limit', 'stop_limit', 'debit', 'credit', 'even'] },
     },
     {
       id: 'stopPrice',
@@ -322,6 +332,22 @@ export const TradingActionBlock: BlockConfig<TradingActionResponse> = {
       layout: 'half',
       placeholder: 'Required for stop/stop-limit orders',
       condition: { field: 'orderType', value: ['stop', 'stop_limit'] },
+    },
+    {
+      id: 'trailPrice',
+      title: 'Trail Price',
+      type: 'short-input',
+      layout: 'half',
+      placeholder: 'Trailing stop price offset (use price or percent)',
+      condition: { field: 'orderType', value: 'trailing_stop' },
+    },
+    {
+      id: 'trailPercent',
+      title: 'Trail Percent',
+      type: 'short-input',
+      layout: 'half',
+      placeholder: 'Trailing stop percent offset (use percent or price)',
+      condition: { field: 'orderType', value: 'trailing_stop' },
     },
     {
       id: 'timeInForce',
@@ -378,6 +404,8 @@ export const TradingActionBlock: BlockConfig<TradingActionResponse> = {
           orderType: params.orderType,
           limitPrice: toOptionalNumber(params.limitPrice),
           stopPrice: toOptionalNumber(params.stopPrice),
+          trailPrice: toOptionalNumber(params.trailPrice),
+          trailPercent: toOptionalNumber(params.trailPercent),
           timeInForce: params.timeInForce,
           ...extraFields,
         }

--- a/apps/tradinggoose/blocks/blocks/trading_order_history.ts
+++ b/apps/tradinggoose/blocks/blocks/trading_order_history.ts
@@ -1,0 +1,61 @@
+import { DollarIcon } from '@/components/icons/icons'
+import type { BlockConfig } from '@/blocks/types'
+import { buildInputsFromToolParams } from '@/blocks/utils'
+import { orderHistoryTool } from '@/tools/trading'
+import type { OrderHistoryResponse } from '@/tools/trading/order_history'
+
+export const TradingOrderHistoryBlock: BlockConfig<OrderHistoryResponse> = {
+  type: 'trading_order_history',
+  name: 'Trading Order History',
+  description: 'Retrieve recorded trading order submissions for a date range.',
+  longDescription:
+    'Fetches order submission history recorded by the Trading Action tool for the selected workflow and date range.',
+  category: 'tools',
+  bgColor: '#0f766e',
+  icon: DollarIcon,
+  subBlocks: [
+    {
+      id: 'startDate',
+      title: 'Start Date',
+      type: 'datetime-input',
+      layout: 'half',
+      placeholder: 'YYYY-MM-DDTHH:mm:ssZ',
+      required: true,
+    },
+    {
+      id: 'endDate',
+      title: 'End Date',
+      type: 'datetime-input',
+      layout: 'half',
+      placeholder: 'YYYY-MM-DDTHH:mm:ssZ',
+      required: true,
+    },
+    {
+      id: 'workflowId',
+      title: 'Workflow ID',
+      type: 'short-input',
+      layout: 'full',
+      placeholder: 'Defaults to current workflow',
+      required: false,
+    },
+  ],
+  tools: {
+    access: ['trading_order_history'],
+    config: {
+      tool: () => 'trading_order_history',
+      params: (params) => ({
+        startDate: params.startDate,
+        endDate: params.endDate,
+        workflowId: params.workflowId,
+      }),
+    },
+  },
+  inputs: buildInputsFromToolParams(orderHistoryTool.params),
+  outputs: {
+    history: { type: 'array', description: 'Order submissions recorded in the date range.' },
+    count: { type: 'number', description: 'Number of records returned.' },
+    startDate: { type: 'string', description: 'Start datetime used for filtering.' },
+    endDate: { type: 'string', description: 'End datetime used for filtering.' },
+    workflowId: { type: 'string', description: 'Workflow ID used for filtering.' },
+  },
+}

--- a/apps/tradinggoose/blocks/registry.ts
+++ b/apps/tradinggoose/blocks/registry.ts
@@ -72,6 +72,7 @@ import { TelegramBlock } from '@/blocks/blocks/telegram'
 import { ThinkingBlock } from '@/blocks/blocks/thinking'
 import { TradingActionBlock } from '@/blocks/blocks/trading_action'
 import { TradingHoldingsBlock } from '@/blocks/blocks/trading_holdings'
+import { TradingOrderHistoryBlock } from '@/blocks/blocks/trading_order_history'
 import { TranslateBlock } from '@/blocks/blocks/translate'
 import { TwilioSMSBlock } from '@/blocks/blocks/twilio'
 import { TypeformBlock } from '@/blocks/blocks/typeform'
@@ -227,6 +228,7 @@ export const registry: Record<string, BlockConfig> = {
   thinking: ThinkingBlock,
   trading_action: TradingActionBlock,
   trading_holdings: TradingHoldingsBlock,
+  trading_order_history: TradingOrderHistoryBlock,
   translate: TranslateBlock,
   twilio_sms: TwilioSMSBlock,
   typeform: TypeformBlock,

--- a/apps/tradinggoose/blocks/types.ts
+++ b/apps/tradinggoose/blocks/types.ts
@@ -136,6 +136,8 @@ export interface SubBlockConfig {
   layout?: SubBlockLayout
   mode?: 'basic' | 'advanced' | 'both' | 'trigger' // Default is 'both' if not specified
   canonicalParamId?: string
+  providerType?: 'market' | 'trading'
+  providerFieldId?: string
   required?:
     | boolean
     | {

--- a/apps/tradinggoose/providers/trading/alpaca/config.ts
+++ b/apps/tradinggoose/providers/trading/alpaca/config.ts
@@ -199,7 +199,37 @@ export const alpacaTradingProviderConfig: TradingProviderConfig = {
   },
   capabilities: {
     order: {
-      orderTypes: ['market', 'limit', 'stop', 'stop_limit'],
+      orderTypes: [
+        {
+          id: 'market',
+          label: 'Market',
+          assetClasses: ['stock', 'crypto'],
+        },
+        {
+          id: 'limit',
+          label: 'Limit',
+          assetClasses: ['stock', 'crypto'],
+          requires: ['limitPrice'],
+        },
+        {
+          id: 'stop',
+          label: 'Stop',
+          assetClasses: ['stock'],
+          requires: ['stopPrice'],
+        },
+        {
+          id: 'stop_limit',
+          label: 'Stop Limit',
+          assetClasses: ['stock', 'crypto'],
+          requires: ['limitPrice', 'stopPrice'],
+        },
+        {
+          id: 'trailing_stop',
+          label: 'Trailing Stop',
+          assetClasses: ['stock'],
+          requires: ['trailPrice', 'trailPercent'],
+        },
+      ],
       timeInForce: ['day', 'gtc', 'ioc', 'fok'],
       supportsLimit: true,
       supportsStop: true,

--- a/apps/tradinggoose/providers/trading/alpaca/listing.ts
+++ b/apps/tradinggoose/providers/trading/alpaca/listing.ts
@@ -1,0 +1,6 @@
+import type { TradingSymbolInput } from '@/providers/trading/types'
+import { resolveTradingSymbol } from '@/providers/trading/utils'
+import { alpacaTradingProviderConfig } from '@/providers/trading/alpaca/config'
+
+export const normalizeAlpacaListingSymbol = (input: TradingSymbolInput): string =>
+  resolveTradingSymbol(alpacaTradingProviderConfig, input)

--- a/apps/tradinggoose/providers/trading/alpaca/orders.test.ts
+++ b/apps/tradinggoose/providers/trading/alpaca/orders.test.ts
@@ -94,4 +94,41 @@ describe('buildAlpacaOrderRequest', () => {
       })
     ).toThrow('time_in_force=day')
   })
+
+  it('supports trailing stop orders with trail price', () => {
+    const request = buildAlpacaOrderRequest({
+      ...baseParams,
+      quantity: 1,
+      orderType: 'trailing_stop',
+      trailPrice: 1.5,
+    })
+
+    expect(request.body).toMatchObject({
+      qty: '1',
+      side: 'buy',
+      type: 'trailing_stop',
+      time_in_force: 'day',
+      trail_price: 1.5,
+    })
+  })
+
+  it('requires a single trailing stop offset', () => {
+    expect(() =>
+      buildAlpacaOrderRequest({
+        ...baseParams,
+        quantity: 1,
+        orderType: 'trailing_stop',
+      })
+    ).toThrow('trailPrice or trailPercent')
+
+    expect(() =>
+      buildAlpacaOrderRequest({
+        ...baseParams,
+        quantity: 1,
+        orderType: 'trailing_stop',
+        trailPrice: 1,
+        trailPercent: 2,
+      })
+    ).toThrow('trailPrice or trailPercent')
+  })
 })

--- a/apps/tradinggoose/providers/trading/alpaca/orders.ts
+++ b/apps/tradinggoose/providers/trading/alpaca/orders.ts
@@ -64,6 +64,7 @@ export const buildAlpacaOrderRequest = (
 
   const orderType = (params.orderType || 'market').toLowerCase()
   const timeInForce = params.timeInForce || 'day'
+  const isTrailingStop = orderType === 'trailing_stop'
 
   if (useNotional) {
     const supportedTypes = new Set(['market', 'limit', 'stop', 'stop_limit'])
@@ -96,6 +97,33 @@ export const buildAlpacaOrderRequest = (
   }
   if (hasStopComponent && params.stopPrice !== undefined) {
     body.stop_price = params.stopPrice
+  }
+
+  if (isTrailingStop) {
+    if (params.limitPrice !== undefined || params.stopPrice !== undefined) {
+      throw new Error('Trailing stop orders use trail_price or trail_percent, not limit/stop price.')
+    }
+    const trailPrice =
+      typeof params.trailPrice === 'number' && Number.isFinite(params.trailPrice)
+        ? params.trailPrice
+        : undefined
+    const trailPercent =
+      typeof params.trailPercent === 'number' && Number.isFinite(params.trailPercent)
+        ? params.trailPercent
+        : undefined
+
+    if (
+      (trailPrice === undefined && trailPercent === undefined) ||
+      (trailPrice !== undefined && trailPercent !== undefined)
+    ) {
+      throw new Error('Trailing stop orders require either trailPrice or trailPercent.')
+    }
+    if (trailPrice !== undefined) {
+      body.trail_price = trailPrice
+    }
+    if (trailPercent !== undefined) {
+      body.trail_percent = trailPercent
+    }
   }
 
   return {

--- a/apps/tradinggoose/providers/trading/alpaca/orders.ts
+++ b/apps/tradinggoose/providers/trading/alpaca/orders.ts
@@ -3,9 +3,8 @@ import type {
   TradingOrderInput,
   TradingRequestConfig,
 } from '@/providers/trading/types'
-import { resolveTradingSymbol } from '@/providers/trading/utils'
-import { alpacaTradingProviderConfig } from '@/providers/trading/alpaca/config'
 import { buildAlpacaAuthHeaders } from '@/providers/trading/alpaca/auth'
+import { normalizeAlpacaListingSymbol } from '@/providers/trading/alpaca/listing'
 
 export const buildAlpacaOrderRequest = (
   params: TradingOrderInput
@@ -17,7 +16,7 @@ export const buildAlpacaOrderRequest = (
       ? 'https://paper-api.alpaca.markets'
       : 'https://api.alpaca.markets'
 
-  const symbol = resolveTradingSymbol(alpacaTradingProviderConfig, {
+  const symbol = normalizeAlpacaListingSymbol({
     listing: params.listing,
     base: params.base,
     quote: params.quote,

--- a/apps/tradinggoose/providers/trading/order-types.ts
+++ b/apps/tradinggoose/providers/trading/order-types.ts
@@ -1,0 +1,97 @@
+import type { ListingInputValue } from '@/lib/listing/identity'
+import type { AssetClass } from '@/providers/market/types'
+import { getTradingProviderConfig } from '@/providers/trading/providers'
+import type { TradingOrderTypeDefinition } from '@/providers/trading/providers'
+import type { TradingProviderId } from '@/providers/trading/types'
+
+const ASSET_CLASS_SET = new Set<AssetClass>([
+  'stock',
+  'etf',
+  'future',
+  'currency',
+  'crypto',
+  'indice',
+  'mutualfund',
+])
+
+const toTitleCase = (value: string): string =>
+  value
+    .replace(/[_-]+/g, ' ')
+    .split(' ')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+
+const normalizeOrderClass = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim().toLowerCase()
+  return trimmed ? trimmed : undefined
+}
+
+const resolveAssetClass = (listing?: ListingInputValue): AssetClass | undefined => {
+  if (!listing || typeof listing === 'string') return undefined
+  const record = listing as Record<string, unknown>
+
+  const direct = record.assetClass ?? record.base_asset_class ?? record.quote_asset_class
+  if (typeof direct === 'string' && ASSET_CLASS_SET.has(direct as AssetClass)) {
+    return direct as AssetClass
+  }
+
+  const listingType = typeof record.listing_type === 'string' ? record.listing_type : undefined
+  if (listingType === 'crypto' || listingType === 'currency') {
+    return listingType as AssetClass
+  }
+  if (listingType === 'equity') {
+    return 'stock'
+  }
+
+  return undefined
+}
+
+const normalizeOrderTypeDefinitions = (
+  orderTypes?: TradingOrderTypeDefinition[]
+): TradingOrderTypeDefinition[] => {
+  if (!orderTypes?.length) return []
+  return orderTypes
+}
+
+export function getTradingOrderTypeOptions(
+  providerId?: TradingProviderId,
+  context: {
+    listing?: ListingInputValue
+    orderClass?: string
+  } = {}
+): Array<{ id: string; label: string }> {
+  if (!providerId) return []
+
+  const config = getTradingProviderConfig(providerId)
+  const definitions = normalizeOrderTypeDefinitions(config?.capabilities?.order?.orderTypes)
+  if (!definitions.length) return []
+
+  const assetClass = resolveAssetClass(context.listing)
+  const normalizedOrderClass =
+    normalizeOrderClass(context.orderClass) ?? (providerId === 'tradier' ? 'equity' : undefined)
+
+  const filtered = definitions.filter((definition) => {
+    if (assetClass && definition.assetClasses?.length) {
+      if (!definition.assetClasses.includes(assetClass)) return false
+    }
+    if (normalizedOrderClass && definition.orderClasses?.length) {
+      if (!definition.orderClasses.includes(normalizedOrderClass)) return false
+    }
+    return true
+  })
+
+  const resultSource = filtered.length ? filtered : definitions
+  const seen = new Set<string>()
+
+  return resultSource.reduce<Array<{ id: string; label: string }>>((acc, definition) => {
+    if (seen.has(definition.id)) return acc
+    seen.add(definition.id)
+    acc.push({
+      id: definition.id,
+      label: definition.label || toTitleCase(definition.id),
+    })
+    return acc
+  }, [])
+}

--- a/apps/tradinggoose/providers/trading/providers.ts
+++ b/apps/tradinggoose/providers/trading/providers.ts
@@ -31,7 +31,7 @@ export interface TradingProviderAvailability {
 }
 
 export interface TradingOrderInputCapabilities {
-  orderTypes?: string[]
+  orderTypes?: TradingOrderTypeDefinition[]
   timeInForce?: string[]
   supportsLimit?: boolean
   supportsStop?: boolean
@@ -103,6 +103,20 @@ export interface TradingProviderParamDefinition {
   dependsOn?: string[]
   condition?: TradingProviderParamCondition
   displayOrder?: number
+}
+
+export type TradingOrderTypeRequirement =
+  | 'limitPrice'
+  | 'stopPrice'
+  | 'trailPrice'
+  | 'trailPercent'
+
+export interface TradingOrderTypeDefinition {
+  id: string
+  label: string
+  assetClasses?: AssetClass[]
+  orderClasses?: string[]
+  requires?: TradingOrderTypeRequirement[]
 }
 
 export interface TradingProviderParamConfig {

--- a/apps/tradinggoose/providers/trading/robinhood/config.ts
+++ b/apps/tradinggoose/providers/trading/robinhood/config.ts
@@ -65,7 +65,12 @@ export const robinhoodTradingProviderConfig: TradingProviderConfig = {
   },
   capabilities: {
     order: {
-      orderTypes: ['market', 'limit', 'stop', 'stop_limit'],
+      orderTypes: [
+        { id: 'market', label: 'Market' },
+        { id: 'limit', label: 'Limit', requires: ['limitPrice'] },
+        { id: 'stop', label: 'Stop', requires: ['stopPrice'] },
+        { id: 'stop_limit', label: 'Stop Limit', requires: ['limitPrice', 'stopPrice'] },
+      ],
       timeInForce: ['gfd', 'gtc', 'ioc', 'fok'],
       supportsLimit: true,
       supportsStop: true,

--- a/apps/tradinggoose/providers/trading/robinhood/listing.ts
+++ b/apps/tradinggoose/providers/trading/robinhood/listing.ts
@@ -1,0 +1,6 @@
+import type { TradingSymbolInput } from '@/providers/trading/types'
+import { resolveTradingSymbol } from '@/providers/trading/utils'
+import { robinhoodTradingProviderConfig } from '@/providers/trading/robinhood/config'
+
+export const normalizeRobinhoodListingSymbol = (input: TradingSymbolInput): string =>
+  resolveTradingSymbol(robinhoodTradingProviderConfig, input)

--- a/apps/tradinggoose/providers/trading/robinhood/orders.ts
+++ b/apps/tradinggoose/providers/trading/robinhood/orders.ts
@@ -3,8 +3,7 @@ import type {
   TradingOrderInput,
   TradingRequestConfig,
 } from '@/providers/trading/types'
-import { resolveTradingSymbol } from '@/providers/trading/utils'
-import { robinhoodTradingProviderConfig } from '@/providers/trading/robinhood/config'
+import { normalizeRobinhoodListingSymbol } from '@/providers/trading/robinhood/listing'
 
 export const buildRobinhoodOrderRequest = (
   params: TradingOrderInput
@@ -19,7 +18,7 @@ export const buildRobinhoodOrderRequest = (
     throw new Error('Quantity is required for Robinhood orders')
   }
 
-  const symbol = resolveTradingSymbol(robinhoodTradingProviderConfig, {
+  const symbol = normalizeRobinhoodListingSymbol({
     listing: params.listing,
     base: params.base,
     quote: params.quote,

--- a/apps/tradinggoose/providers/trading/tradier/config.ts
+++ b/apps/tradinggoose/providers/trading/tradier/config.ts
@@ -45,6 +45,23 @@ const params: TradingProviderConfig['params'] = {
   ],
   order: [
     {
+      id: 'orderClass',
+      type: 'string',
+      title: 'Order Class',
+      description: 'Tradier order class (equity, option, multileg, or combo).',
+      required: false,
+      visibility: 'user-or-llm',
+      inputType: 'dropdown',
+      options: [
+        { id: 'equity', label: 'Equity' },
+        { id: 'option', label: 'Option' },
+        { id: 'multileg', label: 'Multileg' },
+        { id: 'combo', label: 'Combo' },
+      ],
+      defaultValue: 'equity',
+      displayOrder: 5,
+    },
+    {
       id: 'quantity',
       type: 'number',
       title: 'Quantity (Shares)',
@@ -70,7 +87,49 @@ export const tradierTradingProviderConfig: TradingProviderConfig = {
   },
   capabilities: {
     order: {
-      orderTypes: ['market', 'limit', 'stop', 'stop_limit'],
+      orderTypes: [
+        {
+          id: 'market',
+          label: 'Market',
+          orderClasses: ['equity', 'option', 'multileg', 'combo'],
+        },
+        {
+          id: 'limit',
+          label: 'Limit',
+          orderClasses: ['equity', 'option'],
+          requires: ['limitPrice'],
+        },
+        {
+          id: 'stop',
+          label: 'Stop',
+          orderClasses: ['equity', 'option'],
+          requires: ['stopPrice'],
+        },
+        {
+          id: 'stop_limit',
+          label: 'Stop Limit',
+          orderClasses: ['equity', 'option'],
+          requires: ['limitPrice', 'stopPrice'],
+        },
+        {
+          id: 'debit',
+          label: 'Debit',
+          orderClasses: ['multileg', 'combo'],
+          requires: ['limitPrice'],
+        },
+        {
+          id: 'credit',
+          label: 'Credit',
+          orderClasses: ['multileg', 'combo'],
+          requires: ['limitPrice'],
+        },
+        {
+          id: 'even',
+          label: 'Even',
+          orderClasses: ['multileg', 'combo'],
+          requires: ['limitPrice'],
+        },
+      ],
       timeInForce: ['day', 'gtc', 'pre', 'post'],
       supportsLimit: true,
       supportsStop: true,

--- a/apps/tradinggoose/providers/trading/tradier/listing.ts
+++ b/apps/tradinggoose/providers/trading/tradier/listing.ts
@@ -1,0 +1,6 @@
+import type { TradingSymbolInput } from '@/providers/trading/types'
+import { resolveTradingSymbol } from '@/providers/trading/utils'
+import { tradierTradingProviderConfig } from '@/providers/trading/tradier/config'
+
+export const normalizeTradierListingSymbol = (input: TradingSymbolInput): string =>
+  resolveTradingSymbol(tradierTradingProviderConfig, input)

--- a/apps/tradinggoose/providers/trading/tradier/orders.ts
+++ b/apps/tradinggoose/providers/trading/tradier/orders.ts
@@ -3,9 +3,8 @@ import type {
   TradingOrderInput,
   TradingRequestConfig,
 } from '@/providers/trading/types'
-import { resolveTradingSymbol } from '@/providers/trading/utils'
-import { tradierTradingProviderConfig } from '@/providers/trading/tradier/config'
 import { buildTradierAuthHeaders, resolveTradierBaseUrl } from '@/providers/trading/tradier/client'
+import { normalizeTradierListingSymbol } from '@/providers/trading/tradier/listing'
 
 const normalizeTradierOrderType = (value?: string) => {
   if (typeof value !== 'string' || !value.trim()) return 'market'
@@ -39,7 +38,7 @@ export const buildTradierOrderRequest = (
   const authHeaders = buildTradierAuthHeaders(params)
   const baseUrl = resolveTradierBaseUrl(params.environment)
 
-  const symbol = resolveTradingSymbol(tradierTradingProviderConfig, {
+  const symbol = normalizeTradierListingSymbol({
     listing: params.listing,
     base: params.base,
     quote: params.quote,

--- a/apps/tradinggoose/providers/trading/tradier/orders.ts
+++ b/apps/tradinggoose/providers/trading/tradier/orders.ts
@@ -51,7 +51,13 @@ export const buildTradierOrderRequest = (
   })
 
   const providerParams = params.providerParams ?? {}
-  const orderClass = String(providerParams.orderClass || providerParams.class || 'equity')
+  const orderClass = String(
+    providerParams.orderClass ||
+      providerParams.class ||
+      (params as { orderClass?: string }).orderClass ||
+      (params as { class?: string }).class ||
+      'equity'
+  )
   const duration = normalizeTradierDuration(providerParams.duration || params.timeInForce)
   const orderType = normalizeTradierOrderType(params.orderType)
 

--- a/apps/tradinggoose/providers/trading/types.ts
+++ b/apps/tradinggoose/providers/trading/types.ts
@@ -7,6 +7,16 @@ export type TradingProviderId = 'alpaca' | 'tradier' | 'robinhood' | (string & {
 
 export type TradingAuthType = 'apiKey' | 'oauth'
 
+export type TradingOrderType =
+  | 'market'
+  | 'limit'
+  | 'stop'
+  | 'stop_limit'
+  | 'trailing_stop'
+  | 'debit'
+  | 'credit'
+  | 'even'
+
 export interface TradingFieldDefinition {
   id: string
   label: string
@@ -45,14 +55,17 @@ export interface TradingOrderInput extends TradingSymbolInput {
   quantity?: number
   notional?: number
   orderSizingMode?: string
-  orderType?: string
+  orderType?: TradingOrderType
   timeInForce?: string
   limitPrice?: number
   stopPrice?: number
+  trailPrice?: number
+  trailPercent?: number
   environment?: 'paper' | 'live'
   accessToken?: string
   apiKey?: string
   apiSecret?: string
+  orderClass?: string
   accountId?: string
   accountUrl?: string
   instrumentUrl?: string

--- a/apps/tradinggoose/tools/index.ts
+++ b/apps/tradinggoose/tools/index.ts
@@ -157,6 +157,18 @@ export async function executeTool(
 
     // Ensure context is preserved if it exists
     const contextParams = { ...params }
+    if (executionContext) {
+      const existingContext = (contextParams as any)._context || {}
+      const mergedContext = {
+        ...existingContext,
+        workflowId: existingContext.workflowId ?? executionContext.workflowId,
+        workspaceId: existingContext.workspaceId ?? executionContext.workspaceId,
+        executionId: existingContext.executionId ?? executionContext.executionId,
+      }
+      if (mergedContext.workflowId || mergedContext.workspaceId || mergedContext.executionId) {
+        ;(contextParams as any)._context = mergedContext
+      }
+    }
 
     // Validate the tool and its parameters
     validateRequiredParametersAfterMerge(toolId, tool, contextParams)
@@ -279,7 +291,7 @@ export async function executeTool(
 
       // Apply post-processing if available and not skipped
       let finalResult = result
-      if (tool.postProcess && result.success && !skipPostProcess) {
+      if (tool.postProcess && !skipPostProcess && (result.success || toolId === 'trading_place_order')) {
         try {
           finalResult = await tool.postProcess(result, contextParams, executeTool)
         } catch (error) {
@@ -312,7 +324,7 @@ export async function executeTool(
 
     // Apply post-processing if available and not skipped
     let finalResult = result
-    if (tool.postProcess && result.success && !skipPostProcess) {
+    if (tool.postProcess && !skipPostProcess && (result.success || toolId === 'trading_place_order')) {
       try {
         finalResult = await tool.postProcess(result, contextParams, executeTool)
       } catch (error) {

--- a/apps/tradinggoose/tools/params.ts
+++ b/apps/tradinggoose/tools/params.ts
@@ -36,6 +36,8 @@ export interface UIComponentConfig {
   provider?: string
   serviceId?: string
   requiredScopes?: string[]
+  providerType?: 'market' | 'trading'
+  providerFieldId?: string
   mimeType?: string
   columns?: string[]
   min?: number
@@ -82,6 +84,8 @@ export interface SubBlockConfig {
   provider?: string
   serviceId?: string
   requiredScopes?: string[]
+  providerType?: 'market' | 'trading'
+  providerFieldId?: string
   mimeType?: string
   columns?: string[]
   min?: number
@@ -409,6 +413,8 @@ export function getToolParametersConfig(
               provider: subBlock.provider,
               serviceId: subBlock.serviceId,
               requiredScopes: subBlock.requiredScopes,
+              providerType: subBlock.providerType,
+              providerFieldId: subBlock.providerFieldId,
               mimeType: subBlock.mimeType,
               columns: subBlock.columns,
               min: subBlock.min,

--- a/apps/tradinggoose/tools/registry.ts
+++ b/apps/tradinggoose/tools/registry.ts
@@ -174,7 +174,7 @@ import {
 import { slackCanvasTool, slackMessageReaderTool, slackMessageTool } from '@/tools/slack'
 import { smsSendTool } from '@/tools/sms'
 import { stagehandAgentTool, stagehandExtractTool } from '@/tools/stagehand'
-import { tradingActionTool, tradingHoldingsTool } from '@/tools/trading'
+import { orderHistoryTool, tradingActionTool, tradingHoldingsTool } from '@/tools/trading'
 import {
   supabaseDeleteTool,
   supabaseGetRowTool,
@@ -361,6 +361,7 @@ export const tools: Record<string, ToolConfig> = {
   thinking_tool: thinkingTool,
   trading_place_order: tradingActionTool,
   trading_get_holdings: tradingHoldingsTool,
+  trading_order_history: orderHistoryTool,
   stagehand_extract: stagehandExtractTool,
   stagehand_agent: stagehandAgentTool,
   mem0_add_memories: mem0AddMemoriesTool,

--- a/apps/tradinggoose/tools/trading/action.ts
+++ b/apps/tradinggoose/tools/trading/action.ts
@@ -1,9 +1,121 @@
 import { createLogger } from '@/lib/logs/console/logger'
+import { resolveListingKey, toListingValueObject } from '@/lib/listing/identity'
+import { getBaseUrl } from '@/lib/urls/utils'
 import { executeTradingProviderRequest, getTradingProvider } from '@/providers/trading'
 import type { ToolConfig } from '@/tools/types'
-import type { TradingActionParams, TradingActionResponse } from '@/tools/trading/types'
+import type {
+  OrderSubmit,
+  OrderSubmitRequest,
+  OrderSubmitResponse,
+  TradingActionParams,
+  TradingActionResponse,
+} from '@/tools/trading/types'
 
 const logger = createLogger('TradingActionTool')
+
+const ORDER_HISTORY_OMIT_KEYS = new Set([
+  'provider',
+  'environment',
+  'side',
+  'listing',
+  'quantity',
+  'notional',
+  'orderType',
+  'limitPrice',
+  'stopPrice',
+  'trailPrice',
+  'trailPercent',
+  'timeInForce',
+  'orderSizingMode',
+  'orderClass',
+  'credential',
+  'accessToken',
+  'apiKey',
+  'apiSecret',
+  'tradierCredential',
+  'robinhoodCredential',
+  'alpacaCredential',
+  '_context',
+  '_workflowId',
+  '_credentialId',
+])
+
+const extractProviderParams = (params: TradingActionParams): Record<string, unknown> => {
+  const extras: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(params as Record<string, unknown>)) {
+    if (ORDER_HISTORY_OMIT_KEYS.has(key) || key.startsWith('_')) continue
+    if (value !== undefined) {
+      extras[key] = value
+    }
+  }
+  return extras
+}
+
+const buildOrderSubmitRequest = (params: TradingActionParams): OrderSubmitRequest => {
+  const providerParams = extractProviderParams(params)
+  const normalized = normalizeOrderSizing(params)
+  return {
+    side: params.side,
+    orderType: params.orderType,
+    timeInForce: params.timeInForce,
+    quantity: normalized.quantity,
+    notional: normalized.notional,
+    limitPrice: normalizeSizingValue(params.limitPrice),
+    stopPrice: normalizeSizingValue(params.stopPrice),
+    trailPrice: normalizeSizingValue(params.trailPrice),
+    trailPercent: normalizeSizingValue(params.trailPercent),
+    orderSizingMode: params.orderSizingMode,
+    orderClass: params.orderClass,
+    providerParams: Object.keys(providerParams).length ? providerParams : undefined,
+  }
+}
+
+const buildOrderSubmitResponse = (
+  normalizedOrder: Record<string, any> | undefined,
+  rawOrder: Record<string, any> | undefined,
+  success = true,
+  errorMessage?: string | null
+): OrderSubmitResponse => {
+  const orderId =
+    normalizedOrder?.id ?? rawOrder?.id ?? rawOrder?.order_id ?? rawOrder?.order?.id ?? null
+  const clientOrderId =
+    rawOrder?.client_order_id ??
+    rawOrder?.clientOrderId ??
+    rawOrder?.order?.client_order_id ??
+    null
+  const createdAt =
+    rawOrder?.created_at ??
+    rawOrder?.create_date ??
+    rawOrder?.createdAt ??
+    rawOrder?.order?.created_at ??
+    rawOrder?.order?.create_date ??
+    null
+  const submittedAt =
+    normalizedOrder?.submittedAt ??
+    rawOrder?.submitted_at ??
+    rawOrder?.submittedAt ??
+    rawOrder?.order?.submitted_at ??
+    null
+  const symbol = normalizedOrder?.symbol ?? rawOrder?.symbol ?? rawOrder?.order?.symbol ?? null
+  const status =
+    normalizedOrder?.status ??
+    rawOrder?.status ??
+    rawOrder?.state ??
+    rawOrder?.order?.status ??
+    null
+
+  return {
+    success,
+    orderId,
+    clientOrderId,
+    createdAt,
+    submittedAt,
+    symbol,
+    status,
+    errorMessage: errorMessage ?? null,
+    raw: rawOrder ?? normalizedOrder,
+  }
+}
 
 const normalizeSizingValue = (value: unknown): number | undefined => {
   if (value === null || value === undefined) return undefined
@@ -224,6 +336,78 @@ export const tradingActionTool: ToolConfig<TradingActionParams, TradingActionRes
     method: (params) => resolveOrderRequest(params).method,
     headers: (params) => resolveOrderRequest(params).headers,
     body: (params) => resolveOrderRequest(params).body,
+  },
+
+  postProcess: async (result, params) => {
+    try {
+      const normalizedOrder =
+        result.output && typeof result.output === 'object'
+          ? (result.output as any).order
+          : undefined
+      const rawOrder =
+        normalizedOrder && typeof normalizedOrder === 'object' && 'raw' in normalizedOrder
+          ? (normalizedOrder as any).raw
+          : normalizedOrder
+
+      const listingIdentity = toListingValueObject(params.listing)
+      const listingKey = resolveListingKey(params.listing)
+      const listingId =
+        params.listing &&
+        typeof params.listing === 'object' &&
+        'id' in params.listing &&
+        (params.listing as any).id
+          ? String((params.listing as any).id)
+          : undefined
+
+      const errorPayload = result.success
+        ? undefined
+        : {
+            error: result.error,
+            output: result.output,
+          }
+      const responsePayload = buildOrderSubmitResponse(
+        normalizedOrder as Record<string, any> | undefined,
+        (rawOrder as Record<string, any> | undefined) ?? (errorPayload as any),
+        result.success,
+        result.success ? undefined : result.error
+      )
+
+      const context = (params as any)._context as
+        | { workflowId?: string; executionId?: string }
+        | undefined
+
+      const orderSubmit: OrderSubmit = {
+        provider: params.provider,
+        environment: params.environment,
+        recordedAt: new Date().toISOString(),
+        workflowId: context?.workflowId ?? (params as any)._workflowId,
+        workflowExecutionId: context?.executionId,
+        listingId,
+        listingKey,
+        listingType: listingIdentity?.listing_type,
+        listingIdentity,
+        request: buildOrderSubmitRequest(params),
+        response: responsePayload,
+        normalizedOrder: normalizedOrder as Record<string, any> | undefined,
+      }
+
+      const baseUrl = getBaseUrl()
+      const recordUrl = new URL('/api/tools/trading/order-history', baseUrl).toString()
+
+      await fetch(recordUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(orderSubmit),
+      })
+    } catch (error: any) {
+      logger.warn('Failed to record order history entry', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+
+    return result
   },
 
   transformResponse: async (response, params) => {

--- a/apps/tradinggoose/tools/trading/action.ts
+++ b/apps/tradinggoose/tools/trading/action.ts
@@ -108,11 +108,18 @@ export const tradingActionTool: ToolConfig<TradingActionParams, TradingActionRes
       visibility: 'user-or-llm',
       description: 'Order sizing mode (quantity or notional) for Alpaca.',
     },
+    orderClass: {
+      type: 'string',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Order class for providers that support it (e.g., equity, option, multileg).',
+    },
     orderType: {
       type: 'string',
       required: false,
       visibility: 'user-or-llm',
-      description: 'Order type (market, limit, stop, stop_limit).',
+      description:
+        'Order type (provider-specific, e.g., market, limit, stop, stop_limit, trailing_stop, debit, credit, even).',
     },
     timeInForce: {
       type: 'string',
@@ -131,6 +138,18 @@ export const tradingActionTool: ToolConfig<TradingActionParams, TradingActionRes
       required: false,
       visibility: 'user-or-llm',
       description: 'Stop price (required for stop/stop_limit orders).',
+    },
+    trailPrice: {
+      type: 'number',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Trailing stop price offset (Alpaca trailing_stop).',
+    },
+    trailPercent: {
+      type: 'number',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Trailing stop percent offset (Alpaca trailing_stop).',
     },
     environment: {
       type: 'string',

--- a/apps/tradinggoose/tools/trading/index.ts
+++ b/apps/tradinggoose/tools/trading/index.ts
@@ -1,4 +1,5 @@
 import { tradingActionTool } from '@/tools/trading/action'
 import { tradingHoldingsTool } from '@/tools/trading/holdings'
+import { orderHistoryTool } from '@/tools/trading/order_history'
 
-export { tradingActionTool, tradingHoldingsTool }
+export { tradingActionTool, tradingHoldingsTool, orderHistoryTool }

--- a/apps/tradinggoose/tools/trading/order_history.ts
+++ b/apps/tradinggoose/tools/trading/order_history.ts
@@ -1,0 +1,131 @@
+import type { ToolConfig } from '@/tools/types'
+import type { OrderHistory } from '@/tools/trading/types'
+
+export interface OrderHistoryParams {
+  startDate: string
+  endDate: string
+  workflowId?: string
+}
+
+export interface OrderHistoryResponse {
+  success: boolean
+  output: {
+    history: OrderHistory
+    count: number
+    workflowId?: string | null
+    startDate: string
+    endDate: string
+  }
+  error?: string
+}
+
+export const orderHistoryTool: ToolConfig<OrderHistoryParams, OrderHistoryResponse> = {
+  id: 'trading_order_history',
+  name: 'Trading: Order History',
+  description: 'Retrieve order submissions recorded for a workflow within a datetime range.',
+  version: '1.0.0',
+
+  params: {
+    startDate: {
+      type: 'string',
+      required: true,
+      visibility: 'user-or-llm',
+      description: 'Start datetime (ISO 8601).',
+    },
+    endDate: {
+      type: 'string',
+      required: true,
+      visibility: 'user-or-llm',
+      description: 'End datetime (ISO 8601).',
+    },
+    workflowId: {
+      type: 'string',
+      required: false,
+      visibility: 'user-or-llm',
+      description:
+        'Optional workflow ID to filter by. Defaults to the current workflow execution context.',
+    },
+  },
+
+  request: {
+    url: (
+      params: OrderHistoryParams & { _context?: { workflowId?: string } }
+    ) => {
+      const startDate = params.startDate
+      const endDate = params.endDate
+      const workflowId = params.workflowId || params._context?.workflowId
+
+      if (!startDate || !endDate) {
+        return {
+          _errorResponse: {
+            status: 400,
+            data: {
+              success: false,
+              error: {
+                message: 'startDate and endDate are required',
+              },
+            },
+          },
+        }
+      }
+
+      const searchParams = new URLSearchParams()
+      searchParams.set('startDate', startDate)
+      searchParams.set('endDate', endDate)
+      if (workflowId) {
+        searchParams.set('workflowId', workflowId)
+      }
+
+      return `/api/tools/trading/order-history?${searchParams.toString()}`
+    },
+    method: 'GET',
+    headers: () => ({
+      'Content-Type': 'application/json',
+    }),
+  },
+
+  transformResponse: async (response): Promise<OrderHistoryResponse> => {
+    const result = await response.json()
+    const data = result.data || result
+
+    const history = (data.history || []) as OrderHistory
+
+    return {
+      success: true,
+      output: {
+        history,
+        count: typeof data.count === 'number' ? data.count : history.length,
+        workflowId: data.workflowId,
+        startDate: data.startDate || '',
+        endDate: data.endDate || '',
+      },
+    }
+  },
+
+  outputs: {
+    history: {
+      type: 'array',
+      description: 'Ordered list of recorded order submissions.',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Order history record ID' },
+          provider: { type: 'string', description: 'Trading provider' },
+          recordedAt: { type: 'string', description: 'Recorded timestamp' },
+          workflowId: { type: 'string', description: 'Workflow ID' },
+          workflowExecutionId: { type: 'string', description: 'Workflow execution ID' },
+          listingId: { type: 'string', description: 'Listing object ID' },
+          listingKey: { type: 'string', description: 'Listing identity key' },
+          listingType: { type: 'string', description: 'Listing type' },
+          request: { type: 'object', description: 'Normalized order request payload' },
+          response: { type: 'object', description: 'Normalized order response payload' },
+          normalizedOrder: { type: 'object', description: 'Provider-normalized order details' },
+        },
+      },
+    },
+    count: { type: 'number', description: 'Number of records returned.' },
+    workflowId: { type: 'string', description: 'Workflow ID used for filtering.' },
+    startDate: { type: 'string', description: 'Start datetime used for filtering.' },
+    endDate: { type: 'string', description: 'End datetime used for filtering.' },
+  },
+}

--- a/apps/tradinggoose/tools/trading/types.ts
+++ b/apps/tradinggoose/tools/trading/types.ts
@@ -4,7 +4,7 @@ import type {
   TradingProviderId,
   TradingOrderType,
 } from '@/providers/trading/types'
-import type { ListingInputValue } from '@/lib/listing/identity'
+import type { ListingIdentity, ListingInputValue, ListingType } from '@/lib/listing/identity'
 
 export interface TradingActionParams {
   provider: TradingProviderId
@@ -31,7 +31,7 @@ export interface TradingActionParams {
   accountId?: string
   accountUrl?: string
   instrumentUrl?: string
-  orderSizingMode?:string
+  orderSizingMode?: string
   orderClass?: string
 }
 
@@ -43,6 +43,83 @@ export interface TradingHoldingsParams {
   apiSecret?: string
   accountId?: string
   accountUrl?: string
+}
+
+export interface OrderSubmitRequest {
+  side: 'buy' | 'sell'
+  orderType?: TradingOrderType
+  timeInForce?: string
+  quantity?: number
+  notional?: number
+  limitPrice?: number
+  stopPrice?: number
+  trailPrice?: number
+  trailPercent?: number
+  orderSizingMode?: string
+  orderClass?: string
+  providerParams?: Record<string, unknown>
+}
+
+export interface OrderSubmitResponse {
+  success: boolean
+  orderId?: string | null
+  clientOrderId?: string | null
+  createdAt?: string | null
+  submittedAt?: string | null
+  symbol?: string | null
+  status?: string | null
+  errorMessage?: string | null
+  raw?: unknown
+}
+
+export interface OrderSubmit {
+  id?: string
+  provider: TradingProviderId
+  environment?: 'paper' | 'live' | string
+  recordedAt: string
+  workflowId?: string
+  workflowExecutionId?: string
+  listingId?: string | null
+  listingKey?: string | null
+  listingType?: ListingType
+  listingIdentity?: ListingIdentity | null
+  request: OrderSubmitRequest
+  response: OrderSubmitResponse
+  normalizedOrder?: Record<string, any>
+}
+
+export type OrderHistory = OrderSubmit[]
+
+export interface OrderStatus {
+  id?: string | null
+  clientOrderId?: string | null
+  createdAt?: string | null
+  updatedAt?: string | null
+  submittedAt?: string | null
+  filledAt?: string | null
+  expiredAt?: string | null
+  canceledAt?: string | null
+  failedAt?: string | null
+  replacedAt?: string | null
+  replacedBy?: string | null
+  replaces?: string | null
+  assetId?: string | null
+  symbol?: string | null
+  assetClass?: string | null
+  notional?: string | number | null
+  qty?: string | number | null
+  filledQty?: string | number | null
+  filledAvgPrice?: string | number | null
+  orderClass?: string | null
+  orderType?: string | null
+  side?: string | null
+  timeInForce?: string | null
+  limitPrice?: string | number | null
+  stopPrice?: string | number | null
+  status?: string | null
+  extendedHours?: boolean | null
+  legs?: OrderStatus[] | null
+  raw?: unknown
 }
 
 export type { TradingActionResponse, TradingHoldingsResponse }

--- a/apps/tradinggoose/tools/trading/types.ts
+++ b/apps/tradinggoose/tools/trading/types.ts
@@ -2,6 +2,7 @@ import type {
   TradingActionResponse,
   TradingHoldingsResponse,
   TradingProviderId,
+  TradingOrderType,
 } from '@/providers/trading/types'
 import type { ListingInputValue } from '@/lib/listing/identity'
 
@@ -11,10 +12,12 @@ export interface TradingActionParams {
   side: 'buy' | 'sell'
   quantity?: number
   notional?: number
-  orderType?: string
+  orderType?: TradingOrderType
   timeInForce?: string
   limitPrice?: number
   stopPrice?: number
+  trailPrice?: number
+  trailPercent?: number
   environment?: 'paper' | 'live'
   // Auth
   credential?: string
@@ -29,6 +32,7 @@ export interface TradingActionParams {
   accountUrl?: string
   instrumentUrl?: string
   orderSizingMode?:string
+  orderClass?: string
 }
 
 export interface TradingHoldingsParams {

--- a/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-block/components/sub-block/components/listing-selector/listing-selector.tsx
+++ b/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-block/components/sub-block/components/listing-selector/listing-selector.tsx
@@ -26,6 +26,7 @@ interface ListingSelectorInputProps {
   config?: SubBlockConfig
   providerType?: 'market' | 'trading'
   providerFieldId?: string
+  providerValueOverride?: string | null
 }
 
 function isVariableListingInput(value: string): boolean {
@@ -45,10 +46,12 @@ export function ListingSelectorInput({
   config,
   providerType,
   providerFieldId,
+  providerValueOverride,
 }: ListingSelectorInputProps) {
   const [storeValue, setStoreValue] = useSubBlockValue<ListingInputValue>(blockId, subBlockId)
   const providerField = providerFieldId ?? config?.providerFieldId ?? 'provider'
-  const [providerValue] = useSubBlockValue<string | null>(blockId, providerField)
+  const [providerValueFromStore] = useSubBlockValue<string | null>(blockId, providerField)
+  const providerValue = providerValueOverride ?? providerValueFromStore
   const ensureInstance = useListingSelectorStore((state) => state.ensureInstance)
   const updateInstance = useListingSelectorStore((state) => state.updateInstance)
   const instance = useListingSelectorStore((state) => state.instances[`${blockId}-${subBlockId}`])

--- a/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-block/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-block/components/sub-block/components/tool-input/tool-input.tsx
@@ -1206,11 +1206,16 @@ export function ToolInput({
         )
 
       case 'market-selector': {
-        const providerFieldId =
-          toolIndex !== undefined
-            ? `${subBlockId}-tool-${toolIndex}-provider`
-            : `${subBlockId}-provider`
-        const providerType = toolId?.startsWith('trading_') ? 'trading' : 'market'
+        const providerFieldKey =
+          (uiComponent as { providerFieldId?: string })?.providerFieldId || 'provider'
+        const providerFieldId = `${subBlockId}-param-${providerFieldKey}`
+        const providerType =
+          (uiComponent as { providerType?: 'market' | 'trading' })?.providerType ||
+          (toolId?.startsWith('trading_') ? 'trading' : 'market')
+        const providerValueOverride =
+          (currentToolParams as Record<string, any> | undefined)?.[providerFieldKey] ??
+          (currentToolParams as Record<string, any> | undefined)?.provider ??
+          null
 
         return (
           <ListingSelectorInput
@@ -1222,6 +1227,7 @@ export function ToolInput({
             onChange={(listing) => onChange(listing ?? null)}
             disabled={disabled}
             providerFieldId={providerFieldId}
+            providerValueOverride={providerValueOverride}
             providerType={providerType}
             config={{
               id: uniqueSubBlockId,


### PR DESCRIPTION
## Summary

Introduce a full order-history pipeline for Trading Action runs. This adds a canonical `orderHistoryTable` to persist normalized `orderSubmit` records (including provider, listing identity, workflow/workflow execution IDs, request/response, and normalized order data), along with a migration. The Trading Action tool now writes history on both success and failure, and tool context now includes `executionId` so records can be traced to a specific workflow run. A new `trading_order_history` tool and `/api/tools/trading/order-history` endpoint allow querying by datetime range (optionally filtered by workflow). Finally, a new **Trading Order History** block surfaces this tool in the UI, so it appears in the Agent tool selector, workflow Tools button, and block picker.


## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
Not run locally. Reviewers should verify:
- orderHistoryTable migration applies and inserts work
- trading_place_order records history on success/failure
- orderHistoryTool and Trading Order History block surface in UI

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [X] No new warnings introduced
- [X] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

<img width="298" height="294" alt="image" src="https://github.com/user-attachments/assets/93685ec2-99b7-44e6-bcad-e8d22fc954ef" />

