### PR TITLE
Docker and Compose flow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,51 @@
-LICENSE
-NOTICE
-.prettierrc
-.prettierignore
-README.md
-.gitignore
-.husky
+# Git / workspace metadata
+.git
 .github
 .devcontainer
-.env.example
+.husky
+.codex
+.vscode
+
+# Dependency installs and caches
 node_modules
+**/node_modules
+.turbo
+**/.turbo
+**/.next
+**/out
+**/build
+**/dist
+**/standalone
+**/coverage
+
+# Docs and generated content
+LICENSE
+NOTICE
+README.md
+.prettierrc
+.prettierignore
+.gitignore
+.env.example
+/apps/docs/.source
+/apps/docs/.contentlayer
+/apps/docs/.content-collections
+/apps/docs/.next
+/apps/docs/out
+/apps/docs/build
+/apps/docs/coverage
+
+# Environment and local secrets
+.env
+*.env
+.env.local
+.env.development
+.env.test
+.env.production
+
+# Miscellaneous
+*.log
+*.map
+.DS_Store
+*.pem
+**/postgres_data/
+CURSOR_MEMORY

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -154,9 +154,15 @@ After running this command, open [http://localhost:3000/](http://localhost:3000/
 git clone https://github.com/<your-username>/TradingGoose-Studio.git
 cd TradingGoose-Studio
 
-# Start TradingGoose
+# Copy the root Compose env template and set the required secrets/tags
+cp .env.example .env
+
 docker compose -f docker-compose.prod.yml up -d
 ```
+
+Your root `.env` must include `POSTGRES_*`, `NEXT_PUBLIC_APP_URL`,
+`BETTER_AUTH_SECRET`, `ENCRYPTION_KEY`, `API_ENCRYPTION_KEY`, and
+`INTERNAL_API_SECRET`. The `ENCRYPTION_KEY` value must be available to both the app and realtime containers.
 
 Access the application at [http://localhost:3000/](http://localhost:3000/)
 
@@ -178,14 +184,13 @@ ollama pull gemma3:4b
 
 ```bash
 # With NVIDIA GPU support
-docker compose --profile local-gpu -f docker-compose.ollama.yml up -d
+docker compose --profile gpu --profile setup -f docker-compose.ollama.yml up -d
 
 # Without GPU (CPU only)
-docker compose --profile local-cpu -f docker-compose.ollama.yml up -d
+docker compose --profile cpu --profile setup -f docker-compose.ollama.yml up -d
 
-# If hosting on a server, update the environment variables in the docker-compose.prod.yml file
-# to include the server's public IP then start again (OLLAMA_URL to i.e. http://1.1.1.1:11434)
-docker compose -f docker-compose.prod.yml up -d
+# If hosting on a server, point OLLAMA_URL in .env to the remote endpoint
+# before starting docker compose -f docker-compose.prod.yml up -d
 ```
 
 ### Option 3: Using VS Code / Cursor Dev Containers
@@ -238,7 +243,8 @@ If you prefer not to use Docker or Dev Containers:
      cd apps/tradinggoose
      ```
    - Copy `.env.example` to `.env`
-   - Configure required variables (DATABASE_URL, BETTER_AUTH_SECRET, BETTER_AUTH_URL)
+   - Configure required variables (DATABASE_URL, NEXT_PUBLIC_APP_URL, BETTER_AUTH_SECRET, ENCRYPTION_KEY, INTERNAL_API_SECRET)
+   - Add `API_ENCRYPTION_KEY` if you want encrypted API-key storage in local development
 
 3. **Set Up Database:**
 

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -5,58 +5,51 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: build-and-push-images
+  cancel-in-progress: false
+
 permissions:
   contents: read
   packages: write
-  id-token: write
 
 jobs:
-  build-amd64:
-    name: Build AMD64
+  build-images:
+    name: Build Images
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:
         include:
           - dockerfile: ./docker/app.Dockerfile
-            ghcr_image: ghcr.io/tradinggoose/tradinggoose
-            ecr_repo_secret: ECR_APP
+            repo: tradinggoose
           - dockerfile: ./docker/db.Dockerfile
-            ghcr_image: ghcr.io/tradinggoose/migrations
-            ecr_repo_secret: ECR_MIGRATIONS
+            repo: migrations
           - dockerfile: ./docker/realtime.Dockerfile
-            ghcr_image: ghcr.io/tradinggoose/realtime
-            ecr_repo_secret: ECR_REALTIME
-    outputs:
-      registry: ${{ steps.login-ecr.outputs.registry }}
+            repo: realtime
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
         with:
-          role-to-assume: ${{ github.ref == 'refs/heads/main' && secrets.AWS_ROLE_TO_ASSUME || secrets.STAGING_AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ github.ref == 'refs/heads/main' && secrets.AWS_REGION || secrets.STAGING_AWS_REGION }}
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          platforms: arm64
 
       - name: Login to GHCR
-        if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        if: github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: useblacksmith/setup-docker-builder@v1
@@ -64,119 +57,30 @@ jobs:
       - name: Generate tags
         id: meta
         run: |
-          ECR_REGISTRY="${{ steps.login-ecr.outputs.registry }}"
-          ECR_REPO="${{ secrets[matrix.ecr_repo_secret] }}"
-          GHCR_IMAGE="${{ matrix.ghcr_image }}"
+          set -euo pipefail
 
-          # ECR tags (always build for ECR)
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            ECR_TAG="latest"
-          else
-            ECR_TAG="staging"
-          fi
-          ECR_IMAGE="${ECR_REGISTRY}/${ECR_REPO}:${ECR_TAG}"
+          repo="${{ matrix.repo }}"
+          ghcr_image="ghcr.io/tradinggoose/${repo}"
+          sha_tag="${{ github.sha }}"
+          tags=("${ghcr_image}:${sha_tag}")
 
-          # Build tags list
-          TAGS="${ECR_IMAGE}"
-
-          # Add GHCR tags only for main branch
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            GHCR_AMD64="${GHCR_IMAGE}:latest-amd64"
-            GHCR_SHA="${GHCR_IMAGE}:${{ github.sha }}-amd64"
-            TAGS="${TAGS},$GHCR_AMD64,$GHCR_SHA"
+          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            dockerhub_image="docker.io/${{ secrets.DOCKERHUB_USERNAME }}/${repo}"
+            tags+=("${ghcr_image}:latest")
+            tags+=("${dockerhub_image}:${sha_tag}")
+            tags+=("${dockerhub_image}:latest")
           fi
 
-          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          tags_csv=$(IFS=,; printf '%s' "${tags[*]}")
+          echo "tags=${tags_csv}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push images
         uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          provenance: false
-          sbom: false
-
-  build-ghcr-arm64:
-    name: Build ARM64 (GHCR Only)
-    runs-on: linux-arm64-8-core
-    if: github.ref == 'refs/heads/main'
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - dockerfile: ./docker/app.Dockerfile
-            image: ghcr.io/tradinggoose/tradinggoose
-          - dockerfile: ./docker/db.Dockerfile
-            image: ghcr.io/tradinggoose/migrations
-          - dockerfile: ./docker/realtime.Dockerfile
-            image: ghcr.io/tradinggoose/realtime
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: useblacksmith/setup-docker-builder@v1
-
-      - name: Generate ARM64 tags
-        id: meta
-        run: |
-          IMAGE="${{ matrix.image }}"
-          echo "tags=${IMAGE}:latest-arm64,${IMAGE}:${{ github.sha }}-arm64" >> $GITHUB_OUTPUT
-
-      - name: Build and push ARM64 to GHCR
-        uses: useblacksmith/build-push-action@v2
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          platforms: linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          provenance: false
-          sbom: false
-
-  create-ghcr-manifests:
-    name: Create GHCR Manifests
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [build-amd64, build-ghcr-arm64]
-    if: github.ref == 'refs/heads/main'
-    strategy:
-      matrix:
-        include:
-          - image: ghcr.io/tradinggoose/tradinggoose
-          - image: ghcr.io/tradinggoose/migrations
-          - image: ghcr.io/tradinggoose/realtime
-
-    steps:
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create and push manifests
-        run: |
-          IMAGE_BASE="${{ matrix.image }}"
-
-          # Create latest manifest
-          docker manifest create "${IMAGE_BASE}:latest" \
-            "${IMAGE_BASE}:latest-amd64" \
-            "${IMAGE_BASE}:latest-arm64"
-          docker manifest push "${IMAGE_BASE}:latest"
-
-          # Create SHA manifest
-          docker manifest create "${IMAGE_BASE}:${{ github.sha }}" \
-            "${IMAGE_BASE}:${{ github.sha }}-amd64" \
-            "${IMAGE_BASE}:${{ github.sha }}-arm64"
-          docker manifest push "${IMAGE_BASE}:${{ github.sha }}"
+          provenance: true
+          sbom: true

--- a/README.md
+++ b/README.md
@@ -64,14 +64,18 @@ It is built for analytics, research, charting, monitoring, and workflow automati
 bun install
 ```
 
-#### 2. Start PostgreSQL database
+#### 2. Start PostgreSQL database and Redis
 ```
 docker run --name tradinggoose-db `
-  -e POSTGRES_PASSWORD=postgres `
+  -e POSTGRES_USER=tradinggoose `
+  -e POSTGRES_PASSWORD=<your-postgres-password> `
   -e POSTGRES_DB=tradinggoose `
   -p 5432:5432 `
   -d pgvector/pgvector:pg17
+
+docker run -d --name tradinggoose-redis -p 6379:6379 redis
 ```
+
 #### 3. Setup environment variables
 ```
 cd apps/tradinggoose && cp .env.example .env
@@ -89,6 +93,20 @@ bunx drizzle-kit migrate --config=./drizzle.config.ts
 cd ../..
 bun run dev:full
 ```
+
+## Docker Compose
+
+If you use Docker Compose, create a `.env` file from the `.env.example.docker` file and set the
+required secrets before running the compose manifests. The `.env` must
+include `POSTGRES_*`, `NEXT_PUBLIC_APP_URL`, `BETTER_AUTH_SECRET`,
+`ENCRYPTION_KEY`, `API_ENCRYPTION_KEY`, and `INTERNAL_API_SECRET`. The
+`ENCRYPTION_KEY` value is shared by both the app and realtime containers, and
+`API_ENCRYPTION_KEY` enables encrypted API-key storage in the app container.
+
+```
+docker compose --env-file ./apps/tradinggoose/.env -f docker-compose.local.yml up
+```
+
 
 ## Contributing
 

--- a/apps/tradinggoose/.env.example
+++ b/apps/tradinggoose/.env.example
@@ -26,7 +26,7 @@
 
 # Required: PostgreSQL connection string used by the Next app, socket server,
 # and local Drizzle commands.
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/tradinggoose"
+DATABASE_URL="postgresql://tradinggoose:replace-with-password@localhost:5432/tradinggoose"
 
 # Required: public browser URL for the Studio app.
 # This should match the URL you actually open in your browser.
@@ -37,20 +37,20 @@ NEXT_PUBLIC_APP_URL="http://localhost:3000"
 BETTER_AUTH_URL="http://localhost:3000"
 
 # Required: Better Auth signing secret.
-# Generate with: openssl rand -hex 32
+# Generate a secure 64-character hex secret.
 BETTER_AUTH_SECRET="replace-with-64-hex-characters"
 
 # Required: default secret encryption key for stored secrets.
-# Generate with: openssl rand -hex 32
+# Generate a secure 64-character hex secret.
 ENCRYPTION_KEY="replace-with-64-hex-characters"
 
 # Recommended: dedicated encryption key for stored API credentials.
-# Generate with: openssl rand -hex 32
+# Generate a secure 64-character hex secret.
 API_ENCRYPTION_KEY="replace-with-64-hex-characters"
 
 # Required: internal server-to-server auth secret used by app routes, sockets,
 # cron endpoints, and other internal calls.
-# Generate with: openssl rand -hex 32
+# Generate a secure 64-character hex secret.
 INTERNAL_API_SECRET="replace-with-64-hex-characters"
 
 # Recommended: Redis for cache, locks, idempotency, and rate limiting.
@@ -130,7 +130,7 @@ NEXT_PUBLIC_SSO_ENABLED="false"
 # TRIGGER_SECRET_KEY=""
 
 # Optional: secret expected by cron/internal scheduled requests.
-# Generate with: openssl rand -hex 32
+# Generate a secure 64-character hex secret.
 # CRON_SECRET="replace-with-64-hex-characters"
 
 ###############################################################################

--- a/apps/tradinggoose/.env.example.docker
+++ b/apps/tradinggoose/.env.example.docker
@@ -21,7 +21,7 @@ ENCRYPTION_KEY=generate-the-key  # Use `openssl rand -hex 32` to generate, used 
 INTERNAL_API_SECRET=generate-the-secret  # Use `openssl rand -hex 32` to generate, used to encrypt internal api routes
 
 # Email Provider (Optional)
-# RESEND_API_KEY=  
+# RESEND_API_KEY=
 # Uncomment and add your key from https://resend.com to send actual emails
 # If left commented out, emails will be logged to console instead
 
@@ -35,7 +35,7 @@ INTERNAL_API_SECRET=generate-the-secret  # Use `openssl rand -hex 32` to generat
 # ALPACA_CLIENT_SECRET=
 
 # MARKET_API_URL=https://market.tradinggoose.ai
-# MARKET_API_KEY= 
+# MARKET_API_KEY=
 
 # COPILOT_API_KEY=
 

--- a/apps/tradinggoose/.env.example.docker
+++ b/apps/tradinggoose/.env.example.docker
@@ -1,5 +1,5 @@
 # Database (Required)
-DATABASE_URL="db://postgres:postgres@db:5432/tradinggoose"
+DATABASE_URL="postgres://postgres:postgres@db:5432/tradinggoose"
 
 # PostgreSQL Port (Optional) - defaults to 5432 if not specified
 POSTGRES_USER=postgres

--- a/apps/tradinggoose/.env.example.docker
+++ b/apps/tradinggoose/.env.example.docker
@@ -1,0 +1,42 @@
+# Database (Required)
+DATABASE_URL="db://postgres:postgres@db:5432/tradinggoose"
+
+# PostgreSQL Port (Optional) - defaults to 5432 if not specified
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=tradinggoose
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+
+# Authentication (Required)
+BETTER_AUTH_SECRET=generate-the-secret  # Use `openssl rand -hex 32` to generate, or visit https://www.better-auth.com/docs/installation
+BETTER_AUTH_URL=http://localhost:3000
+
+# NextJS (Required)
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_SOCKET_URL=http://realtime:3002
+
+# Security (Required)
+ENCRYPTION_KEY=generate-the-key  # Use `openssl rand -hex 32` to generate, used to encrypt environment variables
+INTERNAL_API_SECRET=generate-the-secret  # Use `openssl rand -hex 32` to generate, used to encrypt internal api routes
+
+# Email Provider (Optional)
+# RESEND_API_KEY=  
+# Uncomment and add your key from https://resend.com to send actual emails
+# If left commented out, emails will be logged to console instead
+
+# Local AI Models (Optional)
+# OLLAMA_URL=http://localhost:11434  # URL for local Ollama server - uncomment if using local models
+
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
+
+# ALPACA_CLIENT_ID=
+# ALPACA_CLIENT_SECRET=
+
+# MARKET_API_URL=https://market.tradinggoose.ai
+# MARKET_API_KEY= 
+
+# COPILOT_API_KEY=
+
+REDIS_URL=redis://redis:6379

--- a/apps/tradinggoose/lib/guardrails/requirements.txt
+++ b/apps/tradinggoose/lib/guardrails/requirements.txt
@@ -1,4 +1,3 @@
 # Microsoft Presidio for PII detection
-presidio-analyzer>=2.2.0
-presidio-anonymizer>=2.2.0
-
+presidio-analyzer==2.2.362
+presidio-anonymizer==2.2.362

--- a/changelog/April-23-2026.md
+++ b/changelog/April-23-2026.md
@@ -1,5 +1,60 @@
 # April-23-2026
 
+## docker_files @ f2bc8336 vs origin/staging
+
+### Summary
+- Standardizes the Docker and compose flow around pinned Bun 1.3.11 images, a dedicated guardrails build stage, and a bundled realtime socket-server artifact so the app and realtime containers stay smaller and more predictable.
+- Tightens deployment configuration by making Redis, PostgreSQL credentials, auth secrets, encryption keys, and image tags explicit in local, Ollama, and production compose files instead of relying on implicit defaults or generated values.
+- Simplifies image publishing to one multi-platform workflow that pushes GHCR everywhere and Docker Hub on `main`, then updates the docs and env templates to match the new contract.
+
+### Branch Scope
+- Compared `1309ad1279fb0af551a7aad47764c43a5fd1b3d8..f2bc8336` against `origin/staging`.
+- The working tree was clean during this review, so only committed branch changes are included here.
+- Main areas touched: `.dockerignore`, `.github/CONTRIBUTING.md`, `.github/workflows/images.yml`, `README.md`, `apps/tradinggoose/.env.example`, `apps/tradinggoose/.env.example.docker`, `apps/tradinggoose/lib/guardrails/requirements.txt`, `docker-compose.local.yml`, `docker-compose.ollama.yml`, `docker-compose.prod.yml`, `docker/app.Dockerfile`, `docker/db.Dockerfile`, and `docker/realtime.Dockerfile`.
+
+### Key Changes
+- `docker/app.Dockerfile` now builds on `oven/bun:1.3.11-alpine`, pins `turbo@2.5.8` and `sharp@0.34.3`, splits guardrails installation into its own `guardrails` stage, and copies the runtime guardrails virtualenv into the final image instead of rebuilding it in place.
+- `docker/realtime.Dockerfile` now bundles `apps/tradinggoose/socket-server/index.ts` into `/tmp/realtime-build/socket-server.js` and ships only that artifact in the runtime image, rather than copying the full app tree, package tree, and root `package.json` into the container.
+- `docker/db.Dockerfile` narrows the migration image to the files `packages/db` actually needs at runtime: `package.json`, `drizzle.config.ts`, `schema.ts`, `consts.ts`, `schema/`, and `migrations/`.
+- `.github/workflows/images.yml` collapses the previous AMD64/ARM64 split plus ECR workflow into one matrix job that builds `docker/app.Dockerfile`, `docker/db.Dockerfile`, and `docker/realtime.Dockerfile` for `linux/amd64,linux/arm64`, pushes SHA tags everywhere, and publishes `latest` only on `main` for GHCR and Docker Hub.
+- `docker-compose.local.yml`, `docker-compose.ollama.yml`, and `docker-compose.prod.yml` now require explicit `POSTGRES_USER`, `POSTGRES_PASSWORD`, `NEXT_PUBLIC_APP_URL`, `BETTER_AUTH_SECRET`, `ENCRYPTION_KEY`, `INTERNAL_API_SECRET`, and image tags where applicable, add a Redis service dependency, and wire `REDIS_URL=redis://redis:6379` into the app and realtime containers.
+- `docker-compose.ollama.yml` also switches Ollama to `OLLAMA_IMAGE_TAG` instead of `latest`, keeps the GPU and CPU services separate, and makes the setup helper reference the actual service name when explaining how to pull extra models.
+- `.dockerignore` now excludes repo metadata, build output, cache directories, environment files, logs, and local data volumes more aggressively so Docker builds stay focused on source inputs.
+- `apps/tradinggoose/.env.example` and `apps/tradinggoose/.env.example.docker` now document the explicit local boot variables, including the Redis URL, socket URL, and compose-specific database/bootstrap defaults.
+- `.github/CONTRIBUTING.md` and `README.md` now explain the new compose bootstrap flow and the need to copy the appropriate env template before running Docker-based setups.
+
+### Design Decisions
+- The branch makes the runtime contract explicit instead of hiding it behind generated secrets or image defaults. That keeps local Docker, production compose, and CI image publishing aligned on the same required inputs.
+- Redis is treated as a first-class dependency for containerized runs rather than an optional external service, which is why every compose stack now depends on the local Redis container and exports the same `REDIS_URL`.
+- The realtime container now owns a bundled socket-server artifact only. That reduces runtime image surface area and keeps the build/runtime split clear: bundle in the Dockerfile, execute the compiled artifact in the final image.
+- Guardrails setup is isolated in a dedicated build stage so Python package installation does not leak into the app runtime image beyond the prepared virtualenv.
+- The image workflow now publishes multi-platform images from one job instead of maintaining separate build, arm64, and manifest-push jobs. That keeps the publishing path simpler and avoids the previous AWS/ECR dependency chain.
+
+### Shared Contracts and Helpers to Reuse
+- Reuse `apps/tradinggoose/.env.example` for app-only local development and `apps/tradinggoose/.env.example.docker` for Docker Compose setups. Those files now define the canonical required env surface for each path.
+- Reuse the explicit `:?` interpolation pattern in `docker-compose.local.yml`, `docker-compose.ollama.yml`, and `docker-compose.prod.yml` when adding new compose services that should fail fast on missing secrets or tags.
+- Reuse `docker/app.Dockerfile`, `docker/realtime.Dockerfile`, and `docker/db.Dockerfile` as the canonical container build patterns for app, socket server, and migrations work instead of copying full source trees into new images.
+- Reuse the single-job publishing model in `.github/workflows/images.yml` for future image variants so tag generation and platform coverage stay centralized.
+
+### Removed or Replaced Items
+- The old implicit env defaults for PostgreSQL credentials, auth secrets, encryption keys, and image tags were replaced. Future branches should not reintroduce silent fallbacks such as `postgres`, `latest`, or generated compose-time secrets for these paths.
+- The previous separate AMD64/ARM64 build jobs, manifest assembly job, and AWS/ECR login path in `.github/workflows/images.yml` were replaced by the single GHCR/Docker Hub workflow.
+- The realtime image no longer copies the full app and package trees into the runtime layer. The replacement is the bundled `socket-server.js` artifact produced during the Docker build.
+- The db image no longer copies the whole `packages/db` directory. The replacement is the explicit migration input set copied in `docker/db.Dockerfile`.
+
+### Future Branch Guardrails
+- Do not add new compose services that depend on hidden defaults when the rest of the stack now expects explicit `:?`-guarded env vars.
+- Do not reintroduce `latest`-only image references for production or compose-based local boot; use tagged images and make the tag requirement visible in the env file.
+- Do not expand the realtime runtime image back into a full app image unless the socket-server bundling strategy changes with it.
+- Do not move guardrails installation back into the main app runtime layer; keep the isolated build stage and copy only its prepared virtualenv forward.
+- Do not split the image publishing path back into separate platform-specific jobs unless the registry or platform requirements genuinely change.
+
+### Validation Notes
+- Reviewed `git status --short --branch`, `git log --oneline origin/staging..HEAD`, `git diff --stat origin/staging...HEAD`, and `git diff --name-status --find-renames origin/staging...HEAD`.
+- Verified patch hygiene with `git diff --check origin/staging...HEAD`.
+- Validated all three compose files with `docker compose -f docker-compose.local.yml config`, `docker compose -f docker-compose.ollama.yml config`, and `docker compose -f docker-compose.prod.yml config` using explicit placeholder env values.
+- No application tests were added or updated in this branch; the change set is Docker, compose, and documentation focused.
+
 ## fix/copilot-billing @ 6a60cc11 vs origin/staging
 
 ### Summary

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,26 +1,35 @@
 services:
+  redis:
+    image: redis:7.2.1-alpine
+    ports:
+      - '6379:6379'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 3s
+      retries: 5
   tradinggoose:
     build:
       context: .
       dockerfile: docker/app.Dockerfile
     ports:
       - '3000:3000'
-    deploy:
-      resources:
-        limits:
-          memory: 8G
     environment:
-      - NODE_ENV=development
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-tradinggoose}
+      - NODE_ENV=production
+      - DATABASE_URL=postgresql://${POSTGRES_USER:?set POSTGRES_USER in .env}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@db:5432/${POSTGRES_DB:-tradinggoose}
       - BETTER_AUTH_URL=${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
       - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
-      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:-your_auth_secret_here}
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-your_encryption_key_here}
-      - COPILOT_API_KEY=${COPILOT_API_KEY}
-      - COPILOT_API_URL=${COPILOT_API_URL}
+      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:?set BETTER_AUTH_SECRET in .env}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?set ENCRYPTION_KEY in .env}
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:?set INTERNAL_API_SECRET in .env}
+      - REDIS_URL=redis://redis:6379
+      - COPILOT_API_KEY=${COPILOT_API_KEY:-}
+      - COPILOT_API_URL=${COPILOT_API_URL:-}
       - OLLAMA_URL=${OLLAMA_URL:-http://localhost:11434}
-      - NEXT_PUBLIC_SOCKET_URL=${NEXT_PUBLIC_SOCKET_URL:-}
+      - NEXT_PUBLIC_SOCKET_URL=${NEXT_PUBLIC_SOCKET_URL:-http://realtime:3002}
     depends_on:
+      redis:
+        condition: service_healthy
       db:
         condition: service_healthy
       migrations:
@@ -39,20 +48,22 @@ services:
       context: .
       dockerfile: docker/realtime.Dockerfile
     environment:
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-tradinggoose}
+      - NODE_ENV=production
+      - DATABASE_URL=postgresql://${POSTGRES_USER:?set POSTGRES_USER in .env}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@db:5432/${POSTGRES_DB:-tradinggoose}
       - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
-      - BETTER_AUTH_URL=${BETTER_AUTH_URL:-http://localhost:3000}
-      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:-your_auth_secret_here}
+      - BETTER_AUTH_URL=${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
+      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:?set BETTER_AUTH_SECRET in .env}
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:?set INTERNAL_API_SECRET in .env}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?set ENCRYPTION_KEY in .env}
+      - REDIS_URL=redis://redis:6379
     depends_on:
