### PR TITLE
fix(license): align attribution and Helm metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,7 @@
+TradingGoose Studio
+Copyright 2025-2026 TradingGoose Studio
+Licensed under AGPL-3.0-only. The full license text follows.
+
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 

--- a/apps/tradinggoose/app/(landing)/licenses/page.tsx
+++ b/apps/tradinggoose/app/(landing)/licenses/page.tsx
@@ -26,7 +26,7 @@ export default function LicensesPage() {
           <h2 className='mb-4 font-semibold text-2xl'>Project License</h2>
           <p className='mb-4'>
             The repository-level license for the combined project is AGPL-3.0-only. The root{' '}
-            <code>NOTICE</code> file preserves the TradingGoose Studio attribution required by the upstream
+            <code>NOTICE</code> file preserves the Sim Studio attribution required by the upstream
             Apache-2.0 source on which this project is based.
           </p>
           <p className='mb-4'>
@@ -51,7 +51,7 @@ export default function LicensesPage() {
         <section>
           <h2 className='mb-4 font-semibold text-2xl'>Why AGPL-3.0-only</h2>
           <p className='mb-4'>
-            TradingGoose Studio, the upstream base project, is Apache-2.0 and its required notices remain
+            Sim Studio, the upstream base project, is Apache-2.0 and its required notices remain
             preserved here. The AGPL status of TradingGoose Studio comes from PineTS, which is used
             as an integrated runtime dependency under AGPL terms in this project.
           </p>

--- a/helm/tradinggoose/Chart.yaml
+++ b/helm/tradinggoose/Chart.yaml
@@ -20,4 +20,4 @@ keywords:
   - nextjs
 annotations:
   category: AI/ML Platform
-  licenses: Apache-2.0
+  licenses: AGPL-3.0-only


### PR DESCRIPTION
## Summary
- Added a repository license preamble identifying TradingGoose Studio as AGPL-3.0-only.
- Corrected the licenses page upstream attribution from TradingGoose Studio to Sim Studio.
- Updated the Helm chart license annotation from Apache-2.0 to AGPL-3.0-only.

## Why
This keeps the repository license text, public license page copy, and Helm chart metadata aligned with the project’s AGPL-3.0-only status while preserving the correct upstream attribution.

## Affected Areas
- [x] `apps/tradinggoose`
- [ ] `apps/docs`
- [ ] `packages/*`
- [ ] Workflows / execution
- [ ] Realtime / sockets
- [ ] Market data / charting
- [x] Dev tooling / CI / infra
- [ ] Documentation only
- [x] Other: License and attribution metadata

## Issue Links( if any )
None.

## Validation
```bash
git diff --check origin/staging...HEAD
# Passed: no output.

bunx biome check --files-ignore-unknown=true LICENSE 'apps/tradinggoose/app/(landing)/licenses/page.tsx' helm/tradinggoose/Chart.yaml
# Passed: checked 1 supported file. No fixes applied.

bun run lint:helm
# Failed locally: helm is not installed in this environment.
```

## Risk / Rollout Notes
Low runtime risk. This change is limited to license text, public license page copy, and Helm chart metadata. No rollout sequencing is required. Backout is reverting this PR.

## Config / Data Changes
- Env vars added or changed: None
- Database schema or migration impact: None
- External services or provider behavior changed: None

## Screenshots / Video
Not included; the only visible UI change is copy wording on the licenses page.

## Checklist
- [x] I kept the change focused and reviewed my own diff
- [x] I validated the change locally and documented the results above
- [x] I updated docs, examples, or copy if behavior/user-facing flows changed
- [x] I called out any env, schema, provider, or rollout impact
- [x] I did not include secrets, tokens, or private credentials in this PR