### PR TITLE
fix(trading): use OAuth connection accounts for broker access

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,7 @@
+TradingGoose Studio
+Copyright 2025-2026 TradingGoose Studio
+Licensed under AGPL-3.0-only. The full license text follows.
+
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 

--- a/apps/tradinggoose/app/(landing)/licenses/page.tsx
+++ b/apps/tradinggoose/app/(landing)/licenses/page.tsx
@@ -26,7 +26,7 @@ export default function LicensesPage() {
           <h2 className='mb-4 font-semibold text-2xl'>Project License</h2>
           <p className='mb-4'>
             The repository-level license for the combined project is AGPL-3.0-only. The root{' '}
-            <code>NOTICE</code> file preserves the TradingGoose Studio attribution required by the upstream
+            <code>NOTICE</code> file preserves the Sim Studio attribution required by the upstream
             Apache-2.0 source on which this project is based.
           </p>
           <p className='mb-4'>
@@ -51,7 +51,7 @@ export default function LicensesPage() {
         <section>
           <h2 className='mb-4 font-semibold text-2xl'>Why AGPL-3.0-only</h2>
           <p className='mb-4'>
-            TradingGoose Studio, the upstream base project, is Apache-2.0 and its required notices remain
+            Sim Studio, the upstream base project, is Apache-2.0 and its required notices remain
             preserved here. The AGPL status of TradingGoose Studio comes from PineTS, which is used
             as an integrated runtime dependency under AGPL terms in this project.
           </p>

--- a/apps/tradinggoose/app/api/orders/[orderId]/provider-detail/route.test.ts
+++ b/apps/tradinggoose/app/api/orders/[orderId]/provider-detail/route.test.ts
@@ -174,10 +174,8 @@ describe('order provider detail route', () => {
     expect(mocks.eq).toHaveBeenCalledWith('orderHistoryTable.id', 'order-1')
     expect(mocks.eq).toHaveBeenCalledWith('orderHistoryTable.workspaceId', 'workspace-1')
     expect(authorizeTradingCredentialRequest).toHaveBeenCalledWith({
-      request: expect.any(NextRequest),
       credentialId: 'credential-1',
-      workspaceId: 'workspace-1',
-      workflowId: undefined,
+      userId: 'user-1',
     })
     expect(resolveTradingProviderContext).toHaveBeenCalledWith({
       requestData: {

--- a/apps/tradinggoose/app/api/orders/[orderId]/provider-detail/route.test.ts
+++ b/apps/tradinggoose/app/api/orders/[orderId]/provider-detail/route.test.ts
@@ -5,7 +5,7 @@
 import { NextRequest } from 'next/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
-  authorizeTradingCredentialRequest,
+  authorizeTradingConnectionRequest,
   resolveTradingProviderContext,
 } from '@/lib/trading/context'
 import { executeTradingProviderOrderDetailRequest } from '@/providers/trading'
@@ -87,7 +87,7 @@ vi.mock('drizzle-orm', () => ({
 }))
 
 vi.mock('@/lib/trading/context', () => ({
-  authorizeTradingCredentialRequest: vi.fn(),
+  authorizeTradingConnectionRequest: vi.fn(),
   logTradingBrokerRequestFailure: vi.fn(),
   resolveTradingProviderContext: vi.fn(),
 }))
@@ -123,7 +123,7 @@ const orderRow = {
   listingIdentity: { listing_type: 'stock', listing_id: 'AAPL' },
   request: {
     accountId: 'account-1',
-    credentialId: 'credential-1',
+    tokenAccountId: 'oauth-account-1',
     serviceId: 'alpaca-paper',
     side: 'buy',
   },
@@ -138,9 +138,8 @@ describe('order provider detail route', () => {
     mocks.resultsQueue.length = 0
     mocks.checkAuth.mockResolvedValue({ success: true, userId: 'user-1' })
     mocks.checkWorkspaceAccess.mockResolvedValue({ exists: true, hasAccess: true })
-    vi.mocked(authorizeTradingCredentialRequest).mockResolvedValue({
-      credentialOwnerUserId: 'credential-owner-1',
-      tokenAccountId: 'account-credential-1',
+    vi.mocked(authorizeTradingConnectionRequest).mockResolvedValue({
+      connectionOwnerUserId: 'connection-owner-1',
       accountProviderId: 'alpaca-paper',
     })
     vi.mocked(resolveTradingProviderContext).mockResolvedValue({
@@ -173,20 +172,19 @@ describe('order provider detail route', () => {
     expect(mocks.checkWorkspaceAccess).toHaveBeenCalledWith('workspace-1', 'user-1')
     expect(mocks.eq).toHaveBeenCalledWith('orderHistoryTable.id', 'order-1')
     expect(mocks.eq).toHaveBeenCalledWith('orderHistoryTable.workspaceId', 'workspace-1')
-    expect(authorizeTradingCredentialRequest).toHaveBeenCalledWith({
-      credentialId: 'credential-1',
+    expect(authorizeTradingConnectionRequest).toHaveBeenCalledWith({
+      tokenAccountId: 'oauth-account-1',
       userId: 'user-1',
     })
     expect(resolveTradingProviderContext).toHaveBeenCalledWith({
       requestData: {
-        credentialId: 'credential-1',
+        tokenAccountId: 'oauth-account-1',
         serviceId: 'alpaca-paper',
         provider: 'alpaca',
       },
       requestId: 'request-1',
       userId: 'user-1',
-      credentialOwnerUserId: 'credential-owner-1',
-      tokenAccountId: 'account-credential-1',
+      connectionOwnerUserId: 'connection-owner-1',
       accountProviderId: 'alpaca-paper',
     })
     expect(executeTradingProviderOrderDetailRequest).toHaveBeenCalledWith(
@@ -216,7 +214,7 @@ describe('order provider detail route', () => {
     })
   })
 
-  it('rejects provider-detail refresh when the order record has no credential context', async () => {
+  it('rejects provider-detail refresh when the order record has no connection context', async () => {
     mocks.resultsQueue.push([{ ...orderRow, request: { accountId: 'account-1' } }])
     const { POST } = await import('./route')
 
@@ -230,7 +228,7 @@ describe('order provider detail route', () => {
 
     expect(response.status).toBe(400)
     await expect(response.json()).resolves.toEqual({
-      error: 'Order history record is missing trading credential context',
+      error: 'Order history record is missing trading connection context',
     })
     expect(resolveTradingProviderContext).not.toHaveBeenCalled()
   })

--- a/apps/tradinggoose/app/api/orders/[orderId]/provider-detail/route.ts
+++ b/apps/tradinggoose/app/api/orders/[orderId]/provider-detail/route.ts
@@ -26,16 +26,12 @@ export async function POST(
     if (!workspaceId) {
       return NextResponse.json({ error: 'workspaceId is required' }, { status: 400 })
     }
-    const workflowId = new URL(request.url).searchParams.get('workflowId')?.trim() || undefined
-
     const { orderId } = await params
     const providerDetail = await getRecordedTradingOrderProviderDetail({
       orderId,
-      request,
       requestId,
       userId: auth.userId,
       workspaceId,
-      workflowId,
     })
 
     return NextResponse.json({ data: providerDetail })

--- a/apps/tradinggoose/app/api/providers/trading/order/route.test.ts
+++ b/apps/tradinggoose/app/api/providers/trading/order/route.test.ts
@@ -11,7 +11,7 @@ const mockGetSession = vi.fn()
 const mockRefreshAccessTokenIfNeeded = vi.fn()
 const mockListPortfolioIdentities = vi.fn()
 const mockCheckWorkspaceAccess = vi.fn()
-const mockAuthorizeCredentialUse = vi.fn()
+const mockResolveOAuthConnectionAccountForUser = vi.fn()
 const mockResolveOrderHistoryContext = vi.fn()
 const mockRecordOrderHistory = vi.fn()
 const mockUpdateOrderHistoryResult = vi.fn()
@@ -36,8 +36,8 @@ vi.mock('@/lib/oauth/tokens', () => ({
   refreshAccessTokenIfNeeded: mockRefreshAccessTokenIfNeeded,
 }))
 
-vi.mock('@/lib/auth/credential-access', () => ({
-  authorizeCredentialUse: mockAuthorizeCredentialUse,
+vi.mock('@/lib/credentials/oauth', () => ({
+  resolveOAuthConnectionAccountForUser: mockResolveOAuthConnectionAccountForUser,
 }))
 
 vi.mock('@/lib/permissions/utils', () => ({
@@ -153,15 +153,12 @@ describe('Trading provider order route', () => {
     idempotencyCounter = 0
     vi.stubGlobal('fetch', mockFetch)
     mockGetSession.mockResolvedValue({ user: { id: 'user-1' } })
-    mockAuthorizeCredentialUse.mockImplementation(
-      (_request: unknown, { credentialId }: { credentialId: string }) =>
+    mockResolveOAuthConnectionAccountForUser.mockImplementation(
+      ({ accountId }: { accountId: string }) =>
         Promise.resolve({
-          ok: true,
-          authType: 'session',
-          requesterUserId: 'user-1',
           credentialOwnerUserId: 'user-1',
-          resolvedTokenAccountId: 'account-credential-1',
-          resolvedProviderId: credentialId.startsWith('tradier') ? 'tradier-live' : 'alpaca-live',
+          tokenAccountId: 'account-credential-1',
+          providerId: accountId.startsWith('tradier') ? 'tradier-live' : 'alpaca-live',
         })
     )
     mockRefreshAccessTokenIfNeeded.mockResolvedValue('access-token')
@@ -229,29 +226,25 @@ describe('Trading provider order route', () => {
     expect(mockFetch).not.toHaveBeenCalled()
   })
 
-  it('authorizes the selected portfolio credential before token lookup', async () => {
-    mockAuthorizeCredentialUse.mockResolvedValue({
-      ok: false,
-      error: 'Unauthorized',
-    })
+  it('requires the selected portfolio connection before token lookup', async () => {
+    mockResolveOAuthConnectionAccountForUser.mockResolvedValue(null)
 
     const { POST } = await import('@/app/api/providers/trading/order/route')
     const response = await POST(createProviderOrderRequest('tradier'))
 
-    expect(response.status).toBe(403)
-    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' })
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Trading provider connection not found',
+    })
     expect(mockRefreshAccessTokenIfNeeded).not.toHaveBeenCalled()
     expectNoAccountDiscoveryOrBrokerCall()
   })
 
   it('rejects portfolio identities whose credential service does not match the requested service', async () => {
-    mockAuthorizeCredentialUse.mockResolvedValueOnce({
-      ok: true,
-      authType: 'session',
-      requesterUserId: 'user-1',
+    mockResolveOAuthConnectionAccountForUser.mockResolvedValueOnce({
       credentialOwnerUserId: 'user-1',
-      resolvedTokenAccountId: 'account-credential-1',
-      resolvedProviderId: 'alpaca-live',
+      tokenAccountId: 'account-credential-1',
+      providerId: 'alpaca-live',
     })
 
     const { POST } = await import('@/app/api/providers/trading/order/route')

--- a/apps/tradinggoose/app/api/providers/trading/order/route.test.ts
+++ b/apps/tradinggoose/app/api/providers/trading/order/route.test.ts
@@ -98,7 +98,7 @@ const workspaceId = 'workspace-1'
 
 const portfolioIdentityFor = (providerId: 'alpaca' | 'tradier', accountId = 'ACC-1') => ({
   providerId,
-  credentialId: `${providerId}-credential-1`,
+  tokenAccountId: `${providerId}-oauth-account-1`,
   serviceId: `${providerId}-live`,
   accountId,
 })
@@ -157,7 +157,7 @@ describe('Trading provider order route', () => {
       ({ accountId }: { accountId: string }) =>
         Promise.resolve({
           credentialOwnerUserId: 'user-1',
-          tokenAccountId: 'account-credential-1',
+          tokenAccountId: accountId,
           providerId: accountId.startsWith('tradier') ? 'tradier-live' : 'alpaca-live',
         })
     )
@@ -177,7 +177,7 @@ describe('Trading provider order route', () => {
     mockListPortfolioIdentities.mockResolvedValue([
       {
         providerId: 'alpaca',
-        credentialId: 'alpaca-credential-1',
+        tokenAccountId: 'alpaca-oauth-account-1',
         serviceId: 'alpaca-live',
         accountId: 'ACC-1',
         accountName: 'Main',
@@ -187,7 +187,7 @@ describe('Trading provider order route', () => {
       },
       {
         providerId: 'tradier',
-        credentialId: 'tradier-credential-1',
+        tokenAccountId: 'tradier-oauth-account-1',
         serviceId: 'tradier-live',
         accountId: 'ACC-1',
         accountName: 'Main',
@@ -240,10 +240,10 @@ describe('Trading provider order route', () => {
     expectNoAccountDiscoveryOrBrokerCall()
   })
 
-  it('rejects portfolio identities whose credential service does not match the requested service', async () => {
+  it('rejects portfolio identities whose connection service does not match the requested service', async () => {
     mockResolveOAuthConnectionAccountForUser.mockResolvedValueOnce({
       credentialOwnerUserId: 'user-1',
-      tokenAccountId: 'account-credential-1',
+      tokenAccountId: 'tradier-oauth-account-1',
       providerId: 'alpaca-live',
     })
 
@@ -522,7 +522,7 @@ describe('Trading provider order route', () => {
     mockListPortfolioIdentities.mockResolvedValue([
       {
         providerId: 'tradier',
-        credentialId: 'tradier-credential-1',
+        tokenAccountId: 'tradier-oauth-account-1',
         serviceId: 'tradier-live',
         accountId: 'ACC-2',
       },
@@ -609,7 +609,7 @@ describe('Trading provider order route', () => {
     })
     expect(mockFetch).toHaveBeenCalledTimes(1)
     expect(mockRefreshAccessTokenIfNeeded).toHaveBeenCalledWith(
-      'account-credential-1',
+      'alpaca-oauth-account-1',
       'user-1',
       expect.any(String)
     )
@@ -622,7 +622,7 @@ describe('Trading provider order route', () => {
         request: expect.objectContaining({
           accountId: 'ACC-1',
           clientOrderId,
-          credentialId: 'alpaca-credential-1',
+          tokenAccountId: 'alpaca-oauth-account-1',
           serviceId: 'alpaca-live',
           orderType: 'market',
           quantity: 3,
@@ -771,7 +771,7 @@ describe('Trading provider order route', () => {
         request: expect.objectContaining({
           accountId: 'ACC-1',
           clientOrderId,
-          credentialId: 'tradier-credential-1',
+          tokenAccountId: 'tradier-oauth-account-1',
           serviceId: 'tradier-live',
           quantity: 3,
           side: 'buy',

--- a/apps/tradinggoose/app/api/providers/trading/order/route.ts
+++ b/apps/tradinggoose/app/api/providers/trading/order/route.ts
@@ -92,7 +92,6 @@ export async function POST(request: NextRequest) {
         : { ...requestData, ...(workflowId ? { workflowId } : {}) }
 
     const response = await submitTradingOrder({
-      request,
       requestData: submitRequestData,
       requestId,
       userId: auth.userId,

--- a/apps/tradinggoose/app/api/providers/trading/order/route.ts
+++ b/apps/tradinggoose/app/api/providers/trading/order/route.ts
@@ -21,7 +21,7 @@ const orderListingSchema = z
 const portfolioIdentitySchema = z
   .object({
     providerId: nonEmptyStringSchema,
-    credentialId: nonEmptyStringSchema,
+    tokenAccountId: nonEmptyStringSchema,
     serviceId: nonEmptyStringSchema,
     accountId: nonEmptyStringSchema,
   })

--- a/apps/tradinggoose/app/api/providers/trading/portfolio-identities/route.test.ts
+++ b/apps/tradinggoose/app/api/providers/trading/portfolio-identities/route.test.ts
@@ -66,7 +66,7 @@ describe('trading portfolio identities route', () => {
       {
         providerId: 'alpaca',
         providerName: 'Alpaca',
-        credentialId: 'credential-1',
+        tokenAccountId: 'oauth-account-1',
         serviceId: 'alpaca-live',
         accountId: 'account-1',
         accountName: 'Main',
@@ -94,7 +94,7 @@ describe('trading portfolio identities route', () => {
           label: 'Main',
           rightLabel: 'Alpaca Live - cash - active - USD',
           value: {
-            credentialId: 'credential-1',
+            tokenAccountId: 'oauth-account-1',
             accountId: 'account-1',
           },
         },

--- a/apps/tradinggoose/app/api/providers/trading/portfolio-identities/route.test.ts
+++ b/apps/tradinggoose/app/api/providers/trading/portfolio-identities/route.test.ts
@@ -5,18 +5,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
-  checkWorkspaceAccess: vi.fn(),
   getSession: vi.fn(),
-  verifyWorkflowAccess: vi.fn(),
   listPortfolioIdentities: vi.fn(),
 }))
 
 vi.mock('@/lib/auth', () => ({
   getSession: (...args: unknown[]) => mocks.getSession(...args),
-}))
-
-vi.mock('@/lib/copilot/review-sessions/permissions', () => ({
-  verifyWorkflowAccess: (...args: unknown[]) => mocks.verifyWorkflowAccess(...args),
 }))
 
 vi.mock('@/lib/logs/console/logger', () => ({
@@ -29,13 +23,8 @@ vi.mock('@/lib/oauth', () => ({
   })),
 }))
 
-vi.mock('@/lib/permissions/utils', () => ({
-  checkWorkspaceAccess: (...args: unknown[]) => mocks.checkWorkspaceAccess(...args),
-}))
-
 vi.mock('@/lib/trading/portfolio-identities', () => ({
-  listTradingPortfolioIdentities: (...args: unknown[]) =>
-    mocks.listPortfolioIdentities(...args),
+  listTradingPortfolioIdentities: (...args: unknown[]) => mocks.listPortfolioIdentities(...args),
 }))
 
 vi.mock('@/lib/utils', () => ({
@@ -58,8 +47,6 @@ describe('trading portfolio identities route', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.getSession.mockResolvedValue({ user: { id: 'user-1' } })
-    mocks.checkWorkspaceAccess.mockResolvedValue({ hasAccess: true })
-    mocks.verifyWorkflowAccess.mockResolvedValue({ hasAccess: true, workspaceId: 'workspace-1' })
   })
 
   it('returns a load failure instead of an empty account list when account loading fails', async () => {
@@ -67,9 +54,7 @@ describe('trading portfolio identities route', () => {
     const { GET } = await import('./route')
 
     const response = await GET(
-      new Request(
-        'http://localhost/api/providers/trading/portfolio-identities?provider=alpaca&workspaceId=workspace-1'
-      )
+      new Request('http://localhost/api/providers/trading/portfolio-identities?provider=alpaca')
     )
 
     expect(response.status).toBe(502)
@@ -93,12 +78,16 @@ describe('trading portfolio identities route', () => {
     const { GET } = await import('./route')
 
     const response = await GET(
-      new Request(
-        'http://localhost/api/providers/trading/portfolio-identities?provider=alpaca&workspaceId=workspace-1'
-      )
+      new Request('http://localhost/api/providers/trading/portfolio-identities?provider=alpaca')
     )
 
     expect(response.status).toBe(200)
+    expect(mocks.listPortfolioIdentities).toHaveBeenCalledWith({
+      userId: 'user-1',
+      providerId: 'alpaca',
+      serviceId: undefined,
+      requestId: 'request-1',
+    })
     await expect(response.json()).resolves.toMatchObject({
       options: [
         {

--- a/apps/tradinggoose/app/api/providers/trading/portfolio-identities/route.ts
+++ b/apps/tradinggoose/app/api/providers/trading/portfolio-identities/route.ts
@@ -1,9 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getSession } from '@/lib/auth'
-import { verifyWorkflowAccess } from '@/lib/copilot/review-sessions/permissions'
 import { createLogger } from '@/lib/logs/console/logger'
 import { getServiceByProviderAndId } from '@/lib/oauth'
-import { checkWorkspaceAccess } from '@/lib/permissions/utils'
 import { listTradingPortfolioIdentities } from '@/lib/trading/portfolio-identities'
 import { generateRequestId } from '@/lib/utils'
 import {
@@ -39,8 +37,6 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
   const providerId = searchParams.get('provider')?.trim() as TradingProviderId | undefined
   const serviceId = searchParams.get('serviceId')?.trim() || undefined
-  const workspaceId = searchParams.get('workspaceId')?.trim() || undefined
-  const workflowId = searchParams.get('workflowId')?.trim() || undefined
 
   if (!providerId) {
     return NextResponse.json({ error: 'provider is required' }, { status: 400 })
@@ -49,22 +45,6 @@ export async function GET(request: Request) {
   const session = await getSession()
   if (!session?.user?.id) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-  let effectiveWorkspaceId = workspaceId
-  if (workflowId) {
-    const access = await verifyWorkflowAccess(session.user.id, workflowId, 'read')
-    if (!access.hasAccess || !access.workspaceId) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
-    effectiveWorkspaceId = access.workspaceId
-  } else {
-    if (!effectiveWorkspaceId) {
-      return NextResponse.json({ error: 'workspaceId is required' }, { status: 400 })
-    }
-    const access = await checkWorkspaceAccess(effectiveWorkspaceId, session.user.id)
-    if (!access.hasAccess) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
   }
 
   const provider = getTradingProviderDefinition(providerId)
@@ -76,7 +56,6 @@ export async function GET(request: Request) {
   try {
     portfolioIdentities = await listTradingPortfolioIdentities({
       userId: session.user.id,
-      workspaceId: effectiveWorkspaceId,
       providerId,
       serviceId,
       requestId,

--- a/apps/tradinggoose/app/api/tools/trading/holdings/route.ts
+++ b/apps/tradinggoose/app/api/tools/trading/holdings/route.ts
@@ -49,8 +49,7 @@ export async function POST(request: NextRequest) {
     }
 
     const holdings = await getTradingHoldings({
-      request,
-      requestData: { ...body, workflowId, workspaceId },
+      requestData: body,
       requestId,
       userId: auth.userId,
     })

--- a/apps/tradinggoose/app/api/tools/trading/order-history/route.test.ts
+++ b/apps/tradinggoose/app/api/tools/trading/order-history/route.test.ts
@@ -82,7 +82,7 @@ describe('order history support route', () => {
         listingIdentity: { listing_id: 'AAPL', listing_type: 'stock' },
         request: {
           accountId: 'account-1',
-          credentialId: 'credential-1',
+          tokenAccountId: 'oauth-account-1',
           serviceId: 'alpaca-paper',
           quantity: 1,
           side: 'buy',
@@ -107,7 +107,7 @@ describe('order history support route', () => {
         history: [
           expect.not.objectContaining({
             accountId: 'account-1',
-            credentialId: 'credential-1',
+            tokenAccountId: 'oauth-account-1',
             serviceId: 'alpaca-paper',
           }),
         ],

--- a/apps/tradinggoose/blocks/blocks/trading_order_contracts.test.ts
+++ b/apps/tradinggoose/blocks/blocks/trading_order_contracts.test.ts
@@ -81,7 +81,7 @@ describe('trading order block contracts', () => {
     const params = TradingActionBlock.tools.config!.params!({
       portfolioIdentity: {
         providerId: 'tradier',
-        credentialId: 'credential-1',
+        tokenAccountId: 'oauth-account-1',
         serviceId: 'tradier-live',
         accountId: 'ACC-1',
       },

--- a/apps/tradinggoose/blocks/utils.ts
+++ b/apps/tradinggoose/blocks/utils.ts
@@ -88,7 +88,6 @@ export const fetchTradingPortfolioIdentityOptions = async (
   if (!provider) return []
 
   const params = new URLSearchParams({ provider })
-  if (context.workflowId) params.set('workflowId', context.workflowId)
 
   const response = await fetch(`/api/providers/trading/portfolio-identities?${params}`, {
     cache: 'no-store',

--- a/apps/tradinggoose/hooks/queries/oauth-connections.ts
+++ b/apps/tradinggoose/hooks/queries/oauth-connections.ts
@@ -75,10 +75,11 @@ async function fetchOAuthConnections(): Promise<ServiceInfo[]> {
 /**
  * Hook to fetch OAuth connections
  */
-export function useOAuthConnections() {
+export function useOAuthConnections({ enabled = true }: { enabled?: boolean } = {}) {
   return useQuery({
     queryKey: oauthConnectionsKeys.connections(),
     queryFn: fetchOAuthConnections,
+    enabled,
     staleTime: 30 * 1000, // 30 seconds - connections don't change often
     retry: false,
     placeholderData: keepPreviousData, // Show cached data immediately

--- a/apps/tradinggoose/hooks/queries/trading-portfolio.ts
+++ b/apps/tradinggoose/hooks/queries/trading-portfolio.ts
@@ -21,7 +21,6 @@ import type {
 type TradingPortfolioChannel = 'accounts' | 'account-snapshot' | 'portfolio-performance'
 
 type TradingAccountsRequest = {
-  workspaceId?: string
   provider?: string
   serviceId?: string
   refreshKey?: number | string | null
@@ -39,7 +38,6 @@ type TradingPerformanceRequest = TradingSnapshotRequest & {
 type TradingPortfolioSubscribedPayload = {
   provider?: string
   serviceId?: string
-  workspaceId?: string
   channel?: TradingPortfolioChannel
   subscriptionId?: string
   clientSubscriptionId?: string
@@ -80,7 +78,6 @@ type SocketSubscriptionRef = {
   clientSubscriptionId: string
   provider: string
   serviceId?: string
-  workspaceId: string
   channel: TradingPortfolioChannel
   portfolioIdentity?: PortfolioIdentity
 }
@@ -117,7 +114,6 @@ function useTradingPortfolioSocketData<T>({
   channel,
   provider,
   serviceId,
-  workspaceId,
   portfolioIdentity,
   window,
   refreshKey,
@@ -128,7 +124,6 @@ function useTradingPortfolioSocketData<T>({
   channel: TradingPortfolioChannel
   provider?: string
   serviceId?: string
-  workspaceId?: string
   portfolioIdentity?: PortfolioIdentity | null
   window?: TradingPortfolioPerformanceWindow
   refreshKey?: number | string | null
@@ -152,14 +147,12 @@ function useTradingPortfolioSocketData<T>({
 
   const normalizedProvider = provider?.trim()
   const normalizedServiceId = serviceId?.trim()
-  const normalizedWorkspaceId = workspaceId?.trim()
   const normalizedPortfolioIdentity = toPortfolioValueObject(portfolioIdentity)
   const normalizedPortfolioIdentityKey = normalizedPortfolioIdentity
     ? getPortfolioIdentityKey(normalizedPortfolioIdentity)
     : ''
   const requestKey = [
     channel,
-    normalizedWorkspaceId ?? '',
     normalizedProvider ?? '',
     normalizedServiceId ?? '',
     normalizedPortfolioIdentityKey,
@@ -169,7 +162,6 @@ function useTradingPortfolioSocketData<T>({
   const shouldSubscribe =
     enabled &&
     Boolean(normalizedProvider) &&
-    Boolean(normalizedWorkspaceId) &&
     (channel === 'accounts' || Boolean(normalizedPortfolioIdentityKey)) &&
     (channel !== 'portfolio-performance' || Boolean(window))
   const isCurrentRequestResolved = dataState.key === requestKey
@@ -206,7 +198,6 @@ function useTradingPortfolioSocketData<T>({
       clientSubscriptionId,
       provider: normalizedProvider as string,
       serviceId: normalizedServiceId,
-      workspaceId: normalizedWorkspaceId as string,
       channel,
       portfolioIdentity: normalizedPortfolioIdentity ?? undefined,
     }
@@ -225,7 +216,6 @@ function useTradingPortfolioSocketData<T>({
       ) {
         return false
       }
-      if (payload.workspaceId && payload.workspaceId !== normalizedWorkspaceId) return false
       const payloadPortfolioIdentity = toPortfolioValueObject(payload.portfolioIdentity)
       if (
         payloadPortfolioIdentity &&
@@ -248,7 +238,6 @@ function useTradingPortfolioSocketData<T>({
       socket.emit('trading-portfolio-subscribe', {
         provider: normalizedProvider,
         serviceId: normalizedServiceId,
-        workspaceId: normalizedWorkspaceId,
         channel,
         portfolioIdentity: normalizedPortfolioIdentity,
         window,
@@ -325,7 +314,6 @@ function useTradingPortfolioSocketData<T>({
     normalizedServiceId,
     normalizedPortfolioIdentityKey,
     normalizedProvider,
-    normalizedWorkspaceId,
     refetchNonce,
     refreshKey,
     requestKey,
@@ -366,7 +354,6 @@ export function usePortfolioIdentities(request: TradingAccountsRequest) {
     channel: 'accounts',
     provider: request.provider,
     serviceId: request.serviceId,
-    workspaceId: request.workspaceId,
     refreshKey: request.refreshKey,
     enabled: request.enabled,
     dataEvent: 'trading-portfolio-accounts',
@@ -379,7 +366,6 @@ export function usePortfolioDetail(request: TradingSnapshotRequest) {
     channel: 'account-snapshot',
     provider: request.provider,
     serviceId: request.serviceId,
-    workspaceId: request.workspaceId,
     portfolioIdentity: request.portfolioIdentity,
     refreshKey: request.refreshKey,
     enabled: request.enabled,
@@ -393,7 +379,6 @@ export function usePortfolioPerformance(request: TradingPerformanceRequest) {
     channel: 'portfolio-performance',
     provider: request.provider,
     serviceId: request.serviceId,
-    workspaceId: request.workspaceId,
     portfolioIdentity: request.portfolioIdentity,
     window: request.selectedWindow,
     refreshKey: request.refreshKey,

--- a/apps/tradinggoose/lib/credentials/oauth.ts
+++ b/apps/tradinggoose/lib/credentials/oauth.ts
@@ -188,7 +188,7 @@ export async function listOAuthCredentialsForUser(
     .map((row) => toOAuthCredential({ ...row, requesterUserId: params.userId }))
 }
 
-export async function listOAuthConnectionsForUser(params: {
+export async function listOAuthConnectionAccountsForUser(params: {
   userId: string
   providerIds?: string[]
 }) {
@@ -198,65 +198,63 @@ export async function listOAuthConnectionsForUser(params: {
     filters.push(inArray(account.providerId, providerIds))
   }
 
-  const rows = (
+  return (
     await db
       .select({
-        id: account.id,
+        tokenAccountId: account.id,
         accountId: account.accountId,
         providerId: account.providerId,
         idToken: account.idToken,
         updatedAt: account.updatedAt,
         scope: account.scope,
-        accountUserId: account.userId,
+        credentialOwnerUserId: account.userId,
       })
       .from(account)
       .where(and(...filters))
       .orderBy(desc(account.updatedAt))
   ).filter((row) => !isSignInOAuthProviderId(row.providerId))
+}
+
+export async function listOAuthConnectionsForUser(params: {
+  userId: string
+  providerIds?: string[]
+}) {
+  const rows = await listOAuthConnectionAccountsForUser(params)
 
   return rows.map((row) =>
     toOAuthCredential({
-      id: row.id,
+      id: row.tokenAccountId,
       displayName: getCredentialDisplayName(row),
       providerId: row.providerId,
       updatedAt: row.updatedAt,
       scope: row.scope,
-      accountUserId: row.accountUserId,
+      accountUserId: row.credentialOwnerUserId,
       requesterUserId: params.userId,
     })
   )
 }
 
-export async function listOAuthCredentialAccountsForUser(
-  params: OAuthCredentialQueryParams & { workspaceId: string }
-) {
-  const requesterAccess = await checkWorkspaceAccess(params.workspaceId, params.userId)
-  if (!requesterAccess.hasAccess) return []
-
-  const filters = [eq(credential.type, 'oauth'), eq(credential.workspaceId, params.workspaceId)]
-  if (params.providerIds?.length) {
-    filters.push(inArray(account.providerId, params.providerIds))
-  }
-
-  const rows = await db
+export async function resolveOAuthConnectionAccountForUser(params: {
+  accountId: string
+  userId: string
+}) {
+  const [row] = await db
     .select({
-      credentialId: credential.id,
       tokenAccountId: account.id,
       providerId: account.providerId,
-      credentialOwnerUserId: account.userId,
+      accountUserId: account.userId,
     })
-    .from(credential)
-    .innerJoin(account, eq(credential.accountId, account.id))
-    .where(and(...filters))
+    .from(account)
+    .where(and(eq(account.id, params.accountId), eq(account.userId, params.userId)))
+    .limit(1)
 
-  const usableCredentialIds = await listUsableCredentialIds({
-    userId: params.userId,
-    workspaceId: params.workspaceId,
-    canWrite: requesterAccess.canWrite,
-    rows,
-  })
+  if (!row || isSignInOAuthProviderId(row.providerId)) return null
 
-  return rows.filter((row) => usableCredentialIds.has(row.credentialId))
+  return {
+    tokenAccountId: row.tokenAccountId,
+    providerId: row.providerId,
+    credentialOwnerUserId: row.accountUserId,
+  }
 }
 
 export async function resolveOAuthCredentialAccountForUser(params: {

--- a/apps/tradinggoose/lib/trading/context.ts
+++ b/apps/tradinggoose/lib/trading/context.ts
@@ -15,14 +15,13 @@ const logger = createLogger('TradingServices')
 
 type ProviderRequestData = {
   provider: string
-  credentialId: string
+  tokenAccountId: string
   serviceId: string
 }
 
 type PreflightContext = {
   requestId: string
   providerId: string
-  credentialId: string
   tokenAccountId: string
   serviceId: string
   environment: 'paper' | 'live'
@@ -45,16 +44,15 @@ const requireStringField = (input: string | undefined, field: string): string =>
   return value
 }
 
-export async function authorizeTradingCredentialRequest(params: {
-  credentialId: string
+export async function authorizeTradingConnectionRequest(params: {
+  tokenAccountId: string
   userId: string
 }): Promise<{
-  credentialOwnerUserId: string
-  tokenAccountId: string
+  connectionOwnerUserId: string
   accountProviderId: string
 }> {
   const connection = await resolveOAuthConnectionAccountForUser({
-    accountId: params.credentialId,
+    accountId: params.tokenAccountId,
     userId: params.userId,
   })
   if (!connection) {
@@ -62,8 +60,7 @@ export async function authorizeTradingCredentialRequest(params: {
   }
 
   return {
-    credentialOwnerUserId: connection.credentialOwnerUserId,
-    tokenAccountId: connection.tokenAccountId,
+    connectionOwnerUserId: connection.credentialOwnerUserId,
     accountProviderId: connection.providerId,
   }
 }
@@ -72,15 +69,13 @@ export async function resolveTradingProviderContext({
   requestData,
   requestId,
   userId,
-  credentialOwnerUserId,
-  tokenAccountId,
+  connectionOwnerUserId,
   accountProviderId,
 }: {
   requestData: ProviderRequestData
   requestId: string
   userId: string
-  credentialOwnerUserId: string
-  tokenAccountId: string
+  connectionOwnerUserId: string
   accountProviderId: string
 }): Promise<PreflightContext> {
   const providerId = requireStringField(requestData.provider, 'provider')
@@ -96,14 +91,14 @@ export async function resolveTradingProviderContext({
     throw new TradingServiceError('Trading provider connection is required')
   }
 
-  const credentialId = requireStringField(requestData.credentialId, 'credentialId')
+  const tokenAccountId = requireStringField(requestData.tokenAccountId, 'tokenAccountId')
   if (accountProviderId !== serviceId) {
     throw new TradingServiceError('Trading provider connection does not match requested service')
   }
 
   const resolvedAccessToken = await refreshAccessTokenIfNeeded(
     tokenAccountId,
-    credentialOwnerUserId,
+    connectionOwnerUserId,
     requestId
   )
   if (!resolvedAccessToken) {
@@ -117,7 +112,6 @@ export async function resolveTradingProviderContext({
   return {
     requestId,
     providerId,
-    credentialId,
     tokenAccountId,
     serviceId: serviceId,
     environment,
@@ -140,7 +134,7 @@ export async function resolveTradingProviderSelectedAccount({
   const portfolioIdentity = portfolioIdentities.find(
     (candidate) =>
       candidate.providerId === baseContext.providerId &&
-      candidate.credentialId === baseContext.credentialId &&
+      candidate.tokenAccountId === baseContext.tokenAccountId &&
       candidate.serviceId === baseContext.serviceId &&
       candidate.accountId === selectedAccountId
   )

--- a/apps/tradinggoose/lib/trading/context.ts
+++ b/apps/tradinggoose/lib/trading/context.ts
@@ -1,5 +1,4 @@
-import type { NextRequest } from 'next/server'
-import { authorizeCredentialUse } from '@/lib/auth/credential-access'
+import { resolveOAuthConnectionAccountForUser } from '@/lib/credentials/oauth'
 import { createLogger } from '@/lib/logs/console/logger'
 import { refreshAccessTokenIfNeeded } from '@/lib/oauth/tokens'
 import { TradingServiceError } from '@/lib/trading/errors'
@@ -47,39 +46,25 @@ const requireStringField = (input: string | undefined, field: string): string =>
 }
 
 export async function authorizeTradingCredentialRequest(params: {
-  request: NextRequest
   credentialId: string
-  workspaceId?: string
-  workflowId?: string
+  userId: string
 }): Promise<{
   credentialOwnerUserId: string
   tokenAccountId: string
   accountProviderId: string
 }> {
-  const authorization = await authorizeCredentialUse(params.request, {
-    credentialId: params.credentialId,
-    workspaceId: params.workspaceId,
-    workflowId: params.workflowId,
+  const connection = await resolveOAuthConnectionAccountForUser({
+    accountId: params.credentialId,
+    userId: params.userId,
   })
-  if (
-    !authorization.ok ||
-    !authorization.credentialOwnerUserId ||
-    !authorization.resolvedTokenAccountId ||
-    !authorization.resolvedProviderId
-  ) {
-    const status =
-      authorization.error === 'Credential not found'
-        ? 404
-        : authorization.error === 'Authentication required'
-          ? 401
-          : 403
-    throw new TradingServiceError(authorization.error || 'Unauthorized', status)
+  if (!connection) {
+    throw new TradingServiceError('Trading provider connection not found', 404)
   }
 
   return {
-    credentialOwnerUserId: authorization.credentialOwnerUserId,
-    tokenAccountId: authorization.resolvedTokenAccountId,
-    accountProviderId: authorization.resolvedProviderId,
+    credentialOwnerUserId: connection.credentialOwnerUserId,
+    tokenAccountId: connection.tokenAccountId,
+    accountProviderId: connection.providerId,
   }
 }
 

--- a/apps/tradinggoose/lib/trading/holdings.ts
+++ b/apps/tradinggoose/lib/trading/holdings.ts
@@ -1,5 +1,5 @@
 import {
-  authorizeTradingCredentialRequest,
+  authorizeTradingConnectionRequest,
   resolveTradingProviderContext,
   resolveTradingProviderSelectedAccount,
 } from '@/lib/trading/context'
@@ -33,22 +33,21 @@ export async function getTradingHoldings({
   if (!portfolioIdentity) {
     throw new TradingServiceError('Portfolio identity is required')
   }
-  const credentialAuthorization = await authorizeTradingCredentialRequest({
-    credentialId: portfolioIdentity.credentialId,
+  const connectionAuthorization = await authorizeTradingConnectionRequest({
+    tokenAccountId: portfolioIdentity.tokenAccountId,
     userId,
   })
 
   const baseContext = await resolveTradingProviderContext({
     requestData: {
       provider: portfolioIdentity.providerId,
-      credentialId: portfolioIdentity.credentialId,
+      tokenAccountId: portfolioIdentity.tokenAccountId,
       serviceId: portfolioIdentity.serviceId,
     },
     requestId,
     userId,
-    credentialOwnerUserId: credentialAuthorization.credentialOwnerUserId,
-    tokenAccountId: credentialAuthorization.tokenAccountId,
-    accountProviderId: credentialAuthorization.accountProviderId,
+    connectionOwnerUserId: connectionAuthorization.connectionOwnerUserId,
+    accountProviderId: connectionAuthorization.accountProviderId,
   })
   const providerDefinition = getTradingProviderDefinition(baseContext.providerId)
   if (!providerDefinition) {
@@ -61,7 +60,7 @@ export async function getTradingHoldings({
 
   const holdings = await getPortfolioDetail({
     providerId: baseContext.providerId,
-    credentialId: baseContext.credentialId,
+    tokenAccountId: baseContext.tokenAccountId,
     serviceId: baseContext.serviceId,
     environment: baseContext.environment,
     accessToken: baseContext.accessToken,

--- a/apps/tradinggoose/lib/trading/holdings.ts
+++ b/apps/tradinggoose/lib/trading/holdings.ts
@@ -23,7 +23,6 @@ export type TradingHoldingsResult = {
 }
 
 export async function getTradingHoldings({
-  request,
   requestData,
   requestId,
   userId,
@@ -39,10 +38,8 @@ export async function getTradingHoldings({
     throw new TradingServiceError('Portfolio identity is required')
   }
   const credentialAuthorization = await authorizeTradingCredentialRequest({
-    request,
     credentialId: portfolioIdentity.credentialId,
-    workspaceId: requestData.workspaceId,
-    workflowId: requestData.workflowId,
+    userId,
   })
 
   const baseContext = await resolveTradingProviderContext({

--- a/apps/tradinggoose/lib/trading/holdings.ts
+++ b/apps/tradinggoose/lib/trading/holdings.ts
@@ -1,4 +1,3 @@
-import type { NextRequest } from 'next/server'
 import {
   authorizeTradingCredentialRequest,
   resolveTradingProviderContext,
@@ -12,8 +11,6 @@ import { TradingServiceError } from './errors'
 
 export interface TradingHoldingsRequest {
   portfolioIdentity?: PortfolioIdentity | null
-  workspaceId?: string
-  workflowId?: string
 }
 
 export type TradingHoldingsResult = {
@@ -27,7 +24,6 @@ export async function getTradingHoldings({
   requestId,
   userId,
 }: {
-  request: NextRequest
   requestData: TradingHoldingsRequest
   requestId: string
   userId: string

--- a/apps/tradinggoose/lib/trading/order-detail.ts
+++ b/apps/tradinggoose/lib/trading/order-detail.ts
@@ -2,7 +2,7 @@ import { db, orderHistoryTable } from '@tradinggoose/db'
 import { and, eq } from 'drizzle-orm'
 import { checkWorkspaceAccess } from '@/lib/permissions/utils'
 import {
-  authorizeTradingCredentialRequest,
+  authorizeTradingConnectionRequest,
   logTradingBrokerRequestFailure,
   resolveTradingProviderContext,
 } from '@/lib/trading/context'
@@ -10,8 +10,8 @@ import { TradingServiceError } from '@/lib/trading/errors'
 import {
   deepRedactSecrets,
   readOrderAccountId,
-  readOrderCredentialId,
   readOrderServiceId,
+  readOrderTokenAccountId,
 } from '@/lib/trading/order-records'
 import { executeTradingProviderOrderDetailRequest } from '@/providers/trading'
 import { TradingBrokerRequestError } from '@/providers/trading/portfolio-utils'
@@ -61,27 +61,26 @@ export async function getRecordedTradingOrderProviderDetail({
     throw new TradingServiceError('Tradier order history record is missing accountId')
   }
 
-  const credentialId = readOrderCredentialId(order)
+  const tokenAccountId = readOrderTokenAccountId(order)
   const serviceId = readOrderServiceId(order)
-  if (!credentialId || !serviceId) {
-    throw new TradingServiceError('Order history record is missing trading credential context')
+  if (!tokenAccountId || !serviceId) {
+    throw new TradingServiceError('Order history record is missing trading connection context')
   }
-  const credentialAuthorization = await authorizeTradingCredentialRequest({
-    credentialId,
+  const connectionAuthorization = await authorizeTradingConnectionRequest({
+    tokenAccountId,
     userId,
   })
 
   const baseContext = await resolveTradingProviderContext({
     requestData: {
       provider: order.provider,
-      credentialId,
+      tokenAccountId,
       serviceId,
     },
     requestId,
     userId,
-    credentialOwnerUserId: credentialAuthorization.credentialOwnerUserId,
-    tokenAccountId: credentialAuthorization.tokenAccountId,
-    accountProviderId: credentialAuthorization.accountProviderId,
+    connectionOwnerUserId: connectionAuthorization.connectionOwnerUserId,
+    accountProviderId: connectionAuthorization.accountProviderId,
   })
 
   const detailInput: TradingOrderDetailInput = {

--- a/apps/tradinggoose/lib/trading/order-detail.ts
+++ b/apps/tradinggoose/lib/trading/order-detail.ts
@@ -1,6 +1,5 @@
 import { db, orderHistoryTable } from '@tradinggoose/db'
 import { and, eq } from 'drizzle-orm'
-import type { NextRequest } from 'next/server'
 import { checkWorkspaceAccess } from '@/lib/permissions/utils'
 import {
   authorizeTradingCredentialRequest,
@@ -39,11 +38,9 @@ export async function getRecordedTradingOrderProviderDetail({
   workspaceId,
 }: {
   orderId: string
-  request: NextRequest
   requestId: string
   userId: string
   workspaceId: string
-  workflowId?: string
 }): Promise<TradingProviderOrderDetailResult> {
   const access = await checkWorkspaceAccess(workspaceId, userId)
   if (!access.exists || !access.hasAccess) {

--- a/apps/tradinggoose/lib/trading/order-detail.ts
+++ b/apps/tradinggoose/lib/trading/order-detail.ts
@@ -34,11 +34,9 @@ export type TradingProviderOrderDetailResult = {
 
 export async function getRecordedTradingOrderProviderDetail({
   orderId,
-  request,
   requestId,
   userId,
   workspaceId,
-  workflowId,
 }: {
   orderId: string
   request: NextRequest
@@ -72,10 +70,8 @@ export async function getRecordedTradingOrderProviderDetail({
     throw new TradingServiceError('Order history record is missing trading credential context')
   }
   const credentialAuthorization = await authorizeTradingCredentialRequest({
-    request,
     credentialId,
-    workspaceId,
-    workflowId,
+    userId,
   })
 
   const baseContext = await resolveTradingProviderContext({

--- a/apps/tradinggoose/lib/trading/order-records.test.ts
+++ b/apps/tradinggoose/lib/trading/order-records.test.ts
@@ -88,7 +88,7 @@ describe('order record utils', () => {
         request: {
           accountId: 'account-1',
           accessToken: 'secret-token',
-          credentialId: 'credential-1',
+          tokenAccountId: 'oauth-account-1',
           serviceId: 'alpaca-paper',
           orderType: 'limit',
           quantity: '5',
@@ -137,7 +137,7 @@ describe('order record utils', () => {
     expect(record.request).toMatchObject({
       accountId: '[redacted]',
       accessToken: '[redacted]',
-      credentialId: '[redacted]',
+      tokenAccountId: '[redacted]',
       serviceId: '[redacted]',
     })
     expect(record.response).toMatchObject({

--- a/apps/tradinggoose/lib/trading/order-records.ts
+++ b/apps/tradinggoose/lib/trading/order-records.ts
@@ -102,7 +102,6 @@ const SECRET_KEY_EXACT_KEYS = new Set([
   'apikey',
   'apisecret',
   'authorization',
-  'credentialid',
   'password',
   'refreshtoken',
   'serviceid',
@@ -250,8 +249,8 @@ const readOrderRequestString = (row: Pick<RecordsOrderRow, 'request'>, key: stri
 export const readOrderAccountId = (row: Pick<RecordsOrderRow, 'request'>) =>
   readOrderRequestString(row, 'accountId')
 
-export const readOrderCredentialId = (row: Pick<RecordsOrderRow, 'request'>) =>
-  readOrderRequestString(row, 'credentialId')
+export const readOrderTokenAccountId = (row: Pick<RecordsOrderRow, 'request'>) =>
+  readOrderRequestString(row, 'tokenAccountId')
 
 export const readOrderServiceId = (row: Pick<RecordsOrderRow, 'request'>) =>
   readOrderRequestString(row, 'serviceId')

--- a/apps/tradinggoose/lib/trading/orders.ts
+++ b/apps/tradinggoose/lib/trading/orders.ts
@@ -6,7 +6,7 @@ import { resolveListingIdentity } from '@/lib/listing/resolve'
 import { createLogger } from '@/lib/logs/console/logger'
 import { checkWorkspaceAccess } from '@/lib/permissions/utils'
 import {
-  authorizeTradingCredentialRequest,
+  authorizeTradingConnectionRequest,
   logTradingBrokerRequestFailure,
   resolveTradingProviderContext,
   resolveTradingProviderSelectedAccount,
@@ -342,22 +342,21 @@ export async function submitTradingOrder({
     submissionSource: requestData.submissionSource,
     logId: requestData.logId,
   })
-  const credentialAuthorization = await authorizeTradingCredentialRequest({
-    credentialId: portfolioIdentity.credentialId,
+  const connectionAuthorization = await authorizeTradingConnectionRequest({
+    tokenAccountId: portfolioIdentity.tokenAccountId,
     userId,
   })
 
   const baseContext = await resolveTradingProviderContext({
     requestData: {
       provider: portfolioIdentity.providerId,
-      credentialId: portfolioIdentity.credentialId,
+      tokenAccountId: portfolioIdentity.tokenAccountId,
       serviceId: portfolioIdentity.serviceId,
     },
     requestId,
     userId,
-    credentialOwnerUserId: credentialAuthorization.credentialOwnerUserId,
-    tokenAccountId: credentialAuthorization.tokenAccountId,
-    accountProviderId: credentialAuthorization.accountProviderId,
+    connectionOwnerUserId: connectionAuthorization.connectionOwnerUserId,
+    accountProviderId: connectionAuthorization.accountProviderId,
   })
 
   const resolvedListing = await resolveOrderListing(requestData.listing as ListingInputValue)
@@ -391,7 +390,7 @@ export async function submitTradingOrder({
   })
   const clientOrderId = createTradingOrderClientOrderId(requestData.idempotencyKey)
   const orderHistoryRequest = compactRecord({
-    credentialId: baseContext.credentialId,
+    tokenAccountId: baseContext.tokenAccountId,
     serviceId: baseContext.serviceId,
     accountId: accountContext.accountId,
     clientOrderId,

--- a/apps/tradinggoose/lib/trading/orders.ts
+++ b/apps/tradinggoose/lib/trading/orders.ts
@@ -320,7 +320,6 @@ const extractOrderProviderMessage = (
   readMessage(rawOrder) ?? readMessage(normalizedOrder?.raw) ?? readMessage(normalizedOrder)
 
 export async function submitTradingOrder({
-  request,
   requestData,
   requestId,
   userId,
@@ -346,10 +345,8 @@ export async function submitTradingOrder({
     logId: requestData.logId,
   })
   const credentialAuthorization = await authorizeTradingCredentialRequest({
-    request,
     credentialId: portfolioIdentity.credentialId,
-    workspaceId: requestData.workspaceId,
-    workflowId: requestData.workflowId,
+    userId,
   })
 
   const baseContext = await resolveTradingProviderContext({

--- a/apps/tradinggoose/lib/trading/orders.ts
+++ b/apps/tradinggoose/lib/trading/orders.ts
@@ -1,5 +1,4 @@
 import { createHash } from 'crypto'
-import type { NextRequest } from 'next/server'
 import { IdempotencyService } from '@/lib/idempotency'
 import type { ListingInputValue } from '@/lib/listing/identity'
 import { toListingValueObject } from '@/lib/listing/identity'
@@ -324,7 +323,6 @@ export async function submitTradingOrder({
   requestId,
   userId,
 }: {
-  request: NextRequest
   requestData: TradingOrderSubmitRequest
   requestId: string
   userId: string

--- a/apps/tradinggoose/lib/trading/portfolio-identities.test.ts
+++ b/apps/tradinggoose/lib/trading/portfolio-identities.test.ts
@@ -5,7 +5,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
-  credentials: [] as Array<{
+  connections: [] as Array<{
     tokenAccountId: string
     providerId: string
     credentialOwnerUserId: string
@@ -19,7 +19,7 @@ vi.mock('@/lib/oauth/tokens', () => ({
 }))
 
 vi.mock('@/lib/credentials/oauth', () => ({
-  listOAuthConnectionAccountsForUser: vi.fn(() => Promise.resolve(mocks.credentials)),
+  listOAuthConnectionAccountsForUser: vi.fn(() => Promise.resolve(mocks.connections)),
 }))
 
 vi.mock('@/providers/trading/portfolio', () => ({
@@ -45,7 +45,7 @@ vi.mock('@/providers/trading/providers', () => ({
 
 const portfolioIdentity = {
   providerId: 'alpaca',
-  credentialId: 'account-live',
+  tokenAccountId: 'account-live',
   serviceId: 'alpaca-live',
   accountId: 'account-1',
 }
@@ -53,13 +53,13 @@ const portfolioIdentity = {
 describe('listTradingPortfolioIdentities', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mocks.credentials = []
+    mocks.connections = []
     mocks.refreshAccessTokenIfNeeded.mockResolvedValue('token')
     mocks.listPortfolioIdentities.mockResolvedValue([portfolioIdentity])
   })
 
   it('throws for a selected service when any same-service account load fails', async () => {
-    mocks.credentials = [
+    mocks.connections = [
       {
         tokenAccountId: 'account-live',
         providerId: 'alpaca-live',
@@ -71,8 +71,8 @@ describe('listTradingPortfolioIdentities', () => {
         credentialOwnerUserId: 'user-1',
       },
     ]
-    mocks.refreshAccessTokenIfNeeded.mockImplementation((credentialId: string) =>
-      credentialId === 'account-stale' ? null : 'token'
+    mocks.refreshAccessTokenIfNeeded.mockImplementation((tokenAccountId: string) =>
+      tokenAccountId === 'account-stale' ? null : 'token'
     )
     const { listTradingPortfolioIdentities } = await import('./portfolio-identities')
 
@@ -87,7 +87,7 @@ describe('listTradingPortfolioIdentities', () => {
   })
 
   it('returns healthy identities when another service fails during all-service loading', async () => {
-    mocks.credentials = [
+    mocks.connections = [
       {
         tokenAccountId: 'account-live',
         providerId: 'alpaca-live',
@@ -99,8 +99,8 @@ describe('listTradingPortfolioIdentities', () => {
         credentialOwnerUserId: 'user-1',
       },
     ]
-    mocks.refreshAccessTokenIfNeeded.mockImplementation((credentialId: string) =>
-      credentialId === 'account-paper' ? null : 'token'
+    mocks.refreshAccessTokenIfNeeded.mockImplementation((tokenAccountId: string) =>
+      tokenAccountId === 'account-paper' ? null : 'token'
     )
     const { listTradingPortfolioIdentities } = await import('./portfolio-identities')
 

--- a/apps/tradinggoose/lib/trading/portfolio-identities.test.ts
+++ b/apps/tradinggoose/lib/trading/portfolio-identities.test.ts
@@ -6,7 +6,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   credentials: [] as Array<{
-    credentialId: string
     tokenAccountId: string
     providerId: string
     credentialOwnerUserId: string
@@ -20,7 +19,7 @@ vi.mock('@/lib/oauth/tokens', () => ({
 }))
 
 vi.mock('@/lib/credentials/oauth', () => ({
-  listOAuthCredentialAccountsForUser: vi.fn(() => Promise.resolve(mocks.credentials)),
+  listOAuthConnectionAccountsForUser: vi.fn(() => Promise.resolve(mocks.credentials)),
 }))
 
 vi.mock('@/providers/trading/portfolio', () => ({
@@ -46,7 +45,7 @@ vi.mock('@/providers/trading/providers', () => ({
 
 const portfolioIdentity = {
   providerId: 'alpaca',
-  credentialId: 'credential-live',
+  credentialId: 'account-live',
   serviceId: 'alpaca-live',
   accountId: 'account-1',
 }
@@ -62,13 +61,11 @@ describe('listTradingPortfolioIdentities', () => {
   it('throws for a selected service when any same-service account load fails', async () => {
     mocks.credentials = [
       {
-        credentialId: 'credential-live',
         tokenAccountId: 'account-live',
         providerId: 'alpaca-live',
         credentialOwnerUserId: 'user-1',
       },
       {
-        credentialId: 'credential-stale',
         tokenAccountId: 'account-stale',
         providerId: 'alpaca-live',
         credentialOwnerUserId: 'user-1',
@@ -82,7 +79,6 @@ describe('listTradingPortfolioIdentities', () => {
     await expect(
       listTradingPortfolioIdentities({
         userId: 'user-1',
-        workspaceId: 'workspace-1',
         providerId: 'alpaca',
         serviceId: 'alpaca-live',
         requestId: 'request-1',
@@ -93,13 +89,11 @@ describe('listTradingPortfolioIdentities', () => {
   it('returns healthy identities when another service fails during all-service loading', async () => {
     mocks.credentials = [
       {
-        credentialId: 'credential-live',
         tokenAccountId: 'account-live',
         providerId: 'alpaca-live',
         credentialOwnerUserId: 'user-1',
       },
       {
-        credentialId: 'credential-paper',
         tokenAccountId: 'account-paper',
         providerId: 'alpaca-paper',
         credentialOwnerUserId: 'user-1',
@@ -113,7 +107,6 @@ describe('listTradingPortfolioIdentities', () => {
     await expect(
       listTradingPortfolioIdentities({
         userId: 'user-1',
-        workspaceId: 'workspace-1',
         providerId: 'alpaca',
         requestId: 'request-1',
       })

--- a/apps/tradinggoose/lib/trading/portfolio-identities.ts
+++ b/apps/tradinggoose/lib/trading/portfolio-identities.ts
@@ -30,31 +30,31 @@ export async function listTradingPortfolioIdentities({
   const targetServiceIds = selectedServiceId ? [selectedServiceId] : serviceIds
   if (!targetServiceIds.length) return []
 
-  const credentials = await listOAuthConnectionAccountsForUser({
+  const connections = await listOAuthConnectionAccountsForUser({
     userId,
     providerIds: targetServiceIds,
   })
 
   const identities = await Promise.allSettled(
-    credentials.map(async (credential) => {
-      const environment = getTradingProviderOAuthEnvironment(providerId, credential.providerId)
+    connections.map(async (connection) => {
+      const environment = getTradingProviderOAuthEnvironment(providerId, connection.providerId)
       if (!environment) {
-        throw new Error(`Unsupported trading service: ${credential.providerId}`)
+        throw new Error(`Unsupported trading service: ${connection.providerId}`)
       }
 
       const accessToken = await refreshAccessTokenIfNeeded(
-        credential.tokenAccountId,
-        credential.credentialOwnerUserId,
+        connection.tokenAccountId,
+        connection.credentialOwnerUserId,
         requestId
       )
       if (!accessToken) {
-        throw new Error(`Trading credential token unavailable: ${credential.tokenAccountId}`)
+        throw new Error(`Trading connection token unavailable: ${connection.tokenAccountId}`)
       }
 
       return listPortfolioIdentities({
         providerId,
-        credentialId: credential.tokenAccountId,
-        serviceId: credential.providerId,
+        tokenAccountId: connection.tokenAccountId,
+        serviceId: connection.providerId,
         environment,
         accessToken,
       })

--- a/apps/tradinggoose/lib/trading/portfolio-identities.ts
+++ b/apps/tradinggoose/lib/trading/portfolio-identities.ts
@@ -1,4 +1,4 @@
-import { listOAuthCredentialAccountsForUser } from '@/lib/credentials/oauth'
+import { listOAuthConnectionAccountsForUser } from '@/lib/credentials/oauth'
 import { refreshAccessTokenIfNeeded } from '@/lib/oauth/tokens'
 import { listPortfolioIdentities } from '@/providers/trading/portfolio'
 import {
@@ -10,13 +10,11 @@ import type { TradingProviderId } from '@/providers/trading/types'
 
 export async function listTradingPortfolioIdentities({
   userId,
-  workspaceId,
   providerId,
   serviceId,
   requestId,
 }: {
   userId: string
-  workspaceId: string
   providerId: TradingProviderId
   serviceId?: string
   requestId: string
@@ -32,9 +30,8 @@ export async function listTradingPortfolioIdentities({
   const targetServiceIds = selectedServiceId ? [selectedServiceId] : serviceIds
   if (!targetServiceIds.length) return []
 
-  const credentials = await listOAuthCredentialAccountsForUser({
+  const credentials = await listOAuthConnectionAccountsForUser({
     userId,
-    workspaceId,
     providerIds: targetServiceIds,
   })
 
@@ -51,12 +48,12 @@ export async function listTradingPortfolioIdentities({
         requestId
       )
       if (!accessToken) {
-        throw new Error(`Trading credential token unavailable: ${credential.credentialId}`)
+        throw new Error(`Trading credential token unavailable: ${credential.tokenAccountId}`)
       }
 
       return listPortfolioIdentities({
         providerId,
-        credentialId: credential.credentialId,
+        credentialId: credential.tokenAccountId,
         serviceId: credential.providerId,
         environment,
         accessToken,

--- a/apps/tradinggoose/providers/trading/alpaca/accounts.ts
+++ b/apps/tradinggoose/providers/trading/alpaca/accounts.ts
@@ -57,7 +57,7 @@ export const mapAlpacaAccountType = (account: any): UnifiedTradingAccountType =>
 
 export const normalizeAlpacaTradingAccount = (
   account: any,
-  context: Pick<TradingPortfolioBaseContext, 'credentialId' | 'serviceId' | 'providerId'>
+  context: Pick<TradingPortfolioBaseContext, 'tokenAccountId' | 'serviceId' | 'providerId'>
 ): PortfolioIdentity => {
   const id = typeof account?.id === 'string' ? account.id.trim() : ''
   if (!id) {
@@ -71,7 +71,7 @@ export const normalizeAlpacaTradingAccount = (
 
   return {
     providerId: context.providerId,
-    credentialId: context.credentialId,
+    tokenAccountId: context.tokenAccountId,
     serviceId: context.serviceId,
     accountId: id,
     providerName: 'Alpaca',

--- a/apps/tradinggoose/providers/trading/alpaca/portfolio.test.ts
+++ b/apps/tradinggoose/providers/trading/alpaca/portfolio.test.ts
@@ -48,13 +48,13 @@ describe('Alpaca portfolio helpers', () => {
         },
         {
           providerId: 'alpaca',
-          credentialId: 'credential-1',
+          tokenAccountId: 'oauth-account-1',
           serviceId: 'alpaca-live',
         }
       )
     ).toEqual({
       providerId: 'alpaca',
-      credentialId: 'credential-1',
+      tokenAccountId: 'oauth-account-1',
       serviceId: 'alpaca-live',
       accountId: 'acct-live',
       providerName: 'Alpaca',
@@ -78,7 +78,7 @@ describe('Alpaca portfolio helpers', () => {
         },
         {
           providerId: 'alpaca',
-          credentialId: 'credential-1',
+          tokenAccountId: 'oauth-account-1',
           serviceId: 'alpaca-live',
         }
       )
@@ -133,7 +133,7 @@ describe('Alpaca portfolio helpers', () => {
 
     const snapshot = await getAlpacaTradingAccountSnapshot({
       providerId: 'alpaca',
-      credentialId: 'credential-1',
+      tokenAccountId: 'oauth-account-1',
       serviceId: 'alpaca-live',
       environment: 'live',
       accessToken: 'token',
@@ -201,7 +201,7 @@ describe('Alpaca portfolio helpers', () => {
 
     const snapshot = await getAlpacaTradingAccountSnapshot({
       providerId: 'alpaca',
-      credentialId: 'credential-1',
+      tokenAccountId: 'oauth-account-1',
       serviceId: 'alpaca-live',
       environment: 'live',
       accessToken: 'token',
@@ -276,7 +276,7 @@ describe('Alpaca portfolio helpers', () => {
 
     const performance = await getAlpacaTradingAccountPerformance({
       providerId: 'alpaca',
-      credentialId: 'credential-1',
+      tokenAccountId: 'oauth-account-1',
       serviceId: 'alpaca-live',
       environment: 'live',
       accessToken: 'token',
@@ -294,7 +294,7 @@ describe('Alpaca portfolio helpers', () => {
 
     const performance = await getAlpacaTradingAccountPerformance({
       providerId: 'alpaca',
-      credentialId: 'credential-1',
+      tokenAccountId: 'oauth-account-1',
       serviceId: 'alpaca-live',
       environment: 'live',
       accessToken: 'token',

--- a/apps/tradinggoose/providers/trading/portfolio-identity.ts
+++ b/apps/tradinggoose/providers/trading/portfolio-identity.ts
@@ -12,7 +12,7 @@ export type PortfolioEnvironment = 'live' | 'paper'
 
 export type PortfolioIdentity = {
   providerId: TradingProviderId
-  credentialId: string
+  tokenAccountId: string
   serviceId: string
   accountId: string
   providerName?: string | null
@@ -44,17 +44,17 @@ export const toPortfolioValueObject = (value: unknown): PortfolioIdentity | null
 
   const record = value as Record<string, unknown>
   const providerId = readText(record, 'providerId')
-  const credentialId = readText(record, 'credentialId')
+  const tokenAccountId = readText(record, 'tokenAccountId')
   const serviceId = readText(record, 'serviceId')
   const accountId = readText(record, 'accountId')
 
-  if (!providerId || !credentialId || !serviceId || !accountId) {
+  if (!providerId || !tokenAccountId || !serviceId || !accountId) {
     return null
   }
 
   const identity: PortfolioIdentity = {
     providerId: providerId as TradingProviderId,
-    credentialId,
+    tokenAccountId,
     serviceId,
     accountId,
   }
@@ -75,7 +75,7 @@ export const toPortfolioValueObject = (value: unknown): PortfolioIdentity | null
 }
 
 export const getPortfolioIdentityKey = (portfolio: PortfolioIdentity) =>
-  `${portfolio.providerId}|${portfolio.credentialId}|${portfolio.serviceId}|${portfolio.accountId}`
+  `${portfolio.providerId}|${portfolio.tokenAccountId}|${portfolio.serviceId}|${portfolio.accountId}`
 
 export const arePortfolioIdentitiesEqual = (
   left?: PortfolioIdentity | null,

--- a/apps/tradinggoose/providers/trading/providers.ts
+++ b/apps/tradinggoose/providers/trading/providers.ts
@@ -109,12 +109,6 @@ export interface TradingProviderDefinition {
   description: string
   authType: TradingAuthType
   oauth?: TradingProviderOAuthConfig
-  credentialFields?: Array<{
-    id: string
-    label: string
-    secret?: boolean
-    description?: string
-  }>
   defaults?: {
     orderSizingMode?: TradingOrderSizingMode
     orderType?: string
@@ -137,10 +131,7 @@ export const TRADING_PROVIDER_DEFINITIONS: Record<string, TradingProviderDefinit
         { serviceId: 'alpaca-paper', environment: 'paper' },
       ],
       scopes: getCanonicalScopesForProvider('alpaca-live'),
-      credentialTitle: 'Alpaca Account',
-      credentialPlaceholder: 'Select or connect Alpaca connection',
     },
-    credentialFields: [],
     defaults: {
       orderSizingMode: 'quantity',
       orderType: 'market',
@@ -157,8 +148,6 @@ export const TRADING_PROVIDER_DEFINITIONS: Record<string, TradingProviderDefinit
       provider: 'tradier',
       services: [{ serviceId: 'tradier-live', environment: 'live' }],
       scopes: getCanonicalScopesForProvider('tradier-live'),
-      credentialTitle: 'Tradier Account',
-      credentialPlaceholder: 'Select or connect Tradier connection',
     },
     defaults: {
       orderSizingMode: 'quantity',

--- a/apps/tradinggoose/providers/trading/tradier/accounts.ts
+++ b/apps/tradinggoose/providers/trading/tradier/accounts.ts
@@ -27,7 +27,7 @@ const toTradierAccountsArray = (profileResponse: any) => {
 
 export const normalizeTradierTradingAccount = (
   account: any,
-  context: Pick<TradingPortfolioBaseContext, 'credentialId' | 'serviceId' | 'providerId'>
+  context: Pick<TradingPortfolioBaseContext, 'tokenAccountId' | 'serviceId' | 'providerId'>
 ): PortfolioIdentity => {
   const accountNumber =
     typeof account?.account_number === 'string' ? account.account_number.trim() : ''
@@ -40,7 +40,7 @@ export const normalizeTradierTradingAccount = (
 
   return {
     providerId: context.providerId,
-    credentialId: context.credentialId,
+    tokenAccountId: context.tokenAccountId,
     serviceId: context.serviceId,
     accountId: accountNumber,
     providerName: 'Tradier',

--- a/apps/tradinggoose/providers/trading/tradier/portfolio.test.ts
+++ b/apps/tradinggoose/providers/trading/tradier/portfolio.test.ts
@@ -47,13 +47,13 @@ describe('Tradier portfolio helpers', () => {
         },
         {
           providerId: 'tradier',
-          credentialId: 'credential-1',
+          tokenAccountId: 'oauth-account-1',
           serviceId: 'tradier-live',
         }
       )
     ).toEqual({
       providerId: 'tradier',
-      credentialId: 'credential-1',
+      tokenAccountId: 'oauth-account-1',
       serviceId: 'tradier-live',
       accountId: 'ACC-123',
       providerName: 'Tradier',
@@ -110,7 +110,7 @@ describe('Tradier portfolio helpers', () => {
 
     const snapshot = await getTradierTradingAccountSnapshot({
       providerId: 'tradier',
-      credentialId: 'credential-1',
+      tokenAccountId: 'oauth-account-1',
       serviceId: 'tradier-live',
       environment: 'live',
       accessToken: 'token',
@@ -167,7 +167,7 @@ describe('Tradier portfolio helpers', () => {
   it('returns an explicit unavailable payload for Tradier paper performance in v1', async () => {
     const performance = await getTradierTradingAccountPerformance({
       providerId: 'tradier',
-      credentialId: 'credential-1',
+      tokenAccountId: 'oauth-account-1',
       serviceId: 'tradier-live',
       environment: 'paper',
       accessToken: 'token',
@@ -185,7 +185,7 @@ describe('Tradier portfolio helpers', () => {
   it('returns an explicit unavailable payload for unsupported Tradier windows', async () => {
     const performance = await getTradierTradingAccountPerformance({
       providerId: 'tradier',
-      credentialId: 'credential-1',
+      tokenAccountId: 'oauth-account-1',
       serviceId: 'tradier-live',
       environment: 'live',
       accessToken: 'token',

--- a/apps/tradinggoose/providers/trading/types.ts
+++ b/apps/tradinggoose/providers/trading/types.ts
@@ -84,7 +84,7 @@ export interface TradingOrderDetailResult {
 
 export interface TradingPortfolioBaseContext {
   providerId: TradingProviderId
-  credentialId: string
+  tokenAccountId: string
   serviceId: string
   environment?: 'paper' | 'live'
   accessToken: string
@@ -252,8 +252,6 @@ export interface TradingProviderOAuthConfig {
     environment?: 'paper' | 'live'
   }>
   scopes?: string[]
-  credentialTitle?: string
-  credentialPlaceholder?: string
 }
 
 export interface TradingActionResponse {

--- a/apps/tradinggoose/socket-server/index.ts
+++ b/apps/tradinggoose/socket-server/index.ts
@@ -9,8 +9,12 @@ import { setupAllHandlers } from '@/socket-server/handlers'
 import { IndicatorMonitorRuntime } from '@/socket-server/market/indicator-monitor-runtime'
 import { type AuthenticatedSocket, authenticateSocket } from '@/socket-server/middleware/auth'
 import { createHttpHandler } from '@/socket-server/routes/http'
+import { tradingPortfolioStreamManager } from '@/socket-server/trading/portfolio-manager'
+import {
+  isYjsUpgradeRequest,
+  shieldNonYjsUpgradeListeners,
+} from '@/socket-server/yjs/upgrade-routing'
 import { handleYjsUpgrade } from '@/socket-server/yjs/ws-handler'
-import { isYjsUpgradeRequest, shieldNonYjsUpgradeListeners } from '@/socket-server/yjs/upgrade-routing'
 
 const logger = createLogger('CollaborativeSocketServer')
 
@@ -130,13 +134,17 @@ const shutdown = () => {
   isShuttingDown = true
 
   logger.info('Shutting down Socket.IO server...')
+  tradingPortfolioStreamManager.stop()
   void indicatorMonitorRuntime
     .stop()
     .catch((error) => {
       logger.error('Failed to stop indicator monitor runtime cleanly', { error })
     })
     .finally(() => {
-      httpServer.close(() => {
+      void io.close((error) => {
+        if (error) {
+          logger.error('Failed to close Socket.IO server cleanly', { error })
+        }
         void closeRedisConnection()
           .catch((error) => {
             logger.error('Failed to close Redis connection cleanly', { error })

--- a/apps/tradinggoose/socket-server/trading/portfolio-manager.test.ts
+++ b/apps/tradinggoose/socket-server/trading/portfolio-manager.test.ts
@@ -176,7 +176,6 @@ describe('TradingPortfolioStreamManager', () => {
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       portfolioIdentity,
-      workspaceId: 'workspace-1',
       channel: 'account-snapshot',
       clientSubscriptionId: 'snapshot-1',
     })
@@ -184,7 +183,6 @@ describe('TradingPortfolioStreamManager', () => {
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       portfolioIdentity,
-      workspaceId: 'workspace-1',
       channel: 'account-snapshot',
       clientSubscriptionId: 'snapshot-2',
     })
@@ -213,7 +211,6 @@ describe('TradingPortfolioStreamManager', () => {
       expect.objectContaining({
         provider: 'alpaca',
         serviceId: 'alpaca-live',
-        workspaceId: 'workspace-1',
         channel: 'account-snapshot',
         portfolioIdentity,
         portfolioDetail: expect.objectContaining({ accountId: 'acct-1' }),
@@ -241,7 +238,6 @@ describe('TradingPortfolioStreamManager', () => {
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       portfolioIdentity,
-      workspaceId: 'workspace-1',
       channel: 'account-snapshot',
       clientSubscriptionId: 'portfolio_snapshot',
     })
@@ -249,7 +245,6 @@ describe('TradingPortfolioStreamManager', () => {
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       portfolioIdentity,
-      workspaceId: 'workspace-1',
       channel: 'account-snapshot',
       clientSubscriptionId: 'portfolio_snapshot',
     })
@@ -286,7 +281,6 @@ describe('TradingPortfolioStreamManager', () => {
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       portfolioIdentity,
-      workspaceId: 'workspace-1',
       channel: 'account-snapshot',
       clientSubscriptionId: 'snapshot-1',
     })
@@ -294,7 +288,6 @@ describe('TradingPortfolioStreamManager', () => {
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       portfolioIdentity,
-      workspaceId: 'workspace-1',
       channel: 'portfolio-performance',
       window: '1D',
       clientSubscriptionId: 'performance-1',
@@ -310,7 +303,6 @@ describe('TradingPortfolioStreamManager', () => {
       expect.objectContaining({
         provider: 'alpaca',
         serviceId: 'alpaca-live',
-        workspaceId: 'workspace-1',
         channel: 'portfolio-performance',
         portfolioIdentity,
         window: '1D',
@@ -330,7 +322,6 @@ describe('TradingPortfolioStreamManager', () => {
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       portfolioIdentity,
-      workspaceId: 'workspace-1',
       channel: 'account-snapshot',
       clientSubscriptionId: 'snapshot-1',
     })
@@ -345,7 +336,6 @@ describe('TradingPortfolioStreamManager', () => {
         provider: 'alpaca',
         serviceId: 'alpaca-live',
         portfolioIdentity,
-        workspaceId: 'workspace-1',
         channel: 'account-snapshot',
       })
     ).rejects.toThrow('Trading portfolio stream manager is stopped')

--- a/apps/tradinggoose/socket-server/trading/portfolio-manager.test.ts
+++ b/apps/tradinggoose/socket-server/trading/portfolio-manager.test.ts
@@ -321,20 +321,29 @@ describe('TradingPortfolioStreamManager', () => {
     manager.removeSocket(socket.id)
   })
 
-  it('requires workspace scope before broker calls', async () => {
+  it('stops portfolio polling without waiting for socket disconnect', async () => {
+    vi.useFakeTimers()
     const manager = new TradingPortfolioStreamManager()
     const socket = createSocket('socket-1')
 
-    await expect(
-      manager.subscribe(socket, {
-        provider: 'alpaca',
-        serviceId: 'alpaca-live',
-        portfolioIdentity,
-        channel: 'account-snapshot',
-      })
-    ).rejects.toThrow('workspaceId is required')
+    await manager.subscribe(socket, {
+      provider: 'alpaca',
+      serviceId: 'alpaca-live',
+      portfolioIdentity,
+      workspaceId: 'workspace-1',
+      channel: 'account-snapshot',
+      clientSubscriptionId: 'snapshot-1',
+    })
+    await flushPortfolioPolls()
 
-    expect(refreshAccessTokenIfNeededMock).not.toHaveBeenCalled()
-    expect(getPortfolioDetailMock).not.toHaveBeenCalled()
+    expect(refreshAccessTokenIfNeededMock).toHaveBeenCalledTimes(1)
+    expect(getPortfolioDetailMock).toHaveBeenCalledTimes(1)
+
+    manager.stop()
+    await vi.advanceTimersByTimeAsync(30_000)
+    await flushPortfolioPolls()
+
+    expect(refreshAccessTokenIfNeededMock).toHaveBeenCalledTimes(1)
+    expect(getPortfolioDetailMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/tradinggoose/socket-server/trading/portfolio-manager.test.ts
+++ b/apps/tradinggoose/socket-server/trading/portfolio-manager.test.ts
@@ -71,7 +71,7 @@ import { TradingPortfolioStreamManager } from './portfolio-manager'
 
 const portfolioIdentity: PortfolioIdentity = {
   providerId: 'alpaca',
-  credentialId: 'account-credential-1',
+  tokenAccountId: 'oauth-account-1',
   serviceId: 'alpaca-live',
   accountId: 'acct-1',
   providerName: 'Alpaca',
@@ -144,7 +144,7 @@ describe('TradingPortfolioStreamManager', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     resolveOAuthConnectionAccountForUserMock.mockResolvedValue({
-      tokenAccountId: 'account-credential-1',
+      tokenAccountId: 'oauth-account-1',
       credentialOwnerUserId: 'user-1',
       providerId: 'alpaca-live',
     })
@@ -202,7 +202,7 @@ describe('TradingPortfolioStreamManager', () => {
     expect(getPortfolioDetailMock).toHaveBeenCalledTimes(1)
     expect(getPortfolioDetailMock).toHaveBeenCalledWith({
       providerId: 'alpaca',
-      credentialId: 'account-credential-1',
+      tokenAccountId: 'oauth-account-1',
       serviceId: 'alpaca-live',
       environment: 'live',
       accessToken: 'oauth-token',

--- a/apps/tradinggoose/socket-server/trading/portfolio-manager.test.ts
+++ b/apps/tradinggoose/socket-server/trading/portfolio-manager.test.ts
@@ -340,6 +340,16 @@ describe('TradingPortfolioStreamManager', () => {
     expect(getPortfolioDetailMock).toHaveBeenCalledTimes(1)
 
     manager.stop()
+    await expect(
+      manager.subscribe(socket, {
+        provider: 'alpaca',
+        serviceId: 'alpaca-live',
+        portfolioIdentity,
+        workspaceId: 'workspace-1',
+        channel: 'account-snapshot',
+      })
+    ).rejects.toThrow('Trading portfolio stream manager is stopped')
+
     await vi.advanceTimersByTimeAsync(30_000)
     await flushPortfolioPolls()
 

--- a/apps/tradinggoose/socket-server/trading/portfolio-manager.test.ts
+++ b/apps/tradinggoose/socket-server/trading/portfolio-manager.test.ts
@@ -10,7 +10,7 @@ const {
   getTradingProviderOAuthServiceIdMock,
   getTradingPortfolioSupportedWindowsMock,
   isTradingPortfolioWindowSupportedMock,
-  resolveOAuthCredentialAccountForUserMock,
+  resolveOAuthConnectionAccountForUserMock,
   listTradingPortfolioIdentitiesMock,
   getPortfolioDetailMock,
   getTradingAccountPerformanceMock,
@@ -21,7 +21,7 @@ const {
   getTradingProviderOAuthEnvironmentMock: vi.fn(),
   getTradingPortfolioSupportedWindowsMock: vi.fn(),
   isTradingPortfolioWindowSupportedMock: vi.fn(),
-  resolveOAuthCredentialAccountForUserMock: vi.fn(),
+  resolveOAuthConnectionAccountForUserMock: vi.fn(),
   listTradingPortfolioIdentitiesMock: vi.fn(),
   getPortfolioDetailMock: vi.fn(),
   getTradingAccountPerformanceMock: vi.fn(),
@@ -32,8 +32,8 @@ vi.mock('@/lib/oauth/tokens', () => ({
 }))
 
 vi.mock('@/lib/credentials/oauth', () => ({
-  resolveOAuthCredentialAccountForUser: (...args: unknown[]) =>
-    resolveOAuthCredentialAccountForUserMock(...args),
+  resolveOAuthConnectionAccountForUser: (...args: unknown[]) =>
+    resolveOAuthConnectionAccountForUserMock(...args),
 }))
 
 vi.mock('@/lib/trading/portfolio-identities', () => ({
@@ -71,7 +71,7 @@ import { TradingPortfolioStreamManager } from './portfolio-manager'
 
 const portfolioIdentity: PortfolioIdentity = {
   providerId: 'alpaca',
-  credentialId: 'credential-1',
+  credentialId: 'account-credential-1',
   serviceId: 'alpaca-live',
   accountId: 'acct-1',
   providerName: 'Alpaca',
@@ -143,11 +143,10 @@ const flushPortfolioPolls = async () => {
 describe('TradingPortfolioStreamManager', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    resolveOAuthCredentialAccountForUserMock.mockResolvedValue({
-      accountId: 'account-credential-1',
+    resolveOAuthConnectionAccountForUserMock.mockResolvedValue({
+      tokenAccountId: 'account-credential-1',
       credentialOwnerUserId: 'user-1',
       providerId: 'alpaca-live',
-      workspaceId: 'workspace-1',
     })
     refreshAccessTokenIfNeededMock.mockResolvedValue('oauth-token')
     getTradingProviderDefinitionMock.mockReturnValue({
@@ -194,10 +193,16 @@ describe('TradingPortfolioStreamManager', () => {
 
     expect(refreshAccessTokenIfNeededMock).toHaveBeenCalledTimes(1)
     expect(listTradingPortfolioIdentitiesMock).toHaveBeenCalledTimes(1)
+    expect(listTradingPortfolioIdentitiesMock).toHaveBeenCalledWith({
+      userId: 'user-1',
+      providerId: 'alpaca',
+      serviceId: 'alpaca-live',
+      requestId: expect.any(String),
+    })
     expect(getPortfolioDetailMock).toHaveBeenCalledTimes(1)
     expect(getPortfolioDetailMock).toHaveBeenCalledWith({
       providerId: 'alpaca',
-      credentialId: 'credential-1',
+      credentialId: 'account-credential-1',
       serviceId: 'alpaca-live',
       environment: 'live',
       accessToken: 'oauth-token',

--- a/apps/tradinggoose/socket-server/trading/portfolio-manager.ts
+++ b/apps/tradinggoose/socket-server/trading/portfolio-manager.ts
@@ -145,11 +145,13 @@ export class TradingPortfolioStreamManager {
   private streams = new Map<string, TradingPortfolioStreamState>()
   private socketSubscriptions = new Map<string, Map<string, TradingPortfolioSubscriptionRecord>>()
   private accountsCache = new Map<string, AccountsCacheEntry>()
+  private stopped = false
 
   async subscribe(
     socket: AuthenticatedSocket,
     payload: TradingPortfolioSubscribePayload
   ): Promise<TradingPortfolioSubscriptionInfo> {
+    this.stopped = false
     const userId = socket.userId
     if (!userId) throw new Error('Authentication required')
 
@@ -269,6 +271,19 @@ export class TradingPortfolioStreamManager {
     socketMap.forEach((record) => this.removeRecord(record))
   }
 
+  stop() {
+    this.stopped = true
+    this.streams.forEach((streamState) => {
+      if (streamState.pollingTimer) {
+        clearInterval(streamState.pollingTimer)
+      }
+      streamState.subscribers.clear()
+    })
+    this.streams.clear()
+    this.socketSubscriptions.clear()
+    this.accountsCache.clear()
+  }
+
   private getOrCreateStreamState(
     config: Omit<TradingPortfolioStreamState, 'subscribers'>
   ): TradingPortfolioStreamState {
@@ -298,6 +313,7 @@ export class TradingPortfolioStreamManager {
   }
 
   private async pollState(streamState: TradingPortfolioStreamState, forceRefresh: boolean) {
+    if (this.stopped) return
     if (streamState.pollingInFlight) return
     if (streamState.subscribers.size === 0) return
 
@@ -370,6 +386,7 @@ export class TradingPortfolioStreamManager {
       streamState.lastPayload = payload
       this.emitToSubscribers(streamState, payload)
     } catch (error) {
+      if (this.stopped) return
       this.emitErrorToSubscribers(streamState, error)
     } finally {
       streamState.pollingInFlight = false

--- a/apps/tradinggoose/socket-server/trading/portfolio-manager.ts
+++ b/apps/tradinggoose/socket-server/trading/portfolio-manager.ts
@@ -44,7 +44,6 @@ export interface TradingPortfolioSubscribePayload {
   provider?: string
   serviceId?: string
   portfolioIdentity?: PortfolioIdentity | null
-  workspaceId?: string
   window?: TradingPortfolioPerformanceWindow
   channel?: TradingPortfolioChannel
   clientSubscriptionId?: string
@@ -66,7 +65,6 @@ export interface TradingPortfolioSubscriptionInfo {
   provider: TradingProviderId
   serviceId?: string
   portfolioIdentity?: PortfolioIdentity
-  workspaceId: string
   channel: TradingPortfolioChannel
   window?: TradingPortfolioPerformanceWindow
 }
@@ -80,7 +78,6 @@ interface TradingPortfolioSubscriptionRecord extends TradingPortfolioSubscriptio
 interface TradingPortfolioStreamState {
   streamKey: string
   userId: string
-  workspaceId: string
   providerId: TradingProviderId
   serviceId?: string
   portfolioIdentity?: PortfolioIdentity
@@ -101,7 +98,6 @@ interface AccountsCacheEntry {
 type TradingPortfolioBasePayload = {
   provider: TradingProviderId
   serviceId?: string
-  workspaceId: string
   channel: TradingPortfolioChannel
   receivedAt: string
 }
@@ -157,7 +153,6 @@ export class TradingPortfolioStreamManager {
     if (!userId) throw new Error('Authentication required')
 
     const providerId = resolveTradingProviderId(payload.provider, payload.portfolioIdentity)
-    const workspaceId = resolveWorkspaceId(payload.workspaceId)
 
     const channel = resolveChannel(payload.channel)
     const serviceId = resolveServiceId(
@@ -168,7 +163,6 @@ export class TradingPortfolioStreamManager {
     const window = resolvePerformanceWindow(providerId, channel, payload.window)
     const streamKey = buildStreamKey({
       userId,
-      workspaceId,
       providerId,
       serviceId,
       portfolioIdentity,
@@ -178,7 +172,6 @@ export class TradingPortfolioStreamManager {
     const streamState = this.getOrCreateStreamState({
       streamKey,
       userId,
-      workspaceId,
       providerId,
       serviceId,
       portfolioIdentity,
@@ -199,7 +192,6 @@ export class TradingPortfolioStreamManager {
       provider: providerId,
       serviceId,
       portfolioIdentity,
-      workspaceId,
       channel,
       window,
     }
@@ -221,7 +213,6 @@ export class TradingPortfolioStreamManager {
       providerId,
       serviceId,
       portfolioIdentity: redactPortfolioIdentity(portfolioIdentity),
-      workspaceId,
       channel,
       window,
     })
@@ -232,7 +223,6 @@ export class TradingPortfolioStreamManager {
       provider: providerId,
       serviceId,
       portfolioIdentity,
-      workspaceId,
       channel,
       window,
     }
@@ -325,7 +315,6 @@ export class TradingPortfolioStreamManager {
         const payload: TradingPortfolioAccountsPayload = {
           provider: streamState.providerId,
           serviceId: streamState.serviceId,
-          workspaceId: streamState.workspaceId,
           channel: 'accounts',
           portfolioIdentities,
           receivedAt: new Date().toISOString(),
@@ -350,7 +339,6 @@ export class TradingPortfolioStreamManager {
         const payload: TradingPortfolioSnapshotPayload = {
           provider: streamState.providerId,
           serviceId: streamState.serviceId,
-          workspaceId: streamState.workspaceId,
           channel: 'account-snapshot',
           portfolioIdentity: toPortfolioValueObject(portfolioDetail) ?? portfolioIdentity,
           portfolioDetail,
@@ -377,7 +365,6 @@ export class TradingPortfolioStreamManager {
       const payload: TradingPortfolioPerformancePayload = {
         provider: streamState.providerId,
         serviceId: streamState.serviceId,
-        workspaceId: streamState.workspaceId,
         channel: 'portfolio-performance',
         portfolioIdentity,
         window: streamState.window,
@@ -507,7 +494,6 @@ export class TradingPortfolioStreamManager {
         provider: record.provider,
         serviceId: record.serviceId,
         portfolioIdentity: record.portfolioIdentity,
-        workspaceId: record.workspaceId,
         channel: record.channel,
         window: record.window,
         subscriptionId: record.subscriptionId,
@@ -579,7 +565,6 @@ export class TradingPortfolioStreamManager {
       provider: record.provider,
       serviceId: record.serviceId,
       portfolioIdentity: redactPortfolioIdentity(record.portfolioIdentity),
-      workspaceId: record.workspaceId,
       channel: record.channel,
       window: record.window,
     })
@@ -641,12 +626,6 @@ function resolveTradingProviderId(
   return providerId as TradingProviderId
 }
 
-function resolveWorkspaceId(workspaceId?: string) {
-  const trimmed = workspaceId?.trim()
-  if (!trimmed) throw new Error('workspaceId is required')
-  return trimmed
-}
-
 function resolveServiceId(providerId: TradingProviderId, serviceId?: string) {
   const resolvedServiceId = getTradingProviderOAuthServiceId(providerId, serviceId)
   if (!resolvedServiceId) throw new Error('Trading provider connection is required')
@@ -701,7 +680,6 @@ function resolvePerformanceWindow(
 
 function buildStreamKey(config: {
   userId: string
-  workspaceId: string
   providerId: TradingProviderId
   serviceId?: string
   portfolioIdentity?: PortfolioIdentity
@@ -712,7 +690,6 @@ function buildStreamKey(config: {
     .update(
       [
         config.userId,
-        config.workspaceId,
         config.providerId,
         config.serviceId ?? '',
         config.channel,
@@ -728,7 +705,6 @@ function buildAccountsCacheKey(streamState: TradingPortfolioStreamState) {
     .update(
       [
         streamState.userId,
-        streamState.workspaceId,
         streamState.providerId,
         streamState.serviceId ?? '',
       ].join('|')
@@ -757,7 +733,6 @@ function toSubscriptionInfo(
     provider: record.provider,
     serviceId: record.serviceId,
     portfolioIdentity: record.portfolioIdentity,
-    workspaceId: record.workspaceId,
     channel: record.channel,
     window: record.window,
   }

--- a/apps/tradinggoose/socket-server/trading/portfolio-manager.ts
+++ b/apps/tradinggoose/socket-server/trading/portfolio-manager.ts
@@ -341,7 +341,7 @@ export class TradingPortfolioStreamManager {
       if (streamState.channel === 'account-snapshot') {
         const portfolioDetail = await getPortfolioDetail({
           providerId: context.providerId,
-          credentialId: context.credentialId,
+          tokenAccountId: context.tokenAccountId,
           serviceId: context.serviceId,
           environment: context.environment,
           accessToken: context.accessToken,
@@ -367,7 +367,7 @@ export class TradingPortfolioStreamManager {
 
       const performance = await getTradingAccountPerformance({
         providerId: context.providerId,
-        credentialId: context.credentialId,
+        tokenAccountId: context.tokenAccountId,
         serviceId: context.serviceId,
         environment: context.environment,
         accessToken: context.accessToken,
@@ -597,21 +597,21 @@ async function resolveTradingPortfolioContext(
   const serviceId = getTradingProviderOAuthServiceId(streamState.providerId, streamState.serviceId)
   if (!serviceId) throw new Error('Trading provider OAuth service is not configured')
 
-  const credentialId = streamState.portfolioIdentity?.credentialId
-  if (!credentialId) throw new Error('portfolioIdentity credential is required')
+  const tokenAccountId = streamState.portfolioIdentity?.tokenAccountId
+  if (!tokenAccountId) throw new Error('portfolioIdentity token account is required')
 
-  const credentialAccount = await resolveOAuthConnectionAccountForUser({
-    accountId: credentialId,
+  const connectionAccount = await resolveOAuthConnectionAccountForUser({
+    accountId: tokenAccountId,
     userId: streamState.userId,
   })
-  if (!credentialAccount) throw new Error('Trading provider connection not found')
-  if (credentialAccount.providerId !== serviceId) {
+  if (!connectionAccount) throw new Error('Trading provider connection not found')
+  if (connectionAccount.providerId !== serviceId) {
     throw new Error('Trading provider connection does not match requested service')
   }
 
   const accessToken = await refreshAccessTokenIfNeeded(
-    credentialAccount.tokenAccountId,
-    credentialAccount.credentialOwnerUserId,
+    connectionAccount.tokenAccountId,
+    connectionAccount.credentialOwnerUserId,
     streamState.streamKey
   )
   if (!accessToken) throw new Error('Trading provider connection not found')
@@ -620,7 +620,7 @@ async function resolveTradingPortfolioContext(
 
   return {
     providerId: streamState.providerId,
-    credentialId,
+    tokenAccountId,
     serviceId: serviceId,
     environment,
     accessToken,
@@ -678,7 +678,7 @@ function resolvePortfolioIdentity(
     throw new Error('portfolioIdentity provider does not match subscription provider')
   }
   if (portfolioIdentity.serviceId !== serviceId) {
-    throw new Error('portfolioIdentity credential does not match subscription credential')
+    throw new Error('portfolioIdentity service does not match subscription service')
   }
   return portfolioIdentity
 }

--- a/apps/tradinggoose/socket-server/trading/portfolio-manager.ts
+++ b/apps/tradinggoose/socket-server/trading/portfolio-manager.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'crypto'
-import { resolveOAuthCredentialAccountForUser } from '@/lib/credentials/oauth'
+import { resolveOAuthConnectionAccountForUser } from '@/lib/credentials/oauth'
 import { createLogger } from '@/lib/logs/console/logger'
 import { refreshAccessTokenIfNeeded } from '@/lib/oauth/tokens'
 import { listTradingPortfolioIdentities } from '@/lib/trading/portfolio-identities'
@@ -394,7 +394,6 @@ export class TradingPortfolioStreamManager {
 
     const promise = listTradingPortfolioIdentities({
       userId: streamState.userId,
-      workspaceId: streamState.workspaceId,
       providerId: streamState.providerId,
       serviceId: streamState.serviceId,
       requestId: streamState.streamKey,
@@ -583,10 +582,9 @@ async function resolveTradingPortfolioContext(
   const credentialId = streamState.portfolioIdentity?.credentialId
   if (!credentialId) throw new Error('portfolioIdentity credential is required')
 
-  const credentialAccount = await resolveOAuthCredentialAccountForUser({
-    credentialId,
+  const credentialAccount = await resolveOAuthConnectionAccountForUser({
+    accountId: credentialId,
     userId: streamState.userId,
-    workspaceId: streamState.workspaceId,
   })
   if (!credentialAccount) throw new Error('Trading provider connection not found')
   if (credentialAccount.providerId !== serviceId) {
@@ -594,7 +592,7 @@ async function resolveTradingPortfolioContext(
   }
 
   const accessToken = await refreshAccessTokenIfNeeded(
-    credentialAccount.accountId,
+    credentialAccount.tokenAccountId,
     credentialAccount.credentialOwnerUserId,
     streamState.streamKey
   )

--- a/apps/tradinggoose/socket-server/trading/portfolio-manager.ts
+++ b/apps/tradinggoose/socket-server/trading/portfolio-manager.ts
@@ -151,7 +151,8 @@ export class TradingPortfolioStreamManager {
     socket: AuthenticatedSocket,
     payload: TradingPortfolioSubscribePayload
   ): Promise<TradingPortfolioSubscriptionInfo> {
-    this.stopped = false
+    if (this.stopped) throw new Error('Trading portfolio stream manager is stopped')
+
     const userId = socket.userId
     if (!userId) throw new Error('Authentication required')
 

--- a/apps/tradinggoose/tools/trading/action.test.ts
+++ b/apps/tradinggoose/tools/trading/action.test.ts
@@ -3,13 +3,13 @@ import { tradingActionTool } from '@/tools/trading/action'
 
 const portfolioIdentity = {
   providerId: 'alpaca' as const,
-  credentialId: 'credential-1',
+  tokenAccountId: 'oauth-account-1',
   serviceId: 'alpaca-live',
   accountId: 'ACC-1',
 }
 const tradierPortfolioIdentity = {
   providerId: 'tradier' as const,
-  credentialId: 'credential-2',
+  tokenAccountId: 'oauth-account-2',
   serviceId: 'tradier-live',
   accountId: 'ACC-2',
 }
@@ -51,7 +51,6 @@ describe('tradingActionTool canonical order route payload', () => {
       timeInForce: 'day',
       quantity: 2,
     })
-    expect(body).not.toHaveProperty('credential')
     expect(body).not.toHaveProperty('accessToken')
     expect(body).not.toHaveProperty('accountId')
   })

--- a/apps/tradinggoose/tools/trading/holdings.test.ts
+++ b/apps/tradinggoose/tools/trading/holdings.test.ts
@@ -1,4 +1,3 @@
-import { NextRequest } from 'next/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const getPortfolioDetailMock = vi.fn()
@@ -53,12 +52,9 @@ describe('tradingHoldingsTool', () => {
   })
 
   it('fetches holdings for the selected portfolioIdentity account', async () => {
-    const request = new NextRequest('http://localhost/api/tools/trading/holdings')
     const result = await getTradingHoldings({
-      request,
       requestData: {
         portfolioIdentity,
-        workspaceId: 'workspace-1',
       },
       requestId: 'request-1',
       userId: 'user-1',
@@ -107,15 +103,12 @@ describe('tradingHoldingsTool', () => {
   })
 
   it('authorizes the selected portfolio credential before broker calls', async () => {
-    const request = new NextRequest('http://localhost/api/tools/trading/holdings')
     authorizeTradingCredentialRequestMock.mockRejectedValue(new Error('Unauthorized'))
 
     await expect(
       getTradingHoldings({
-        request,
         requestData: {
           portfolioIdentity,
-          workspaceId: 'workspace-1',
         },
         requestId: 'request-1',
         userId: 'user-1',

--- a/apps/tradinggoose/tools/trading/holdings.test.ts
+++ b/apps/tradinggoose/tools/trading/holdings.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const getPortfolioDetailMock = vi.fn()
-const authorizeTradingCredentialRequestMock = vi.fn()
+const authorizeTradingConnectionRequestMock = vi.fn()
 const resolveTradingProviderContextMock = vi.fn()
 const resolveTradingProviderSelectedAccountMock = vi.fn()
 
@@ -10,8 +10,8 @@ vi.mock('@/providers/trading/portfolio', () => ({
 }))
 
 vi.mock('@/lib/trading/context', () => ({
-  authorizeTradingCredentialRequest: (...args: unknown[]) =>
-    authorizeTradingCredentialRequestMock(...args),
+  authorizeTradingConnectionRequest: (...args: unknown[]) =>
+    authorizeTradingConnectionRequestMock(...args),
   resolveTradingProviderContext: (...args: unknown[]) => resolveTradingProviderContextMock(...args),
   resolveTradingProviderSelectedAccount: (...args: unknown[]) =>
     resolveTradingProviderSelectedAccountMock(...args),
@@ -22,7 +22,7 @@ import { tradingHoldingsTool } from '@/tools/trading/holdings'
 
 const portfolioIdentity = {
   providerId: 'tradier',
-  credentialId: 'credential-1',
+  tokenAccountId: 'oauth-account-1',
   serviceId: 'tradier-live',
   accountId: 'ACC-2',
 }
@@ -31,15 +31,14 @@ describe('tradingHoldingsTool', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     getPortfolioDetailMock.mockResolvedValue({ accountId: 'ACC-2' })
-    authorizeTradingCredentialRequestMock.mockResolvedValue({
-      credentialOwnerUserId: 'user-1',
-      tokenAccountId: 'account-credential-1',
+    authorizeTradingConnectionRequestMock.mockResolvedValue({
+      connectionOwnerUserId: 'user-1',
       accountProviderId: 'tradier-live',
     })
     resolveTradingProviderContextMock.mockResolvedValue({
       requestId: 'request-1',
       providerId: 'tradier',
-      credentialId: 'credential-1',
+      tokenAccountId: 'oauth-account-1',
       serviceId: 'tradier-live',
       environment: 'live',
       accessToken: 'access-token',
@@ -67,18 +66,17 @@ describe('tradingHoldingsTool', () => {
     expect(resolveTradingProviderContextMock).toHaveBeenCalledWith({
       requestData: {
         provider: 'tradier',
-        credentialId: 'credential-1',
+        tokenAccountId: 'oauth-account-1',
         serviceId: 'tradier-live',
       },
       requestId: 'request-1',
       userId: 'user-1',
-      credentialOwnerUserId: 'user-1',
-      tokenAccountId: 'account-credential-1',
+      connectionOwnerUserId: 'user-1',
       accountProviderId: 'tradier-live',
     })
     expect(getPortfolioDetailMock).toHaveBeenCalledWith({
       providerId: 'tradier',
-      credentialId: 'credential-1',
+      tokenAccountId: 'oauth-account-1',
       serviceId: 'tradier-live',
       environment: 'live',
       accessToken: 'access-token',
@@ -102,8 +100,8 @@ describe('tradingHoldingsTool', () => {
     })
   })
 
-  it('authorizes the selected portfolio credential before broker calls', async () => {
-    authorizeTradingCredentialRequestMock.mockRejectedValue(new Error('Unauthorized'))
+  it('authorizes the selected portfolio connection before broker calls', async () => {
+    authorizeTradingConnectionRequestMock.mockRejectedValue(new Error('Unauthorized'))
 
     await expect(
       getTradingHoldings({
@@ -115,8 +113,8 @@ describe('tradingHoldingsTool', () => {
       })
     ).rejects.toThrow('Unauthorized')
 
-    expect(authorizeTradingCredentialRequestMock).toHaveBeenCalledWith({
-      credentialId: 'credential-1',
+    expect(authorizeTradingConnectionRequestMock).toHaveBeenCalledWith({
+      tokenAccountId: 'oauth-account-1',
       userId: 'user-1',
     })
     expect(resolveTradingProviderContextMock).not.toHaveBeenCalled()

--- a/apps/tradinggoose/tools/trading/holdings.test.ts
+++ b/apps/tradinggoose/tools/trading/holdings.test.ts
@@ -100,7 +100,7 @@ describe('tradingHoldingsTool', () => {
     })
   })
 
-  it('requires workspace scope for credential-owned portfolio reads', () => {
+  it('declares workspace read scope for tool execution', () => {
     expect(tradingHoldingsTool.execution).toEqual({
       workspace: { required: true, access: 'read' },
     })
@@ -123,10 +123,8 @@ describe('tradingHoldingsTool', () => {
     ).rejects.toThrow('Unauthorized')
 
     expect(authorizeTradingCredentialRequestMock).toHaveBeenCalledWith({
-      request,
       credentialId: 'credential-1',
-      workspaceId: 'workspace-1',
-      workflowId: undefined,
+      userId: 'user-1',
     })
     expect(resolveTradingProviderContextMock).not.toHaveBeenCalled()
     expect(getPortfolioDetailMock).not.toHaveBeenCalled()

--- a/apps/tradinggoose/widgets/utils/heatmap-params.test.ts
+++ b/apps/tradinggoose/widgets/utils/heatmap-params.test.ts
@@ -3,7 +3,7 @@ import { sanitizeHeatmapParams } from '@/widgets/utils/heatmap-params'
 
 const portfolioIdentity = {
   providerId: 'alpaca',
-  credentialId: 'credential-1',
+  tokenAccountId: 'oauth-account-1',
   serviceId: 'alpaca-live',
   accountId: 'account-1',
 }

--- a/apps/tradinggoose/widgets/utils/portfolio-snapshot-params.test.tsx
+++ b/apps/tradinggoose/widgets/utils/portfolio-snapshot-params.test.tsx
@@ -13,7 +13,7 @@ import {
 
 const portfolioIdentity = {
   providerId: 'alpaca',
-  credentialId: 'credential-1',
+  tokenAccountId: 'oauth-account-1',
   serviceId: 'alpaca-live',
   accountId: 'acct-1',
 }

--- a/apps/tradinggoose/widgets/utils/quick-order-params.test.tsx
+++ b/apps/tradinggoose/widgets/utils/quick-order-params.test.tsx
@@ -13,7 +13,7 @@ import {
 
 const portfolioIdentity = {
   providerId: 'alpaca',
-  credentialId: 'credential-1',
+  tokenAccountId: 'oauth-account-1',
   serviceId: 'alpaca-live',
   accountId: 'acct-1',
 }

--- a/apps/tradinggoose/widgets/widgets/components/trading-account-selector.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/components/trading-account-selector.test.tsx
@@ -101,7 +101,6 @@ describe('TradingAccountSelector', () => {
     expect(mockUseTradingServices).toHaveBeenCalledWith({
       providerId: 'alpaca',
       serviceId: 'alpaca-live',
-      workspaceId: 'workspace-1',
       enabled: true,
     })
     expect(mockUsePortfolioIdentities).toHaveBeenCalledWith({

--- a/apps/tradinggoose/widgets/widgets/components/trading-account-selector.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/components/trading-account-selector.test.tsx
@@ -104,7 +104,6 @@ describe('TradingAccountSelector', () => {
       enabled: true,
     })
     expect(mockUsePortfolioIdentities).toHaveBeenCalledWith({
-      workspaceId: 'workspace-1',
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       enabled: true,

--- a/apps/tradinggoose/widgets/widgets/components/trading-account-selector.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/components/trading-account-selector.test.tsx
@@ -87,7 +87,6 @@ describe('TradingAccountSelector', () => {
       root.render(
         <TooltipProvider>
           <TradingAccountSelector
-            workspaceId='workspace-1'
             providerId='alpaca'
             serviceId='alpaca-live'
             portfolioIdentity={selectedPortfolioIdentity}
@@ -115,7 +114,6 @@ describe('TradingAccountSelector', () => {
       root.render(
         <TooltipProvider>
           <TradingAccountSelector
-            workspaceId='workspace-1'
             providerId='alpaca'
             serviceId='alpaca-live'
             portfolioIdentity={selectedPortfolioIdentity}
@@ -162,7 +160,6 @@ describe('TradingAccountSelector', () => {
       root.render(
         <TooltipProvider>
           <TradingAccountSelector
-            workspaceId='workspace-1'
             providerId='alpaca'
             serviceId='alpaca-live'
             portfolioIdentity={{
@@ -186,7 +183,6 @@ describe('TradingAccountSelector', () => {
       root.render(
         <TooltipProvider>
           <TradingAccountSelector
-            workspaceId='workspace-1'
             providerId='alpaca'
             serviceId='alpaca-live'
             portfolioIdentity={{

--- a/apps/tradinggoose/widgets/widgets/components/trading-account-selector.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/components/trading-account-selector.test.tsx
@@ -26,7 +26,7 @@ describe('TradingAccountSelector', () => {
   let root: Root
   const selectedPortfolioIdentity: PortfolioIdentity = {
     providerId: 'alpaca',
-    credentialId: 'credential-1',
+    tokenAccountId: 'oauth-account-1',
     serviceId: 'alpaca-live',
     accountId: 'acct-1',
   }
@@ -59,7 +59,7 @@ describe('TradingAccountSelector', () => {
         },
         {
           providerId: 'alpaca',
-          credentialId: 'credential-2',
+          tokenAccountId: 'oauth-account-2',
           serviceId: 'alpaca-live',
           accountId: 'acct-2',
           accountName: 'Live Account',
@@ -168,7 +168,7 @@ describe('TradingAccountSelector', () => {
             serviceId='alpaca-live'
             portfolioIdentity={{
               providerId: 'alpaca',
-              credentialId: 'credential-1',
+              tokenAccountId: 'oauth-account-1',
               serviceId: 'alpaca-live',
               accountId: '8b594a8c-1353-40d0-981c-e022a879e0e0',
             }}
@@ -192,7 +192,7 @@ describe('TradingAccountSelector', () => {
             serviceId='alpaca-live'
             portfolioIdentity={{
               providerId: 'alpaca',
-              credentialId: 'credential-1',
+              tokenAccountId: 'oauth-account-1',
               serviceId: 'alpaca-live',
               accountId: 'stale-account-id',
             }}

--- a/apps/tradinggoose/widgets/widgets/components/trading-account-selector.tsx
+++ b/apps/tradinggoose/widgets/widgets/components/trading-account-selector.tsx
@@ -37,7 +37,6 @@ export type TradingAccountSelection = {
 }
 
 type TradingAccountSelectorProps = {
-  workspaceId?: string | null
   providerId?: string | null
   serviceId?: string | null
   portfolioIdentity?: PortfolioIdentity | null

--- a/apps/tradinggoose/widgets/widgets/components/trading-account-selector.tsx
+++ b/apps/tradinggoose/widgets/widgets/components/trading-account-selector.tsx
@@ -68,7 +68,6 @@ const getAccountDescription = (providerId: string, portfolioIdentity: PortfolioI
     .join(' - ')
 
 export function TradingAccountSelector({
-  workspaceId,
   providerId,
   serviceId,
   portfolioIdentity,
@@ -80,14 +79,13 @@ export function TradingAccountSelector({
 }: TradingAccountSelectorProps) {
   const [showOAuthModal, setShowOAuthModal] = useState(false)
   const [oauthModalServiceId, setOAuthModalServiceId] = useState<string | null>(null)
-  const trimmedWorkspaceId = typeof workspaceId === 'string' ? workspaceId.trim() : ''
   const trimmedProviderId = typeof providerId === 'string' ? providerId.trim() : ''
   const providerDefinition = trimmedProviderId
     ? getTradingProviderDefinition(trimmedProviderId)
     : undefined
   const providerName = providerDefinition?.name ?? 'broker'
   const oauthProvider = providerDefinition?.oauth?.provider
-  const isEnabled = Boolean(trimmedWorkspaceId && trimmedProviderId) && !disabled
+  const isEnabled = Boolean(trimmedProviderId) && !disabled
   const selectedPortfolioIdentity = toPortfolioValueObject(portfolioIdentity)
   const requestedServiceId = serviceId ?? selectedPortfolioIdentity?.serviceId
   const services = useTradingServices({
@@ -98,7 +96,6 @@ export function TradingAccountSelector({
   const activeServiceId = services.activeServiceId
   const hasConnection = Boolean(activeServiceId)
   const accountsQuery = usePortfolioIdentities({
-    workspaceId: trimmedWorkspaceId || undefined,
     provider: trimmedProviderId || undefined,
     serviceId: activeServiceId,
     enabled: isEnabled && hasConnection,

--- a/apps/tradinggoose/widgets/widgets/components/trading-account-selector.tsx
+++ b/apps/tradinggoose/widgets/widgets/components/trading-account-selector.tsx
@@ -93,7 +93,6 @@ export function TradingAccountSelector({
   const services = useTradingServices({
     providerId: trimmedProviderId,
     serviceId: requestedServiceId,
-    workspaceId: trimmedWorkspaceId,
     enabled: isEnabled,
   })
   const activeServiceId = services.activeServiceId

--- a/apps/tradinggoose/widgets/widgets/components/trading-provider-controls.tsx
+++ b/apps/tradinggoose/widgets/widgets/components/trading-provider-controls.tsx
@@ -13,7 +13,6 @@ import {
 import { widgetHeaderButtonGroupClassName } from '@/widgets/widgets/components/widget-header-control'
 
 type TradingProviderControlsProps = {
-  workspaceId?: string | null
   providerId?: string | null
   providerOptions: TradingProviderOption[]
   onProviderChange?: (providerId: string) => void
@@ -29,7 +28,6 @@ type TradingProviderControlsProps = {
 }
 
 export function TradingProviderControls({
-  workspaceId,
   providerId,
   providerOptions,
   onProviderChange,
@@ -57,7 +55,6 @@ export function TradingProviderControls({
       />
       {hasSelectedProvider ? (
         <TradingAccountSelector
-          workspaceId={workspaceId}
           providerId={selectedProviderId}
           serviceId={serviceId}
           portfolioIdentity={portfolioIdentity}

--- a/apps/tradinggoose/widgets/widgets/components/trading-services.ts
+++ b/apps/tradinggoose/widgets/widgets/components/trading-services.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { getServiceByProviderAndId } from '@/lib/oauth'
-import { useOAuthCredentialsByProviderIds } from '@/hooks/queries/oauth-credentials'
+import { useOAuthConnections } from '@/hooks/queries/oauth-connections'
 import {
   getTradingProviderDefinition,
   getTradingProviderOAuthServiceIds,
@@ -33,30 +33,24 @@ export function resolveActiveTradingServiceId({
 export function useTradingServices({
   providerId,
   serviceId,
-  workspaceId,
   enabled = true,
 }: {
   providerId?: string | null
   serviceId?: string | null
-  workspaceId?: string | null
   enabled?: boolean
 }): TradingServiceState {
   const trimmedProviderId = typeof providerId === 'string' ? providerId.trim() : ''
-  const trimmedWorkspaceId = typeof workspaceId === 'string' ? workspaceId.trim() : ''
   const providerDefinition = trimmedProviderId
     ? getTradingProviderDefinition(trimmedProviderId)
     : undefined
   const serviceIds = providerDefinition
     ? getTradingProviderOAuthServiceIds(providerDefinition.id)
     : []
-  const credentialsQuery = useOAuthCredentialsByProviderIds(
-    serviceIds,
-    enabled && Boolean(trimmedProviderId),
-    trimmedWorkspaceId ? { workspaceId: trimmedWorkspaceId } : undefined
-  )
-  const credentialsByProviderId = credentialsQuery.data ?? {}
-  const connectedServiceIds = serviceIds.filter(
-    (serviceId) => (credentialsByProviderId[serviceId]?.length ?? 0) > 0
+  const connectionsQuery = useOAuthConnections()
+  const connectedServiceIds = serviceIds.filter((serviceId) =>
+    (connectionsQuery.data ?? []).some(
+      (service) => service.providerId === serviceId && service.isConnected
+    )
   )
   const activeServiceId = resolveActiveTradingServiceId({
     serviceId,
@@ -67,10 +61,10 @@ export function useTradingServices({
     serviceIds,
     connectedServiceIds,
     activeServiceId,
-    isLoading: credentialsQuery.isLoading,
-    error: credentialsQuery.error instanceof Error ? credentialsQuery.error : null,
+    isLoading: enabled && Boolean(trimmedProviderId) ? connectionsQuery.isLoading : false,
+    error: connectionsQuery.error instanceof Error ? connectionsQuery.error : null,
     refetch: () => {
-      void credentialsQuery.refetch()
+      void connectionsQuery.refetch()
     },
   }
 }

--- a/apps/tradinggoose/widgets/widgets/components/trading-services.ts
+++ b/apps/tradinggoose/widgets/widgets/components/trading-services.ts
@@ -46,11 +46,11 @@ export function useTradingServices({
   const serviceIds = providerDefinition
     ? getTradingProviderOAuthServiceIds(providerDefinition.id)
     : []
-  const connectionsQuery = useOAuthConnections()
+  const isQueryEnabled = enabled && Boolean(trimmedProviderId)
+  const connectionsQuery = useOAuthConnections({ enabled: isQueryEnabled })
+  const connections = isQueryEnabled ? (connectionsQuery.data ?? []) : []
   const connectedServiceIds = serviceIds.filter((serviceId) =>
-    (connectionsQuery.data ?? []).some(
-      (service) => service.providerId === serviceId && service.isConnected
-    )
+    connections.some((service) => service.providerId === serviceId && service.isConnected)
   )
   const activeServiceId = resolveActiveTradingServiceId({
     serviceId,
@@ -61,8 +61,8 @@ export function useTradingServices({
     serviceIds,
     connectedServiceIds,
     activeServiceId,
-    isLoading: enabled && Boolean(trimmedProviderId) ? connectionsQuery.isLoading : false,
-    error: connectionsQuery.error instanceof Error ? connectionsQuery.error : null,
+    isLoading: isQueryEnabled ? connectionsQuery.isLoading : false,
+    error: isQueryEnabled && connectionsQuery.error instanceof Error ? connectionsQuery.error : null,
     refetch: () => {
       void connectionsQuery.refetch()
     },

--- a/apps/tradinggoose/widgets/widgets/components/use-portfolio-identity-selection.ts
+++ b/apps/tradinggoose/widgets/widgets/components/use-portfolio-identity-selection.ts
@@ -43,7 +43,6 @@ export function usePortfolioIdentitySelection({
   const services = useTradingServices({
     providerId,
     serviceId: requestedServiceId,
-    workspaceId,
     enabled,
   })
   const activeServiceId = enabled ? services.activeServiceId : undefined

--- a/apps/tradinggoose/widgets/widgets/components/use-portfolio-identity-selection.ts
+++ b/apps/tradinggoose/widgets/widgets/components/use-portfolio-identity-selection.ts
@@ -16,7 +16,6 @@ type EmitPortfolioParamsChange = (input: {
 }) => void
 
 export function usePortfolioIdentitySelection({
-  workspaceId,
   providerId,
   serviceId,
   portfolioIdentity,
@@ -25,7 +24,6 @@ export function usePortfolioIdentitySelection({
   widgetKey,
   emitParamsChange,
 }: {
-  workspaceId?: string | null
   providerId?: string | null
   serviceId?: string | null
   portfolioIdentity?: PortfolioIdentity | null
@@ -47,7 +45,6 @@ export function usePortfolioIdentitySelection({
   })
   const activeServiceId = enabled ? services.activeServiceId : undefined
   const accountsQuery = usePortfolioIdentities({
-    workspaceId: workspaceId ?? undefined,
     provider: enabled ? (providerId ?? undefined) : undefined,
     serviceId: activeServiceId,
     enabled: enabled && Boolean(activeServiceId),

--- a/apps/tradinggoose/widgets/widgets/heatmap/components/body.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/heatmap/components/body.test.tsx
@@ -12,7 +12,7 @@ import { HeatmapWidgetBody } from '@/widgets/widgets/heatmap/components/body'
 const mockUseResolvedListings = vi.fn()
 const mockUseMarketQuoteSnapshots = vi.fn()
 const mockUseOAuthProviderAvailability = vi.fn()
-const mockUseOAuthCredentialsByProviderIds = vi.fn()
+const mockUseOAuthConnections = vi.fn()
 const mockUsePortfolioIdentities = vi.fn()
 const mockUsePortfolioDetail = vi.fn()
 const mockUseWatchlists = vi.fn()
@@ -97,9 +97,8 @@ vi.mock('@/hooks/queries/oauth-provider-availability', () => ({
   useOAuthProviderAvailability: (...args: unknown[]) => mockUseOAuthProviderAvailability(...args),
 }))
 
-vi.mock('@/hooks/queries/oauth-credentials', () => ({
-  useOAuthCredentialsByProviderIds: (...args: unknown[]) =>
-    mockUseOAuthCredentialsByProviderIds(...args),
+vi.mock('@/hooks/queries/oauth-connections', () => ({
+  useOAuthConnections: (...args: unknown[]) => mockUseOAuthConnections(...args),
 }))
 
 vi.mock('@/hooks/queries/trading-portfolio', () => ({
@@ -169,11 +168,9 @@ describe('HeatmapWidgetBody', () => {
     mockUseOAuthProviderAvailability.mockReturnValue(
       createQueryResult({ data: { 'alpaca-live': true, 'alpaca-paper': true } })
     )
-    mockUseOAuthCredentialsByProviderIds.mockReturnValue(
+    mockUseOAuthConnections.mockReturnValue(
       createQueryResult({
-        data: {
-          'alpaca-live': [{ id: 'cred-1', name: 'Alpaca Live', provider: 'alpaca-live' }],
-        },
+        data: [{ providerId: 'alpaca-live', isConnected: true }],
       })
     )
     mockUsePortfolioIdentities.mockReturnValue(createQueryResult({ data: [] }))

--- a/apps/tradinggoose/widgets/widgets/heatmap/components/body.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/heatmap/components/body.test.tsx
@@ -427,7 +427,6 @@ describe('HeatmapWidgetBody', () => {
     })
 
     expect(mockUsePortfolioDetail).toHaveBeenLastCalledWith({
-      workspaceId: 'workspace-1',
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       portfolioIdentity,

--- a/apps/tradinggoose/widgets/widgets/heatmap/components/body.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/heatmap/components/body.test.tsx
@@ -21,7 +21,7 @@ const mockEmitHeatmapParamsChange = vi.fn()
 
 const portfolioIdentity = {
   providerId: 'alpaca',
-  credentialId: 'credential-1',
+  tokenAccountId: 'oauth-account-1',
   serviceId: 'alpaca-live',
   accountId: 'account-1',
   accountName: 'Paper',

--- a/apps/tradinggoose/widgets/widgets/heatmap/components/body.tsx
+++ b/apps/tradinggoose/widgets/widgets/heatmap/components/body.tsx
@@ -143,7 +143,6 @@ export function HeatmapWidgetBody({
     services,
     portfolioIdentities,
   } = usePortfolioIdentitySelection({
-    workspaceId,
     providerId: tradingProviderId,
     serviceId: widgetParams?.serviceId,
     portfolioIdentity: widgetParams?.portfolioIdentity,
@@ -154,7 +153,6 @@ export function HeatmapWidgetBody({
   })
 
   const snapshotQuery = usePortfolioDetail({
-    workspaceId: workspaceId ?? undefined,
     provider: sourceMode === 'portfolio' && isTradingProviderReady ? tradingProviderId : undefined,
     serviceId: activeServiceId,
     portfolioIdentity: activePortfolioIdentity,

--- a/apps/tradinggoose/widgets/widgets/heatmap/components/header.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/heatmap/components/header.test.tsx
@@ -19,7 +19,7 @@ type MockTradingAccountSelectorProps = {
 }
 const selectedPortfolioIdentity: PortfolioIdentity = {
   providerId: 'alpaca',
-  credentialId: 'credential-1',
+  tokenAccountId: 'oauth-account-1',
   serviceId: 'alpaca-paper',
   accountId: 'acct-1',
 }

--- a/apps/tradinggoose/widgets/widgets/heatmap/components/header.tsx
+++ b/apps/tradinggoose/widgets/widgets/heatmap/components/header.tsx
@@ -132,7 +132,7 @@ function HeatmapWatchlistSizeControls({ panelId, widgetKey, params }: HeaderCont
   )
 }
 
-function HeatmapPortfolioControls({ workspaceId, panelId, widgetKey, params }: HeaderControlProps) {
+function HeatmapPortfolioControls({ panelId, widgetKey, params }: HeaderControlProps) {
   const providerAvailabilityQuery = useOAuthProviderAvailability(
     getHeatmapTradingProviderAvailabilityIds()
   )
@@ -144,7 +144,6 @@ function HeatmapPortfolioControls({ workspaceId, panelId, widgetKey, params }: H
 
   return (
     <TradingProviderControls
-      workspaceId={workspaceId}
       providerId={providerId}
       providerOptions={providerOptions}
       serviceId={params?.serviceId}

--- a/apps/tradinggoose/widgets/widgets/portfolio_snapshot/components/body.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/portfolio_snapshot/components/body.test.tsx
@@ -17,7 +17,7 @@ const mockEmitPortfolioSnapshotParamsChange = vi.fn()
 
 const selectedPortfolioIdentity = {
   providerId: 'alpaca',
-  credentialId: 'credential-1',
+  tokenAccountId: 'oauth-account-1',
   serviceId: 'alpaca-live',
   accountId: 'acct-1',
   accountName: 'Paper',
@@ -232,7 +232,7 @@ describe('PortfolioSnapshotWidgetBody', () => {
   it('clears the saved account when the saved service has disconnected', async () => {
     const connectedPaperIdentity = {
       ...selectedPortfolioIdentity,
-      credentialId: 'cred-paper',
+      tokenAccountId: 'oauth-account-paper',
       serviceId: 'alpaca-paper',
       accountId: 'paper-acct',
       accountName: 'Paper Account',
@@ -347,7 +347,7 @@ describe('PortfolioSnapshotWidgetBody', () => {
     const tradierPortfolioIdentity = {
       ...selectedPortfolioIdentity,
       providerId: 'tradier',
-      credentialId: 'credential-2',
+      tokenAccountId: 'oauth-account-2',
       serviceId: 'tradier-live',
     }
     mockUsePortfolioIdentities.mockReturnValue(
@@ -742,7 +742,7 @@ describe('PortfolioSnapshotWidgetBody', () => {
     })
   })
 
-  it('requires selecting a provider before loading credentials or accounts', async () => {
+  it('requires selecting a provider before loading connections or accounts', async () => {
     mockUsePortfolioIdentities.mockReturnValueOnce(createQueryResult({ data: [] }))
 
     await act(async () => {

--- a/apps/tradinggoose/widgets/widgets/portfolio_snapshot/components/body.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/portfolio_snapshot/components/body.test.tsx
@@ -468,7 +468,6 @@ describe('PortfolioSnapshotWidgetBody', () => {
     expect(container.textContent).toContain('Alpaca · active · paper')
     expect(container.textContent).toContain('performance-chart')
     expect(mockUsePortfolioDetail).toHaveBeenCalledWith({
-      workspaceId: 'workspace-1',
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       portfolioIdentity: selectedPortfolioIdentity,

--- a/apps/tradinggoose/widgets/widgets/portfolio_snapshot/components/body.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/portfolio_snapshot/components/body.test.tsx
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { PortfolioSnapshotWidgetBody } from '@/widgets/widgets/portfolio_snapshot/components/body'
 
 const mockUseOAuthProviderAvailability = vi.fn()
-const mockUseOAuthCredentialsByProviderIds = vi.fn()
+const mockUseOAuthConnections = vi.fn()
 const mockUseMarketQuoteSnapshots = vi.fn()
 const mockUsePortfolioIdentities = vi.fn()
 const mockUsePortfolioDetail = vi.fn()
@@ -81,9 +81,8 @@ vi.mock('@/hooks/queries/oauth-provider-availability', () => ({
   useOAuthProviderAvailability: (...args: unknown[]) => mockUseOAuthProviderAvailability(...args),
 }))
 
-vi.mock('@/hooks/queries/oauth-credentials', () => ({
-  useOAuthCredentialsByProviderIds: (...args: unknown[]) =>
-    mockUseOAuthCredentialsByProviderIds(...args),
+vi.mock('@/hooks/queries/oauth-connections', () => ({
+  useOAuthConnections: (...args: unknown[]) => mockUseOAuthConnections(...args),
 }))
 
 vi.mock('@/hooks/queries/market-quote-snapshots', () => ({
@@ -139,12 +138,12 @@ describe('PortfolioSnapshotWidgetBody', () => {
         },
       })
     )
-    mockUseOAuthCredentialsByProviderIds.mockReturnValue(
+    mockUseOAuthConnections.mockReturnValue(
       createQueryResult({
-        data: {
-          'alpaca-live': [{ id: 'cred-1', name: 'Alpaca Live', provider: 'alpaca-live' }],
-          'tradier-live': [{ id: 'cred-2', name: 'Tradier Live', provider: 'tradier-live' }],
-        },
+        data: [
+          { providerId: 'alpaca-live', isConnected: true },
+          { providerId: 'tradier-live', isConnected: true },
+        ],
       })
     )
     mockUsePortfolioIdentities.mockReturnValue(
@@ -238,11 +237,9 @@ describe('PortfolioSnapshotWidgetBody', () => {
       accountId: 'paper-acct',
       accountName: 'Paper Account',
     }
-    mockUseOAuthCredentialsByProviderIds.mockReturnValue(
+    mockUseOAuthConnections.mockReturnValue(
       createQueryResult({
-        data: {
-          'alpaca-paper': [{ id: 'cred-paper', name: 'Alpaca Paper', provider: 'alpaca-paper' }],
-        },
+        data: [{ providerId: 'alpaca-paper', isConnected: true }],
       })
     )
     mockUsePortfolioIdentities.mockReturnValue(

--- a/apps/tradinggoose/widgets/widgets/portfolio_snapshot/components/body.tsx
+++ b/apps/tradinggoose/widgets/widgets/portfolio_snapshot/components/body.tsx
@@ -271,7 +271,6 @@ export function PortfolioSnapshotWidgetBody({
     services,
     portfolioIdentities,
   } = usePortfolioIdentitySelection({
-    workspaceId,
     providerId,
     serviceId: widgetParams?.serviceId,
     portfolioIdentity: widgetParams?.portfolioIdentity,
@@ -282,7 +281,6 @@ export function PortfolioSnapshotWidgetBody({
   })
 
   const snapshotQuery = usePortfolioDetail({
-    workspaceId: workspaceId ?? undefined,
     provider: isProviderReady ? providerId : undefined,
     serviceId: activeServiceId,
     portfolioIdentity: activePortfolioIdentity,
@@ -324,7 +322,6 @@ export function PortfolioSnapshotWidgetBody({
   })
 
   const performanceQuery = usePortfolioPerformance({
-    workspaceId: workspaceId ?? undefined,
     provider: isProviderReady ? providerId : undefined,
     serviceId: activeServiceId,
     portfolioIdentity: activePortfolioIdentity,

--- a/apps/tradinggoose/widgets/widgets/portfolio_snapshot/components/header.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/portfolio_snapshot/components/header.test.tsx
@@ -22,7 +22,7 @@ const mockTradingAccountSelector = vi.fn(({ onAccountSelect }: MockTradingAccoun
       onAccountSelect?.({
         portfolioIdentity: {
           providerId: 'alpaca',
-          credentialId: 'credential-1',
+          tokenAccountId: 'oauth-account-1',
           serviceId: 'alpaca-live',
           accountId: 'acct-1',
         },
@@ -146,7 +146,7 @@ describe('PortfolioSnapshotHeaderControls', () => {
       provider: 'alpaca',
       portfolioIdentity: {
         providerId: 'alpaca',
-        credentialId: 'credential-1',
+        tokenAccountId: 'oauth-account-1',
         serviceId: 'alpaca-live',
         accountId: 'acct-1',
       },
@@ -220,7 +220,7 @@ describe('PortfolioSnapshotHeaderControls', () => {
       params: {
         portfolioIdentity: {
           providerId: 'alpaca',
-          credentialId: 'credential-1',
+          tokenAccountId: 'oauth-account-1',
           serviceId: 'alpaca-live',
           accountId: 'acct-1',
         },

--- a/apps/tradinggoose/widgets/widgets/portfolio_snapshot/components/header.tsx
+++ b/apps/tradinggoose/widgets/widgets/portfolio_snapshot/components/header.tsx
@@ -81,7 +81,6 @@ export function PortfolioSnapshotHeaderControls({
 
       {areProviderOptionsReady ? (
         <TradingProviderControls
-          workspaceId={workspaceId}
           providerId={providerId}
           providerOptions={providerOptions}
           serviceId={params?.serviceId}

--- a/apps/tradinggoose/widgets/widgets/quick_order/components/body.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/quick_order/components/body.test.tsx
@@ -511,7 +511,6 @@ describe('QuickOrderWidgetBody', () => {
       side: 'buy',
     })
     expect(mockUsePortfolioDetail).toHaveBeenLastCalledWith({
-      workspaceId: 'workspace-1',
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       portfolioIdentity: undefined,

--- a/apps/tradinggoose/widgets/widgets/quick_order/components/body.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/quick_order/components/body.test.tsx
@@ -9,7 +9,7 @@ import { useListingSelectorStore } from '@/stores/market/selector/store'
 import { QuickOrderWidgetBody } from '@/widgets/widgets/quick_order/components/body'
 
 const mockUseOAuthProviderAvailability = vi.fn()
-const mockUseOAuthCredentialsByProviderIds = vi.fn()
+const mockUseOAuthConnections = vi.fn()
 const mockUseMarketQuoteSnapshots = vi.fn()
 const mockUsePortfolioIdentities = vi.fn()
 const mockUsePortfolioDetail = vi.fn()
@@ -68,9 +68,8 @@ vi.mock('@/hooks/queries/oauth-provider-availability', () => ({
   useOAuthProviderAvailability: (...args: unknown[]) => mockUseOAuthProviderAvailability(...args),
 }))
 
-vi.mock('@/hooks/queries/oauth-credentials', () => ({
-  useOAuthCredentialsByProviderIds: (...args: unknown[]) =>
-    mockUseOAuthCredentialsByProviderIds(...args),
+vi.mock('@/hooks/queries/oauth-connections', () => ({
+  useOAuthConnections: (...args: unknown[]) => mockUseOAuthConnections(...args),
 }))
 
 vi.mock('@/hooks/queries/market-quote-snapshots', () => ({
@@ -272,11 +271,12 @@ describe('QuickOrderWidgetBody', () => {
     mockUseOAuthProviderAvailability.mockReturnValue(
       queryResult({ data: { 'alpaca-live': true, 'alpaca-paper': true } })
     )
-    mockUseOAuthCredentialsByProviderIds.mockReturnValue(
+    mockUseOAuthConnections.mockReturnValue(
       queryResult({
-        data: {
-          'alpaca-live': [{ id: 'cred-1', name: 'Alpaca Live', provider: 'alpaca-live' }],
-        },
+        data: [
+          { providerId: 'alpaca-live', isConnected: true },
+          { providerId: 'alpaca-paper', isConnected: true },
+        ],
       })
     )
     mockUsePortfolioIdentities.mockReturnValue(queryResult({ data: [portfolioIdentity] }))
@@ -327,18 +327,14 @@ describe('QuickOrderWidgetBody', () => {
     expect(footerButton).toBeDisabled()
   })
 
-  it('scopes broker connection discovery by workspace', async () => {
+  it('uses user broker connections independently of workspace credential scope', async () => {
     await renderBody(container, root, {
       provider: 'alpaca',
       portfolioIdentity,
       side: 'buy',
     })
 
-    expect(mockUseOAuthCredentialsByProviderIds).toHaveBeenCalledWith(
-      ['alpaca-live', 'alpaca-paper'],
-      true,
-      { workspaceId: 'workspace-1' }
-    )
+    expect(mockUseOAuthConnections).toHaveBeenCalled()
   })
 
   it('keeps listing selector state scoped to a stable trading instance and resets on unmount', async () => {

--- a/apps/tradinggoose/widgets/widgets/quick_order/components/body.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/quick_order/components/body.test.tsx
@@ -20,7 +20,7 @@ const mockReset = vi.fn()
 
 const portfolioIdentity = {
   providerId: 'alpaca',
-  credentialId: 'credential-1',
+  tokenAccountId: 'oauth-account-1',
   serviceId: 'alpaca-live',
   accountId: 'acct-1',
   accountName: 'Paper Account',
@@ -327,7 +327,7 @@ describe('QuickOrderWidgetBody', () => {
     expect(footerButton).toBeDisabled()
   })
 
-  it('uses user broker connections independently of workspace credential scope', async () => {
+  it('uses user broker connections independently of workspace scope', async () => {
     await renderBody(container, root, {
       provider: 'alpaca',
       portfolioIdentity,
@@ -617,7 +617,7 @@ describe('QuickOrderWidgetBody', () => {
       mockMutate.mock.calls[0][1].onSuccess()
     })
     expect(mockPortfolioRefetch).toHaveBeenCalled()
-    expect(mockMutate.mock.calls[0][0]).not.toHaveProperty('credentialId')
+    expect(mockMutate.mock.calls[0][0]).not.toHaveProperty('tokenAccountId')
     expect(mockMutate.mock.calls[0][0]).not.toHaveProperty('serviceId')
     expect(mockMutate.mock.calls[0][0]).not.toHaveProperty('environment')
     expect(mockMutate.mock.calls[0][0]).not.toHaveProperty('accountId')

--- a/apps/tradinggoose/widgets/widgets/quick_order/components/body.tsx
+++ b/apps/tradinggoose/widgets/widgets/quick_order/components/body.tsx
@@ -254,7 +254,6 @@ export function QuickOrderWidgetBody({
     providerOptions.length > 0
   const { accountsQuery, activeServiceId, activePortfolioIdentity, services, portfolioIdentities } =
     usePortfolioIdentitySelection({
-      workspaceId,
       providerId,
       serviceId: quickOrderParams?.serviceId,
       portfolioIdentity: quickOrderParams?.portfolioIdentity,
@@ -264,7 +263,6 @@ export function QuickOrderWidgetBody({
       emitParamsChange: emitQuickOrderParamsChange,
     })
   const accountSnapshotQuery = usePortfolioDetail({
-    workspaceId: workspaceId ?? undefined,
     provider: hasSelectedProvider && areProviderOptionsReady ? providerId : undefined,
     serviceId: activeServiceId,
     portfolioIdentity: activePortfolioIdentity,

--- a/apps/tradinggoose/widgets/widgets/quick_order/components/header.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/quick_order/components/header.test.tsx
@@ -69,7 +69,7 @@ const mockTradingAccountSelector = vi.fn(({ onAccountSelect }: MockTradingAccoun
       onAccountSelect?.({
         portfolioIdentity: {
           providerId: 'alpaca',
-          credentialId: 'credential-1',
+          tokenAccountId: 'oauth-account-1',
           serviceId: 'alpaca-live',
           accountId: 'acct-1',
         },
@@ -373,7 +373,7 @@ describe('QuickOrderHeaderControls', () => {
       params: {
         portfolioIdentity: {
           providerId: 'alpaca',
-          credentialId: 'credential-1',
+          tokenAccountId: 'oauth-account-1',
           serviceId: 'alpaca-live',
           accountId: 'acct-1',
         },

--- a/apps/tradinggoose/widgets/widgets/quick_order/components/header.tsx
+++ b/apps/tradinggoose/widgets/widgets/quick_order/components/header.tsx
@@ -79,7 +79,6 @@ export function QuickOrderHeaderControls({
 
       {areProviderOptionsReady ? (
         <TradingProviderControls
-          workspaceId={workspaceId}
           providerId={providerId}
           providerOptions={providerOptions}
           serviceId={params?.serviceId}

--- a/changelog/May-23-2026.md
+++ b/changelog/May-23-2026.md
@@ -1,0 +1,58 @@
+# May-23-2026
+
+## fix/integrations @ abb26b22 vs origin/staging
+
+### Summary
+- Reworked trading integrations to use user-owned OAuth connection accounts as the canonical broker access source instead of workspace-scoped OAuth credential rows.
+- Simplified trading portfolio identity discovery so the route, block option loader, widgets, order submission, holdings tool, and socket portfolio streams all resolve the same connection-account contract.
+- Added explicit socket portfolio stream shutdown so broker polling stops during server termination instead of waiting for socket disconnect cleanup.
+
+### Branch Scope
+- Compared `14293d1812f587e807200d3e3453e1dacdda2ab1..abb26b229e63122fc9bd8220f20f4da57aad32d4`.
+- `git fetch origin staging` failed because the configured `origin` remote no longer publishes a `staging` ref. I refreshed `upstream/staging` and used its current `14293d18` ref as the actual staging merge-base; the stale local `origin/staging` ref at `44034d37` was not used because it would include staging-only license commits in this branch entry.
+- Uncommitted local changes were not included; the working tree was clean before this changelog edit.
+- Main areas touched: `apps/tradinggoose/lib/credentials/oauth.ts`, `apps/tradinggoose/lib/trading/*`, trading provider API routes, trading widgets, `apps/tradinggoose/socket-server/trading/portfolio-manager.ts`, and their focused tests.
+
+### Key Changes
+- `apps/tradinggoose/lib/credentials/oauth.ts` now exposes `listOAuthConnectionAccountsForUser()` and `resolveOAuthConnectionAccountForUser()` for trading integrations. These helpers read directly from the OAuth `account` table, filter out sign-in providers, and return token account ids plus provider ids for the requesting user.
+- `apps/tradinggoose/lib/trading/context.ts` changed `authorizeTradingCredentialRequest()` to accept only `{ credentialId, userId }` and resolve the selected trading connection through `resolveOAuthConnectionAccountForUser()`. `resolveTradingProviderContext()` still enforces that the resolved account provider matches the requested trading service before token refresh.
+- `apps/tradinggoose/lib/trading/portfolio-identities.ts` now lists portfolio identities from `listOAuthConnectionAccountsForUser()` and emits `PortfolioIdentity.credentialId` as the OAuth token account id. The helper no longer accepts `workspaceId`, so account discovery is tied to the signed-in user's connected broker accounts.
+- `apps/tradinggoose/app/api/providers/trading/portfolio-identities/route.ts` now requires only session auth plus `provider` and optional `serviceId`; it no longer accepts `workspaceId` or `workflowId` or calls workspace/workflow access helpers for account discovery.
+- `apps/tradinggoose/blocks/utils.ts`, `apps/tradinggoose/widgets/widgets/components/trading-services.ts`, `apps/tradinggoose/widgets/widgets/components/trading-account-selector.tsx`, and `apps/tradinggoose/widgets/widgets/components/use-portfolio-identity-selection.ts` were aligned with the route contract. Trading UI service detection now uses `useOAuthConnections()` instead of workspace-scoped `useOAuthCredentialsByProviderIds()`.
+- `apps/tradinggoose/lib/trading/holdings.ts`, `apps/tradinggoose/lib/trading/orders.ts`, and `apps/tradinggoose/lib/trading/order-detail.ts` all route selected broker credentials through `authorizeTradingCredentialRequest({ credentialId, userId })`, then pass the resolved token account id into `resolveTradingProviderContext()`.
+- `apps/tradinggoose/socket-server/trading/portfolio-manager.ts` now uses `resolveOAuthConnectionAccountForUser()` for portfolio stream broker context and calls `listTradingPortfolioIdentities()` without workspace scope. It also adds `TradingPortfolioStreamManager.stop()`, a `stopped` guard in polling/error paths, and cache/subscription cleanup.
+- `apps/tradinggoose/socket-server/index.ts` now calls `tradingPortfolioStreamManager.stop()` during shutdown and closes Socket.IO with `io.close()` before closing Redis and exiting.
+
+### Design Decisions
+- Trading broker access now treats the OAuth connection account as the canonical runtime identity. Workspace-scoped credential authorization remains available for saved workspace credentials, but trading account selection uses the user's direct broker connection because the selected `PortfolioIdentity` comes from connected OAuth accounts.
+- The route and UI no longer pass `workflowId` or `workspaceId` to portfolio identity discovery. Workflows and widgets still carry workspace context for execution and subscription gating, but broker account discovery itself is resolved from the authenticated user's connections.
+- The existing `PortfolioIdentity.credentialId` field name was preserved for compatibility with provider and widget contracts, but its trading value is now the token account id from `account.id`. Follow-on code should not assume this value is a workspace `credential.id`.
+- Socket portfolio polling is now owned by `TradingPortfolioStreamManager.stop()` during process shutdown. The manager clears timers, subscribers, stream state, and account cache in one place so broker polling cannot continue after shutdown begins.
+
+### Shared Contracts and Helpers to Reuse
+- Use `listOAuthConnectionAccountsForUser()` in `apps/tradinggoose/lib/credentials/oauth.ts` when trading code needs the current user's connected broker accounts for one or more OAuth service provider ids.
+- Use `resolveOAuthConnectionAccountForUser()` in `apps/tradinggoose/lib/credentials/oauth.ts` when a selected trading `PortfolioIdentity.credentialId` must be verified against the current user and converted into `{ tokenAccountId, providerId, credentialOwnerUserId }`.
+- Use `authorizeTradingCredentialRequest()` and `resolveTradingProviderContext()` from `apps/tradinggoose/lib/trading/context.ts` for trading order, holdings, order-detail, and future broker operations. Do not duplicate provider/service matching or token refresh preflight in routes or tools.
+- Use `listTradingPortfolioIdentities()` from `apps/tradinggoose/lib/trading/portfolio-identities.ts` as the canonical account-discovery helper for the portfolio identity API and socket portfolio manager.
+- Use `useTradingServices()` from `apps/tradinggoose/widgets/widgets/components/trading-services.ts` for widget service selection. It centralizes the `useOAuthConnections()` based connected-service filter and `resolveActiveTradingServiceId()` fallback behavior.
+- Use `TradingPortfolioStreamManager.stop()` from `apps/tradinggoose/socket-server/trading/portfolio-manager.ts` for socket server shutdown or tests that need deterministic portfolio polling cleanup.
+
+### Removed or Replaced Items
+- Removed `listOAuthCredentialAccountsForUser()` from `apps/tradinggoose/lib/credentials/oauth.ts`. For trading account discovery, use `listOAuthConnectionAccountsForUser()`; for workspace credential access, keep using `listOAuthCredentialsForUser()` or `resolveOAuthCredentialAccountForUser()` as appropriate.
+- Replaced trading calls to `authorizeCredentialUse()` with the narrower connection-account path through `authorizeTradingCredentialRequest()` and `resolveOAuthConnectionAccountForUser()`. Do not reintroduce request/workspace/workflow authorization arguments into trading broker account lookup.
+- Replaced `useOAuthCredentialsByProviderIds()` in trading widgets with `useOAuthConnections()` via `useTradingServices()`. Do not bring back workspace-scoped credential discovery for broker service availability.
+- Removed `workspaceId` and `workflowId` from `/api/providers/trading/portfolio-identities` discovery. Future callers should send `provider` and optional `serviceId` only.
+- Replaced shutdown-by-disconnect assumptions in socket portfolio streams with explicit `TradingPortfolioStreamManager.stop()` cleanup.
+
+### Future Branch Guardrails
+- Treat `PortfolioIdentity.credentialId` in trading flows as an OAuth token account id. Do not compare it to workspace `credential.id` unless the code explicitly crosses into saved workspace credential APIs.
+- Keep trading account discovery user-connection based. Workspace access checks still belong around workspace resources such as order history and tool execution, not around listing the user's connected broker accounts.
+- Keep provider/service validation centralized in `resolveTradingProviderContext()` and account ownership validation centralized in `resolveOAuthConnectionAccountForUser()`.
+- Keep widget service availability centralized in `useTradingServices()` so quick order, portfolio snapshot, heatmap, and account selectors do not drift into separate OAuth connection checks.
+- Keep socket portfolio polling shutdown centralized in `TradingPortfolioStreamManager.stop()` and call it from process shutdown paths before closing shared infrastructure.
+
+### Validation Notes
+- Reviewed `git log --oneline 14293d18..fix/integrations`, `git diff --stat 14293d18..fix/integrations`, and `git diff --name-status --find-renames 14293d18..fix/integrations`.
+- Confirmed the branch touched no `*/migration/*` files.
+- Inspected the canonical implementation paths and related callers/tests for OAuth connection accounts, trading context resolution, portfolio identity discovery, widget service selection, and socket portfolio polling shutdown.
+- Ran `bun run test lib/trading/portfolio-identities.test.ts app/api/providers/trading/portfolio-identities/route.test.ts app/api/providers/trading/order/route.test.ts 'app/api/orders/[orderId]/provider-detail/route.test.ts' socket-server/trading/portfolio-manager.test.ts tools/trading/holdings.test.ts widgets/widgets/components/trading-account-selector.test.tsx widgets/widgets/heatmap/components/body.test.tsx widgets/widgets/portfolio_snapshot/components/body.test.tsx widgets/widgets/quick_order/components/body.test.tsx` from `apps/tradinggoose`; 10 files and 90 tests passed.

--- a/helm/tradinggoose/Chart.yaml
+++ b/helm/tradinggoose/Chart.yaml
@@ -20,4 +20,4 @@ keywords:
   - nextjs
 annotations:
   category: AI/ML Platform
-  licenses: Apache-2.0
+  licenses: AGPL-3.0-only


### PR DESCRIPTION
## Summary
Promotes the current `fork/staging` changes to `upstream/main`.

This PR aligns trading broker access around user-owned OAuth connection accounts across portfolio identity discovery, order submission/detail, holdings, widgets, and socket portfolio streams. It also adds explicit socket portfolio polling shutdown and updates license/chart metadata plus the staging changelog.

## Why
Trading flows were mixing workspace-scoped credential IDs with user-owned OAuth account IDs. Using OAuth connection accounts as the runtime broker identity keeps portfolio discovery, widget account selection, order execution, holdings, and realtime portfolio polling on the same contract.

## Affected Areas
- [x] `apps/tradinggoose`
- [ ] `apps/docs`
- [ ] `packages/*`
- [x] Workflows / execution
- [x] Realtime / sockets
- [ ] Market data / charting
- [x] Dev tooling / CI / infra
- [ ] Documentation only
- [x] Other: license metadata and changelog

## Issue Links( if any )
None.

## Validation
```bash
cd apps/tradinggoose
bun run test lib/trading/portfolio-identities.test.ts app/api/providers/trading/portfolio-identities/route.test.ts app/api/providers/trading/order/route.test.ts 'app/api/orders/[orderId]/provider-detail/route.test.ts' socket-server/trading/portfolio-manager.test.ts tools/trading/holdings.test.ts widgets/widgets/components/trading-account-selector.test.tsx widgets/widgets/heatmap/components/body.test.tsx widgets/widgets/portfolio_snapshot/components/body.test.tsx widgets/widgets/quick_order/components/body.test.tsx
```

Result: 10 test files passed, 90 tests passed.

Also verified the branch diff touches no `*/migration/*` files.

## Risk / Rollout Notes
Deploy the app and socket server together because trading payloads now use OAuth token account IDs for broker selection.

Risk is concentrated in trading flows that still send old workspace credential IDs; those should fail under the new contract rather than being silently backfilled. Backout is to revert this PR and redeploy the previous app/socket server pair.

## Config / Data Changes
- Env vars added or changed: none
- Database schema or migration impact: none
- External services or provider behavior changed: Alpaca/Tradier access is now authorized through the authenticated user's OAuth connection account instead of workspace credential lookup

## Screenshots / Video
N/A. No visual layout changes; license page copy changes are text-only.

## Checklist
- [x] I kept the change focused and reviewed my own diff
- [x] I validated the change locally and documented the results above
- [x] I updated docs, examples, or copy if behavior/user-facing flows changed
- [x] I called out any env, schema, provider, or rollout impact
- [x] I did not include secrets, tokens, or private credentials in this PR