+      redis:
+        condition: service_healthy
       db:
         condition: service_healthy
     restart: unless-stopped
     ports:
       - '3002:3002'
-    deploy:
-      resources:
-        limits:
-          memory: 8G
     healthcheck:
       test: ['CMD', 'wget', '--spider', '--quiet', 'http://127.0.0.1:3002/health']
       interval: 90s
@@ -66,7 +77,7 @@ services:
       dockerfile: docker/db.Dockerfile
     working_dir: /app/packages/db
     environment:
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-tradinggoose}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:?set POSTGRES_USER in .env}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@db:5432/${POSTGRES_DB:-tradinggoose}
     depends_on:
       db:
         condition: service_healthy
@@ -79,13 +90,13 @@ services:
     ports:
       - '${POSTGRES_PORT:-5432}:5432'
     environment:
-      - POSTGRES_USER=${POSTGRES_USER:-postgres}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+      - POSTGRES_USER=${POSTGRES_USER:?set POSTGRES_USER in .env}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
       - POSTGRES_DB=${POSTGRES_DB:-tradinggoose}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:?set POSTGRES_USER in .env}']
       interval: 5s
       timeout: 5s
       retries: 5

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,8 +1,6 @@
 services:
   redis:
     image: redis:7.2.1-alpine
-    ports:
-      - '6379:6379'
     healthcheck:
       test: ['CMD', 'redis-cli', 'ping']
       interval: 5s
@@ -27,6 +25,7 @@ services:
       - COPILOT_API_URL=${COPILOT_API_URL:-}
       - OLLAMA_URL=${OLLAMA_URL:-http://localhost:11434}
       - NEXT_PUBLIC_SOCKET_URL=${NEXT_PUBLIC_SOCKET_URL:-http://realtime:3002}
+      - API_ENCRYPTION_KEY=${API_ENCRYPTION_KEY:-}
     depends_on:
       redis:
         condition: service_healthy

--- a/docker-compose.ollama.yml
+++ b/docker-compose.ollama.yml
@@ -1,6 +1,14 @@
 name: tradinggoose-with-ollama
-
 services:
+  redis:
+    image: redis:7.2.1-alpine
+    ports:
+      - '6379:6379'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 3s
+      retries: 5
   # Main TradingGoose Studio Application
   tradinggoose:
     build:
@@ -8,21 +16,22 @@ services:
       dockerfile: docker/app.Dockerfile
     ports:
       - '3000:3000'
-    deploy:
-      resources:
-        limits:
-          memory: 8G
     environment:
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-tradinggoose}
+      - NODE_ENV=production
+      - DATABASE_URL=postgresql://${POSTGRES_USER:?set POSTGRES_USER in .env}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@db:5432/${POSTGRES_DB:-tradinggoose}
       - BETTER_AUTH_URL=${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
       - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
-      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:-tradinggoose_auth_secret_$(openssl rand -hex 16)}
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-$(openssl rand -hex 32)}
-      - COPILOT_API_KEY=${COPILOT_API_KEY}
-      - COPILOT_API_URL=${COPILOT_API_URL}
+      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:?set BETTER_AUTH_SECRET in .env}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?set ENCRYPTION_KEY in .env}
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:?set INTERNAL_API_SECRET in .env}
+      - REDIS_URL=redis://redis:6379
+      - COPILOT_API_KEY=${COPILOT_API_KEY:-}
+      - COPILOT_API_URL=${COPILOT_API_URL:-}
       - OLLAMA_URL=http://ollama:11434
       - NEXT_PUBLIC_SOCKET_URL=${NEXT_PUBLIC_SOCKET_URL:-}
     depends_on:
+      redis:
+        condition: service_healthy
       db:
         condition: service_healthy
       migrations:
@@ -43,20 +52,22 @@ services:
       context: .
       dockerfile: docker/realtime.Dockerfile
     environment:
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-tradinggoose}
+      - NODE_ENV=production
+      - DATABASE_URL=postgresql://${POSTGRES_USER:?set POSTGRES_USER in .env}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@db:5432/${POSTGRES_DB:-tradinggoose}
       - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
-      - BETTER_AUTH_URL=${BETTER_AUTH_URL:-http://localhost:3000}
-      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:-tradinggoose_auth_secret_$(openssl rand -hex 16)}
+      - BETTER_AUTH_URL=${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
+      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:?set BETTER_AUTH_SECRET in .env}
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:?set INTERNAL_API_SECRET in .env}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?set ENCRYPTION_KEY in .env}
+      - REDIS_URL=redis://redis:6379
     depends_on:
+      redis:
+        condition: service_healthy
       db:
         condition: service_healthy
     restart: unless-stopped
     ports:
       - '3002:3002'
-    deploy:
-      resources:
-        limits:
-          memory: 8G
     healthcheck:
       test: ['CMD', 'wget', '--spider', '--quiet', 'http://127.0.0.1:3002/health']
       interval: 90s
@@ -70,7 +81,7 @@ services:
       context: .
       dockerfile: docker/db.Dockerfile
     environment:
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-tradinggoose}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:?set POSTGRES_USER in .env}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@db:5432/${POSTGRES_DB:-tradinggoose}
     depends_on:
       db:
         condition: service_healthy
@@ -81,16 +92,14 @@ services:
   db:
     image: pgvector/pgvector:pg17
     restart: always
-    ports:
-      - '${POSTGRES_PORT:-5432}:5432'
     environment:
-      - POSTGRES_USER=${POSTGRES_USER:-postgres}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+      - POSTGRES_USER=${POSTGRES_USER:?set POSTGRES_USER in .env}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
       - POSTGRES_DB=${POSTGRES_DB:-tradinggoose}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:?set POSTGRES_USER in .env}']
       interval: 5s
       timeout: 5s
       retries: 5
@@ -99,26 +108,16 @@ services:
   ollama:
     profiles:
       - gpu
-    image: ollama/ollama:latest
-    pull_policy: always
+    image: ollama/ollama:${OLLAMA_IMAGE_TAG:?set OLLAMA_IMAGE_TAG in .env}
     volumes:
       - ollama_data:/root/.ollama
-    ports:
-      - '11434:11434'
+    gpus: all
     environment:
       - NVIDIA_DRIVER_CAPABILITIES=all
       - OLLAMA_LOAD_TIMEOUT=-1
       - OLLAMA_KEEP_ALIVE=-1
-      - OLLAMA_DEBUG=1
       - OLLAMA_HOST=0.0.0.0:11434
     command: 'serve'
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
     healthcheck:
       test: ['CMD', 'ollama', 'list']
       interval: 10s
@@ -127,20 +126,16 @@ services:
       start_period: 30s
     restart: unless-stopped
 
-  # Ollama CPU-only version (use with --profile cpu profile)
+  # Ollama CPU-only version (use with --profile cpu)
   ollama-cpu:
     profiles:
       - cpu
-    image: ollama/ollama:latest
-    pull_policy: always
+    image: ollama/ollama:${OLLAMA_IMAGE_TAG:?set OLLAMA_IMAGE_TAG in .env}
     volumes:
       - ollama_data:/root/.ollama
-    ports:
-      - '11434:11434'
     environment:
       - OLLAMA_LOAD_TIMEOUT=-1
       - OLLAMA_KEEP_ALIVE=-1
-      - OLLAMA_DEBUG=1
       - OLLAMA_HOST=0.0.0.0:11434
     command: 'serve'
     healthcheck:
@@ -157,7 +152,7 @@ services:
 
   # Helper container to pull models automatically
   model-setup:
-    image: ollama/ollama:latest
+    image: ollama/ollama:${OLLAMA_IMAGE_TAG:?set OLLAMA_IMAGE_TAG in .env}
     profiles:
       - setup
     volumes:
@@ -172,7 +167,7 @@ services:
         echo 'Pulling gemma3:4b model (recommended starter model)...' &&
         ollama pull gemma3:4b &&
         echo 'Model setup complete! You can now use gemma3:4b in TradingGoose.' &&
-        echo 'To add more models, run: docker compose -f docker-compose.ollama.yml exec ollama ollama pull <model-name>'
+        echo 'To add more models, run: docker compose -f docker-compose.ollama.yml exec <ollama-service> ollama pull <model-name>'
       "
     restart: 'no'
 

--- a/docker-compose.ollama.yml
+++ b/docker-compose.ollama.yml
@@ -2,8 +2,6 @@ name: tradinggoose-with-ollama
 services:
   redis:
     image: redis:7.2.1-alpine
-    ports:
-      - '6379:6379'
     healthcheck:
       test: ['CMD', 'redis-cli', 'ping']
       interval: 5s
@@ -28,7 +26,8 @@ services:
       - COPILOT_API_KEY=${COPILOT_API_KEY:-}
       - COPILOT_API_URL=${COPILOT_API_URL:-}
       - OLLAMA_URL=http://ollama:11434
-      - NEXT_PUBLIC_SOCKET_URL=${NEXT_PUBLIC_SOCKET_URL:-}
+      - NEXT_PUBLIC_SOCKET_URL=${NEXT_PUBLIC_SOCKET_URL:-http://realtime:3002}
+      - API_ENCRYPTION_KEY=${API_ENCRYPTION_KEY:-}
     depends_on:
       redis:
         condition: service_healthy

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,25 +1,34 @@
 services:
+  redis:
+    image: redis:7.2.1-alpine
+    ports:
+      - '6379:6379'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 3s
+      retries: 5
   tradinggoose:
-    image: ghcr.io/tradinggoose/tradinggoose:latest
+    image: ghcr.io/tradinggoose/tradinggoose:${IMAGE_TAG:?set IMAGE_TAG in .env}
     restart: unless-stopped
     ports:
       - '3000:3000'
-    deploy:
-      resources:
-        limits:
-          memory: 8G
     environment:
       - NODE_ENV=production
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-tradinggoose}
-      - BETTER_AUTH_URL=${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
-      - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
-      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:-your_auth_secret_here}
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-your_encryption_key_here}
-      - COPILOT_API_KEY=${COPILOT_API_KEY}
-      - COPILOT_API_URL=${COPILOT_API_URL}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:?set POSTGRES_USER in .env}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@db:5432/${POSTGRES_DB:-tradinggoose}
+      - BETTER_AUTH_URL=${NEXT_PUBLIC_APP_URL:?set NEXT_PUBLIC_APP_URL in .env}
+      - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL:?set NEXT_PUBLIC_APP_URL in .env}
+      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:?set BETTER_AUTH_SECRET in .env}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?set ENCRYPTION_KEY in .env}
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:?set INTERNAL_API_SECRET in .env}
+      - REDIS_URL=redis://redis:6379
+      - COPILOT_API_KEY=${COPILOT_API_KEY:-}
+      - COPILOT_API_URL=${COPILOT_API_URL:-}
       - OLLAMA_URL=${OLLAMA_URL:-http://localhost:11434}
       - NEXT_PUBLIC_SOCKET_URL=${NEXT_PUBLIC_SOCKET_URL:-}
     depends_on:
+      redis:
+        condition: service_healthy
       db:
         condition: service_healthy
       migrations:
@@ -34,20 +43,22 @@ services:
       start_period: 10s
 
   realtime:
-    image: ghcr.io/tradinggoose/realtime:latest
+    image: ghcr.io/tradinggoose/realtime:${IMAGE_TAG:?set IMAGE_TAG in .env}
     restart: unless-stopped
     ports:
       - '3002:3002'
-    deploy:
-      resources:
-        limits:
-          memory: 4G
     environment:
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-tradinggoose}
-      - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
-      - BETTER_AUTH_URL=${BETTER_AUTH_URL:-http://localhost:3000}
-      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:-your_auth_secret_here}
+      - NODE_ENV=production
+      - DATABASE_URL=postgresql://${POSTGRES_USER:?set POSTGRES_USER in .env}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@db:5432/${POSTGRES_DB:-tradinggoose}
+      - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL:?set NEXT_PUBLIC_APP_URL in .env}
+      - BETTER_AUTH_URL=${NEXT_PUBLIC_APP_URL:?set NEXT_PUBLIC_APP_URL in .env}
+      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:?set BETTER_AUTH_SECRET in .env}
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:?set INTERNAL_API_SECRET in .env}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?set ENCRYPTION_KEY in .env}
+      - REDIS_URL=redis://redis:6379
     depends_on:
+      redis:
+        condition: service_healthy
       db:
         condition: service_healthy
     healthcheck:
@@ -58,10 +69,10 @@ services:
       start_period: 10s
 
   migrations:
-    image: ghcr.io/tradinggoose/migrations:latest
+    image: ghcr.io/tradinggoose/migrations:${IMAGE_TAG:?set IMAGE_TAG in .env}
     working_dir: /app/packages/db
     environment:
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-tradinggoose}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:?set POSTGRES_USER in .env}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@db:5432/${POSTGRES_DB:-tradinggoose}
     depends_on:
       db:
         condition: service_healthy
@@ -71,16 +82,14 @@ services:
   db:
     image: pgvector/pgvector:pg17
     restart: unless-stopped
-    ports:
-      - '${POSTGRES_PORT:-5432}:5432'
     environment:
-      - POSTGRES_USER=${POSTGRES_USER:-postgres}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+      - POSTGRES_USER=${POSTGRES_USER:?set POSTGRES_USER in .env}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
       - POSTGRES_DB=${POSTGRES_DB:-tradinggoose}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:?set POSTGRES_USER in .env}']
       interval: 5s
       timeout: 5s
       retries: 5

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,8 +1,6 @@
 services:
   redis:
     image: redis:7.2.1-alpine
-    ports:
-      - '6379:6379'
     healthcheck:
       test: ['CMD', 'redis-cli', 'ping']
       interval: 5s
@@ -25,7 +23,8 @@ services:
       - COPILOT_API_KEY=${COPILOT_API_KEY:-}
       - COPILOT_API_URL=${COPILOT_API_URL:-}
       - OLLAMA_URL=${OLLAMA_URL:-http://localhost:11434}
-      - NEXT_PUBLIC_SOCKET_URL=${NEXT_PUBLIC_SOCKET_URL:-}
+      - NEXT_PUBLIC_SOCKET_URL=${NEXT_PUBLIC_SOCKET_URL:-http://realtime:3002}
+      - API_ENCRYPTION_KEY=${API_ENCRYPTION_KEY:-}
     depends_on:
       redis:
         condition: service_healthy

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -58,7 +58,7 @@ RUN bun run build
 # ========================================
 FROM base AS guardrails
 RUN apk add --no-cache python3 py3-pip bash
-WORKDIR /tmp/guardrails
+WORKDIR /app/lib/guardrails
 
 COPY apps/tradinggoose/lib/guardrails/setup.sh ./setup.sh
 COPY apps/tradinggoose/lib/guardrails/requirements.txt ./requirements.txt

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -1,7 +1,7 @@
 # ========================================
 # Base Stage: Alpine Linux with Bun
 # ========================================
-FROM oven/bun:1.2.22-alpine AS base
+FROM oven/bun:1.3.11-alpine AS base
 
 # ========================================
 # Dependencies Stage: Install Dependencies
@@ -9,9 +9,6 @@ FROM oven/bun:1.2.22-alpine AS base
 FROM base AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
-
-# Install turbo globally
-RUN bun install -g turbo
 
 COPY package.json bun.lock ./
 RUN mkdir -p apps
@@ -26,7 +23,7 @@ FROM base AS builder
 WORKDIR /app
 
 # Install turbo globally in builder stage
-RUN bun install -g turbo
+RUN bun install -g turbo@2.5.8
 
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
@@ -36,7 +33,7 @@ RUN bun install --omit dev --ignore-scripts
 
 # Required for standalone nextjs build
 WORKDIR /app/apps/tradinggoose
-RUN bun install sharp
+RUN bun install sharp@0.34.3
 
 ENV NEXT_TELEMETRY_DISABLED=1 \
     VERCEL_TELEMETRY_DISABLED=1 \
@@ -57,14 +54,27 @@ ENV NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL}
 RUN bun run build
 
 # ========================================
+# Guardrails Stage: Build Presidio runtime
+# ========================================
+FROM base AS guardrails
+RUN apk add --no-cache python3 py3-pip bash
+WORKDIR /tmp/guardrails
+
+COPY apps/tradinggoose/lib/guardrails/setup.sh ./setup.sh
+COPY apps/tradinggoose/lib/guardrails/requirements.txt ./requirements.txt
+COPY apps/tradinggoose/lib/guardrails/validate_pii.py ./validate_pii.py
+
+RUN chmod +x ./setup.sh && ./setup.sh
+
+# ========================================
 # Runner Stage: Run the actual app
 # ========================================
 
 FROM base AS runner
 WORKDIR /app
 
-# Install Python and dependencies for guardrails PII detection
-RUN apk add --no-cache python3 py3-pip bash
+# Install Python runtime for guardrails PII detection
+RUN apk add --no-cache python3
 
 ENV NODE_ENV=production
 
@@ -75,17 +85,14 @@ RUN addgroup -g 1001 -S nodejs && \
 COPY --from=builder --chown=nextjs:nodejs /app/apps/tradinggoose/public ./apps/tradinggoose/public
 COPY --from=builder --chown=nextjs:nodejs /app/apps/tradinggoose/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/apps/tradinggoose/.next/static ./apps/tradinggoose/.next/static
+# Preserve Bun's production dependency trees so yjs can resolve lib0 through the
+# workspace symlink layout inside the runtime image.
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
+COPY --from=builder --chown=nextjs:nodejs /app/apps/tradinggoose/node_modules ./apps/tradinggoose/node_modules
 
-# Guardrails setup (files need to be owned by nextjs for runtime)
-COPY --from=builder --chown=nextjs:nodejs /app/apps/tradinggoose/lib/guardrails/setup.sh ./apps/tradinggoose/lib/guardrails/setup.sh
-COPY --from=builder --chown=nextjs:nodejs /app/apps/tradinggoose/lib/guardrails/requirements.txt ./apps/tradinggoose/lib/guardrails/requirements.txt
-COPY --from=builder --chown=nextjs:nodejs /app/apps/tradinggoose/lib/guardrails/validate_pii.py ./apps/tradinggoose/lib/guardrails/validate_pii.py
-
-# Run guardrails setup as root, then fix ownership of generated venv files
-RUN chmod +x ./apps/tradinggoose/lib/guardrails/setup.sh && \
-    cd ./apps/tradinggoose/lib/guardrails && \
-    ./setup.sh && \
-    chown -R nextjs:nodejs /app/apps/tradinggoose/lib/guardrails
+# Guardrails runtime assets
+COPY --from=guardrails --chown=nextjs:nodejs /tmp/guardrails/venv ./lib/guardrails/venv
+COPY --from=guardrails --chown=nextjs:nodejs /tmp/guardrails/validate_pii.py ./lib/guardrails/validate_pii.py
 
 # Create .next/cache directory with correct ownership
 RUN mkdir -p apps/tradinggoose/.next/cache && \

--- a/docker/db.Dockerfile
+++ b/docker/db.Dockerfile
@@ -1,11 +1,11 @@
 # ========================================
 # Dependencies Stage: Install Dependencies
 # ========================================
-FROM oven/bun:1.2.22-alpine AS deps
+FROM oven/bun:1.3.11-alpine AS deps
 WORKDIR /app
 
 # Copy only package files needed for migrations
-COPY package.json bun.lock turbo.json ./
+COPY package.json bun.lock ./
 COPY packages/db/package.json ./packages/db/package.json
 
 # Install dependencies
@@ -14,17 +14,21 @@ RUN bun install --ignore-scripts
 # ========================================
 # Runner Stage: Production Environment
 # ========================================
-FROM oven/bun:1.2.22-alpine AS runner
+FROM oven/bun:1.3.11-alpine AS runner
 WORKDIR /app
 
 # Create non-root user and group
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S nextjs -u 1001
 
-# Copy only the necessary files from deps
+# Copy only the migration inputs and runtime files from the db package
 COPY --from=deps --chown=nextjs:nodejs /app/node_modules ./node_modules
+COPY --chown=nextjs:nodejs packages/db/package.json ./packages/db/package.json
 COPY --chown=nextjs:nodejs packages/db/drizzle.config.ts ./packages/db/drizzle.config.ts
-COPY --chown=nextjs:nodejs packages/db ./packages/db
+COPY --chown=nextjs:nodejs packages/db/schema.ts ./packages/db/schema.ts
+COPY --chown=nextjs:nodejs packages/db/consts.ts ./packages/db/consts.ts
+COPY --chown=nextjs:nodejs packages/db/schema ./packages/db/schema
+COPY --chown=nextjs:nodejs packages/db/migrations ./packages/db/migrations
 
 # Switch to non-root user
 USER nextjs

--- a/docker/realtime.Dockerfile
+++ b/docker/realtime.Dockerfile
@@ -1,7 +1,7 @@
 # ========================================
 # Base Stage: Alpine Linux with Bun
 # ========================================
-FROM oven/bun:1.2.22-alpine AS base
+FROM oven/bun:1.3.11-alpine AS base
 
 # ========================================
 # Dependencies Stage: Install Dependencies
@@ -9,9 +9,6 @@ FROM oven/bun:1.2.22-alpine AS base
 FROM base AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
-
-# Install turbo globally
-RUN bun install -g turbo
 
 COPY package.json bun.lock ./
 RUN mkdir -p apps
@@ -28,11 +25,16 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
+RUN bun install --omit dev --ignore-scripts
+
+WORKDIR /app/apps/tradinggoose
+RUN bun build --target bun --outfile /tmp/realtime-build/socket-server.js socket-server/index.ts
+
 # ========================================
 # Runner Stage: Run the Socket Server
 # ========================================
 FROM base AS runner
-WORKDIR /app
+WORKDIR /app/apps/tradinggoose
 
 ENV NODE_ENV=production
 
@@ -40,11 +42,8 @@ ENV NODE_ENV=production
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S nextjs -u 1001
 
-# Copy the tradinggoose app and the shared db package needed by socket-server
-COPY --from=builder --chown=nextjs:nodejs /app/apps/tradinggoose ./apps/tradinggoose
-COPY --from=builder --chown=nextjs:nodejs /app/packages/db ./packages/db
-COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
-COPY --from=builder --chown=nextjs:nodejs /app/package.json ./package.json
+# Copy the bundled socket server runtime artifact only
+COPY --from=builder --chown=nextjs:nodejs /tmp/realtime-build/socket-server.js ./socket-server.js
 
 # Switch to non-root user
 USER nextjs
@@ -55,5 +54,5 @@ ENV PORT=3002 \
     SOCKET_PORT=3002 \
     HOSTNAME="0.0.0.0"
 
-# Run the socket server directly
-CMD ["bun", "apps/tradinggoose/socket-server/index.ts"]
+# Run the bundled socket server directly
+CMD ["bun", "./socket-server.js"]


### PR DESCRIPTION
## Summary
- Modernizes the Docker and Compose flow around pinned Bun images, explicit env contracts, Redis, and tagged image references.
- Shrinks the runtime images by splitting guardrails into a build stage and bundling the realtime socket server into a standalone artifact.
- Updates the image workflow and docs so local, Ollama, and production boot instructions match the new container contract.

## Type of Changes
- Breaking change
- Other: Docker / CI / compose infrastructure
- Documentation

## Why
- The old compose and image flow relied on implicit defaults, generated values, and split build jobs. This branch makes the required runtime inputs explicit and reduces the runtime image surface area.

## Affected Areas
- [x] `apps/tradinggoose`
- [ ] `apps/docs`
- [ ] `packages/*`
- [x] Workflows / execution
- [x] Realtime / sockets
- [ ] Market data / charting
- [x] Dev tooling / CI / infra
- [x] Documentation only
- [x] Other: Docker / compose packaging

No application tests were added or updated; this branch is Docker/compose/docs focused.

## Risk / Rollout Notes
This is a breaking change for existing Docker/Compose users because the stack now requires explicit secrets, Redis, and tag-pinned images before booting.

Rollout should verify the deployment env file includes the new required values and that the registry tags match the images being published.

## Config / Data Changes
Env vars added or changed: POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB, NEXT_PUBLIC_APP_URL, BETTER_AUTH_SECRET, ENCRYPTION_KEY, INTERNAL_API_SECRET, REDIS_URL, IMAGE_TAG, OLLAMA_IMAGE_TAG.

Database schema or migration impact: none.
External services or provider behavior changed: Redis is now part of the compose stacks, Ollama images are tag-pinned, and image publishing now goes through GHCR everywhere with Docker Hub on main.

## Screenshots / Video
Not applicable.

## Checklist
- [x] kept the change focused and reviewed my own diff
- [x] validated the change locally and documented the results above
- [x] updated docs, examples, or copy if behavior/user-facing flows changed
- [x] called out any env, schema, provider, or rollout impact
- [x] did not include secrets, tokens, or private credentials in this PR