### PR TITLE
refactor(trading): remove workspaceId from portfolio flow

### DIFF
--- a/apps/tradinggoose/hooks/queries/trading-portfolio.ts
+++ b/apps/tradinggoose/hooks/queries/trading-portfolio.ts
@@ -21,7 +21,6 @@ import type {
 type TradingPortfolioChannel = 'accounts' | 'account-snapshot' | 'portfolio-performance'
 
 type TradingAccountsRequest = {
-  workspaceId?: string
   provider?: string
   serviceId?: string
   refreshKey?: number | string | null
@@ -39,7 +38,6 @@ type TradingPerformanceRequest = TradingSnapshotRequest & {
 type TradingPortfolioSubscribedPayload = {
   provider?: string
   serviceId?: string
-  workspaceId?: string
   channel?: TradingPortfolioChannel
   subscriptionId?: string
   clientSubscriptionId?: string
@@ -80,7 +78,6 @@ type SocketSubscriptionRef = {
   clientSubscriptionId: string
   provider: string
   serviceId?: string
-  workspaceId: string
   channel: TradingPortfolioChannel
   portfolioIdentity?: PortfolioIdentity
 }
@@ -117,7 +114,6 @@ function useTradingPortfolioSocketData<T>({
   channel,
   provider,
   serviceId,
-  workspaceId,
   portfolioIdentity,
   window,
   refreshKey,
@@ -128,7 +124,6 @@ function useTradingPortfolioSocketData<T>({
   channel: TradingPortfolioChannel
   provider?: string
   serviceId?: string
-  workspaceId?: string
   portfolioIdentity?: PortfolioIdentity | null
   window?: TradingPortfolioPerformanceWindow
   refreshKey?: number | string | null
@@ -152,14 +147,12 @@ function useTradingPortfolioSocketData<T>({
 
   const normalizedProvider = provider?.trim()
   const normalizedServiceId = serviceId?.trim()
-  const normalizedWorkspaceId = workspaceId?.trim()
   const normalizedPortfolioIdentity = toPortfolioValueObject(portfolioIdentity)
   const normalizedPortfolioIdentityKey = normalizedPortfolioIdentity
     ? getPortfolioIdentityKey(normalizedPortfolioIdentity)
     : ''
   const requestKey = [
     channel,
-    normalizedWorkspaceId ?? '',
     normalizedProvider ?? '',
     normalizedServiceId ?? '',
     normalizedPortfolioIdentityKey,
@@ -169,7 +162,6 @@ function useTradingPortfolioSocketData<T>({
   const shouldSubscribe =
     enabled &&
     Boolean(normalizedProvider) &&
-    Boolean(normalizedWorkspaceId) &&
     (channel === 'accounts' || Boolean(normalizedPortfolioIdentityKey)) &&
     (channel !== 'portfolio-performance' || Boolean(window))
   const isCurrentRequestResolved = dataState.key === requestKey
@@ -206,7 +198,6 @@ function useTradingPortfolioSocketData<T>({
       clientSubscriptionId,
       provider: normalizedProvider as string,
       serviceId: normalizedServiceId,
-      workspaceId: normalizedWorkspaceId as string,
       channel,
       portfolioIdentity: normalizedPortfolioIdentity ?? undefined,
     }
@@ -225,7 +216,6 @@ function useTradingPortfolioSocketData<T>({
       ) {
         return false
       }
-      if (payload.workspaceId && payload.workspaceId !== normalizedWorkspaceId) return false
       const payloadPortfolioIdentity = toPortfolioValueObject(payload.portfolioIdentity)
       if (
         payloadPortfolioIdentity &&
@@ -248,7 +238,6 @@ function useTradingPortfolioSocketData<T>({
       socket.emit('trading-portfolio-subscribe', {
         provider: normalizedProvider,
         serviceId: normalizedServiceId,
-        workspaceId: normalizedWorkspaceId,
         channel,
         portfolioIdentity: normalizedPortfolioIdentity,
         window,
@@ -325,7 +314,6 @@ function useTradingPortfolioSocketData<T>({
     normalizedServiceId,
     normalizedPortfolioIdentityKey,
     normalizedProvider,
-    normalizedWorkspaceId,
     refetchNonce,
     refreshKey,
     requestKey,
@@ -366,7 +354,6 @@ export function usePortfolioIdentities(request: TradingAccountsRequest) {
     channel: 'accounts',
     provider: request.provider,
     serviceId: request.serviceId,
-    workspaceId: request.workspaceId,
     refreshKey: request.refreshKey,
     enabled: request.enabled,
     dataEvent: 'trading-portfolio-accounts',
@@ -379,7 +366,6 @@ export function usePortfolioDetail(request: TradingSnapshotRequest) {
     channel: 'account-snapshot',
     provider: request.provider,
     serviceId: request.serviceId,
-    workspaceId: request.workspaceId,
     portfolioIdentity: request.portfolioIdentity,
     refreshKey: request.refreshKey,
     enabled: request.enabled,
@@ -393,7 +379,6 @@ export function usePortfolioPerformance(request: TradingPerformanceRequest) {
     channel: 'portfolio-performance',
     provider: request.provider,
     serviceId: request.serviceId,
-    workspaceId: request.workspaceId,
     portfolioIdentity: request.portfolioIdentity,
     window: request.selectedWindow,
     refreshKey: request.refreshKey,

--- a/apps/tradinggoose/socket-server/trading/portfolio-manager.test.ts
+++ b/apps/tradinggoose/socket-server/trading/portfolio-manager.test.ts
@@ -176,7 +176,6 @@ describe('TradingPortfolioStreamManager', () => {
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       portfolioIdentity,
-      workspaceId: 'workspace-1',
       channel: 'account-snapshot',
       clientSubscriptionId: 'snapshot-1',
     })
@@ -184,7 +183,6 @@ describe('TradingPortfolioStreamManager', () => {
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       portfolioIdentity,
-      workspaceId: 'workspace-1',
       channel: 'account-snapshot',
       clientSubscriptionId: 'snapshot-2',
     })
@@ -213,7 +211,6 @@ describe('TradingPortfolioStreamManager', () => {
       expect.objectContaining({
         provider: 'alpaca',
         serviceId: 'alpaca-live',
-        workspaceId: 'workspace-1',
         channel: 'account-snapshot',
         portfolioIdentity,
         portfolioDetail: expect.objectContaining({ accountId: 'acct-1' }),
@@ -241,7 +238,6 @@ describe('TradingPortfolioStreamManager', () => {
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       portfolioIdentity,
-      workspaceId: 'workspace-1',
       channel: 'account-snapshot',
       clientSubscriptionId: 'portfolio_snapshot',
     })
@@ -249,7 +245,6 @@ describe('TradingPortfolioStreamManager', () => {
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       portfolioIdentity,
-      workspaceId: 'workspace-1',
       channel: 'account-snapshot',
       clientSubscriptionId: 'portfolio_snapshot',
     })
@@ -286,7 +281,6 @@ describe('TradingPortfolioStreamManager', () => {
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       portfolioIdentity,
-      workspaceId: 'workspace-1',
       channel: 'account-snapshot',
       clientSubscriptionId: 'snapshot-1',
     })
@@ -294,7 +288,6 @@ describe('TradingPortfolioStreamManager', () => {
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       portfolioIdentity,
-      workspaceId: 'workspace-1',
       channel: 'portfolio-performance',
       window: '1D',
       clientSubscriptionId: 'performance-1',
@@ -310,7 +303,6 @@ describe('TradingPortfolioStreamManager', () => {
       expect.objectContaining({
         provider: 'alpaca',
         serviceId: 'alpaca-live',
-        workspaceId: 'workspace-1',
         channel: 'portfolio-performance',
         portfolioIdentity,
         window: '1D',
@@ -330,7 +322,6 @@ describe('TradingPortfolioStreamManager', () => {
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       portfolioIdentity,
-      workspaceId: 'workspace-1',
       channel: 'account-snapshot',
       clientSubscriptionId: 'snapshot-1',
     })
@@ -345,7 +336,6 @@ describe('TradingPortfolioStreamManager', () => {
         provider: 'alpaca',
         serviceId: 'alpaca-live',
         portfolioIdentity,
-        workspaceId: 'workspace-1',
         channel: 'account-snapshot',
       })
     ).rejects.toThrow('Trading portfolio stream manager is stopped')

--- a/apps/tradinggoose/socket-server/trading/portfolio-manager.ts
+++ b/apps/tradinggoose/socket-server/trading/portfolio-manager.ts
@@ -44,7 +44,6 @@ export interface TradingPortfolioSubscribePayload {
   provider?: string
   serviceId?: string
   portfolioIdentity?: PortfolioIdentity | null
-  workspaceId?: string
   window?: TradingPortfolioPerformanceWindow
   channel?: TradingPortfolioChannel
   clientSubscriptionId?: string
@@ -66,7 +65,6 @@ export interface TradingPortfolioSubscriptionInfo {
   provider: TradingProviderId
   serviceId?: string
   portfolioIdentity?: PortfolioIdentity
-  workspaceId: string
   channel: TradingPortfolioChannel
   window?: TradingPortfolioPerformanceWindow
 }
@@ -80,7 +78,6 @@ interface TradingPortfolioSubscriptionRecord extends TradingPortfolioSubscriptio
 interface TradingPortfolioStreamState {
   streamKey: string
   userId: string
-  workspaceId: string
   providerId: TradingProviderId
   serviceId?: string
   portfolioIdentity?: PortfolioIdentity
@@ -101,7 +98,6 @@ interface AccountsCacheEntry {
 type TradingPortfolioBasePayload = {
   provider: TradingProviderId
   serviceId?: string
-  workspaceId: string
   channel: TradingPortfolioChannel
   receivedAt: string
 }
@@ -157,7 +153,6 @@ export class TradingPortfolioStreamManager {
     if (!userId) throw new Error('Authentication required')
 
     const providerId = resolveTradingProviderId(payload.provider, payload.portfolioIdentity)
-    const workspaceId = resolveWorkspaceId(payload.workspaceId)
 
     const channel = resolveChannel(payload.channel)
     const serviceId = resolveServiceId(
@@ -168,7 +163,6 @@ export class TradingPortfolioStreamManager {
     const window = resolvePerformanceWindow(providerId, channel, payload.window)
     const streamKey = buildStreamKey({
       userId,
-      workspaceId,
       providerId,
       serviceId,
       portfolioIdentity,
@@ -178,7 +172,6 @@ export class TradingPortfolioStreamManager {
     const streamState = this.getOrCreateStreamState({
       streamKey,
       userId,
-      workspaceId,
       providerId,
       serviceId,
       portfolioIdentity,
@@ -199,7 +192,6 @@ export class TradingPortfolioStreamManager {
       provider: providerId,
       serviceId,
       portfolioIdentity,
-      workspaceId,
       channel,
       window,
     }
@@ -221,7 +213,6 @@ export class TradingPortfolioStreamManager {
       providerId,
       serviceId,
       portfolioIdentity: redactPortfolioIdentity(portfolioIdentity),
-      workspaceId,
       channel,
       window,
     })
@@ -232,7 +223,6 @@ export class TradingPortfolioStreamManager {
       provider: providerId,
       serviceId,
       portfolioIdentity,
-      workspaceId,
       channel,
       window,
     }
@@ -325,7 +315,6 @@ export class TradingPortfolioStreamManager {
         const payload: TradingPortfolioAccountsPayload = {
           provider: streamState.providerId,
           serviceId: streamState.serviceId,
-          workspaceId: streamState.workspaceId,
           channel: 'accounts',
           portfolioIdentities,
           receivedAt: new Date().toISOString(),
@@ -350,7 +339,6 @@ export class TradingPortfolioStreamManager {
         const payload: TradingPortfolioSnapshotPayload = {
           provider: streamState.providerId,
           serviceId: streamState.serviceId,
-          workspaceId: streamState.workspaceId,
           channel: 'account-snapshot',
           portfolioIdentity: toPortfolioValueObject(portfolioDetail) ?? portfolioIdentity,
           portfolioDetail,
@@ -377,7 +365,6 @@ export class TradingPortfolioStreamManager {
       const payload: TradingPortfolioPerformancePayload = {
         provider: streamState.providerId,
         serviceId: streamState.serviceId,
-        workspaceId: streamState.workspaceId,
         channel: 'portfolio-performance',
         portfolioIdentity,
         window: streamState.window,
@@ -507,7 +494,6 @@ export class TradingPortfolioStreamManager {
         provider: record.provider,
         serviceId: record.serviceId,
         portfolioIdentity: record.portfolioIdentity,
-        workspaceId: record.workspaceId,
         channel: record.channel,
         window: record.window,
         subscriptionId: record.subscriptionId,
@@ -579,7 +565,6 @@ export class TradingPortfolioStreamManager {
       provider: record.provider,
       serviceId: record.serviceId,
       portfolioIdentity: redactPortfolioIdentity(record.portfolioIdentity),
-      workspaceId: record.workspaceId,
       channel: record.channel,
       window: record.window,
     })
@@ -641,12 +626,6 @@ function resolveTradingProviderId(
   return providerId as TradingProviderId
 }
 
-function resolveWorkspaceId(workspaceId?: string) {
-  const trimmed = workspaceId?.trim()
-  if (!trimmed) throw new Error('workspaceId is required')
-  return trimmed
-}
-
 function resolveServiceId(providerId: TradingProviderId, serviceId?: string) {
   const resolvedServiceId = getTradingProviderOAuthServiceId(providerId, serviceId)
   if (!resolvedServiceId) throw new Error('Trading provider connection is required')
@@ -701,7 +680,6 @@ function resolvePerformanceWindow(
 
 function buildStreamKey(config: {
   userId: string
-  workspaceId: string
   providerId: TradingProviderId
   serviceId?: string
   portfolioIdentity?: PortfolioIdentity
@@ -712,7 +690,6 @@ function buildStreamKey(config: {
     .update(
       [
         config.userId,
-        config.workspaceId,
         config.providerId,
         config.serviceId ?? '',
         config.channel,
@@ -728,7 +705,6 @@ function buildAccountsCacheKey(streamState: TradingPortfolioStreamState) {
     .update(
       [
         streamState.userId,
-        streamState.workspaceId,
         streamState.providerId,
         streamState.serviceId ?? '',
       ].join('|')
@@ -757,7 +733,6 @@ function toSubscriptionInfo(
     provider: record.provider,
     serviceId: record.serviceId,
     portfolioIdentity: record.portfolioIdentity,
-    workspaceId: record.workspaceId,
     channel: record.channel,
     window: record.window,
   }

--- a/apps/tradinggoose/widgets/widgets/components/trading-account-selector.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/components/trading-account-selector.test.tsx
@@ -104,7 +104,6 @@ describe('TradingAccountSelector', () => {
       enabled: true,
     })
     expect(mockUsePortfolioIdentities).toHaveBeenCalledWith({
-      workspaceId: 'workspace-1',
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       enabled: true,

--- a/apps/tradinggoose/widgets/widgets/components/trading-account-selector.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/components/trading-account-selector.test.tsx
@@ -87,7 +87,6 @@ describe('TradingAccountSelector', () => {
       root.render(
         <TooltipProvider>
           <TradingAccountSelector
-            workspaceId='workspace-1'
             providerId='alpaca'
             serviceId='alpaca-live'
             portfolioIdentity={selectedPortfolioIdentity}
@@ -115,7 +114,6 @@ describe('TradingAccountSelector', () => {
       root.render(
         <TooltipProvider>
           <TradingAccountSelector
-            workspaceId='workspace-1'
             providerId='alpaca'
             serviceId='alpaca-live'
             portfolioIdentity={selectedPortfolioIdentity}
@@ -162,7 +160,6 @@ describe('TradingAccountSelector', () => {
       root.render(
         <TooltipProvider>
           <TradingAccountSelector
-            workspaceId='workspace-1'
             providerId='alpaca'
             serviceId='alpaca-live'
             portfolioIdentity={{
@@ -186,7 +183,6 @@ describe('TradingAccountSelector', () => {
       root.render(
         <TooltipProvider>
           <TradingAccountSelector
-            workspaceId='workspace-1'
             providerId='alpaca'
             serviceId='alpaca-live'
             portfolioIdentity={{

--- a/apps/tradinggoose/widgets/widgets/components/trading-account-selector.tsx
+++ b/apps/tradinggoose/widgets/widgets/components/trading-account-selector.tsx
@@ -37,7 +37,6 @@ export type TradingAccountSelection = {
 }
 
 type TradingAccountSelectorProps = {
-  workspaceId?: string | null
   providerId?: string | null
   serviceId?: string | null
   portfolioIdentity?: PortfolioIdentity | null

--- a/apps/tradinggoose/widgets/widgets/components/trading-account-selector.tsx
+++ b/apps/tradinggoose/widgets/widgets/components/trading-account-selector.tsx
@@ -68,7 +68,6 @@ const getAccountDescription = (providerId: string, portfolioIdentity: PortfolioI
     .join(' - ')
 
 export function TradingAccountSelector({
-  workspaceId,
   providerId,
   serviceId,
   portfolioIdentity,
@@ -80,14 +79,13 @@ export function TradingAccountSelector({
 }: TradingAccountSelectorProps) {
   const [showOAuthModal, setShowOAuthModal] = useState(false)
   const [oauthModalServiceId, setOAuthModalServiceId] = useState<string | null>(null)
-  const trimmedWorkspaceId = typeof workspaceId === 'string' ? workspaceId.trim() : ''
   const trimmedProviderId = typeof providerId === 'string' ? providerId.trim() : ''
   const providerDefinition = trimmedProviderId
     ? getTradingProviderDefinition(trimmedProviderId)
     : undefined
   const providerName = providerDefinition?.name ?? 'broker'
   const oauthProvider = providerDefinition?.oauth?.provider
-  const isEnabled = Boolean(trimmedWorkspaceId && trimmedProviderId) && !disabled
+  const isEnabled = Boolean(trimmedProviderId) && !disabled
   const selectedPortfolioIdentity = toPortfolioValueObject(portfolioIdentity)
   const requestedServiceId = serviceId ?? selectedPortfolioIdentity?.serviceId
   const services = useTradingServices({
@@ -98,7 +96,6 @@ export function TradingAccountSelector({
   const activeServiceId = services.activeServiceId
   const hasConnection = Boolean(activeServiceId)
   const accountsQuery = usePortfolioIdentities({
-    workspaceId: trimmedWorkspaceId || undefined,
     provider: trimmedProviderId || undefined,
     serviceId: activeServiceId,
     enabled: isEnabled && hasConnection,

--- a/apps/tradinggoose/widgets/widgets/components/trading-provider-controls.tsx
+++ b/apps/tradinggoose/widgets/widgets/components/trading-provider-controls.tsx
@@ -13,7 +13,6 @@ import {
 import { widgetHeaderButtonGroupClassName } from '@/widgets/widgets/components/widget-header-control'
 
 type TradingProviderControlsProps = {
-  workspaceId?: string | null
   providerId?: string | null
   providerOptions: TradingProviderOption[]
   onProviderChange?: (providerId: string) => void
@@ -29,7 +28,6 @@ type TradingProviderControlsProps = {
 }
 
 export function TradingProviderControls({
-  workspaceId,
   providerId,
   providerOptions,
   onProviderChange,
@@ -57,7 +55,6 @@ export function TradingProviderControls({
       />
       {hasSelectedProvider ? (
         <TradingAccountSelector
-          workspaceId={workspaceId}
           providerId={selectedProviderId}
           serviceId={serviceId}
           portfolioIdentity={portfolioIdentity}

--- a/apps/tradinggoose/widgets/widgets/components/use-portfolio-identity-selection.ts
+++ b/apps/tradinggoose/widgets/widgets/components/use-portfolio-identity-selection.ts
@@ -16,7 +16,6 @@ type EmitPortfolioParamsChange = (input: {
 }) => void
 
 export function usePortfolioIdentitySelection({
-  workspaceId,
   providerId,
   serviceId,
   portfolioIdentity,
@@ -25,7 +24,6 @@ export function usePortfolioIdentitySelection({
   widgetKey,
   emitParamsChange,
 }: {
-  workspaceId?: string | null
   providerId?: string | null
   serviceId?: string | null
   portfolioIdentity?: PortfolioIdentity | null
@@ -47,7 +45,6 @@ export function usePortfolioIdentitySelection({
   })
   const activeServiceId = enabled ? services.activeServiceId : undefined
   const accountsQuery = usePortfolioIdentities({
-    workspaceId: workspaceId ?? undefined,
     provider: enabled ? (providerId ?? undefined) : undefined,
     serviceId: activeServiceId,
     enabled: enabled && Boolean(activeServiceId),

--- a/apps/tradinggoose/widgets/widgets/heatmap/components/body.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/heatmap/components/body.test.tsx
@@ -427,7 +427,6 @@ describe('HeatmapWidgetBody', () => {
     })
 
     expect(mockUsePortfolioDetail).toHaveBeenLastCalledWith({
-      workspaceId: 'workspace-1',
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       portfolioIdentity,

--- a/apps/tradinggoose/widgets/widgets/heatmap/components/body.tsx
+++ b/apps/tradinggoose/widgets/widgets/heatmap/components/body.tsx
@@ -143,7 +143,6 @@ export function HeatmapWidgetBody({
     services,
     portfolioIdentities,
   } = usePortfolioIdentitySelection({
-    workspaceId,
     providerId: tradingProviderId,
     serviceId: widgetParams?.serviceId,
     portfolioIdentity: widgetParams?.portfolioIdentity,
@@ -154,7 +153,6 @@ export function HeatmapWidgetBody({
   })
 
   const snapshotQuery = usePortfolioDetail({
-    workspaceId: workspaceId ?? undefined,
     provider: sourceMode === 'portfolio' && isTradingProviderReady ? tradingProviderId : undefined,
     serviceId: activeServiceId,
     portfolioIdentity: activePortfolioIdentity,

--- a/apps/tradinggoose/widgets/widgets/heatmap/components/header.tsx
+++ b/apps/tradinggoose/widgets/widgets/heatmap/components/header.tsx
@@ -132,7 +132,7 @@ function HeatmapWatchlistSizeControls({ panelId, widgetKey, params }: HeaderCont
   )
 }
 
-function HeatmapPortfolioControls({ workspaceId, panelId, widgetKey, params }: HeaderControlProps) {
+function HeatmapPortfolioControls({ panelId, widgetKey, params }: HeaderControlProps) {
   const providerAvailabilityQuery = useOAuthProviderAvailability(
     getHeatmapTradingProviderAvailabilityIds()
   )
@@ -144,7 +144,6 @@ function HeatmapPortfolioControls({ workspaceId, panelId, widgetKey, params }: H
 
   return (
     <TradingProviderControls
-      workspaceId={workspaceId}
       providerId={providerId}
       providerOptions={providerOptions}
       serviceId={params?.serviceId}

--- a/apps/tradinggoose/widgets/widgets/portfolio_snapshot/components/body.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/portfolio_snapshot/components/body.test.tsx
@@ -468,7 +468,6 @@ describe('PortfolioSnapshotWidgetBody', () => {
     expect(container.textContent).toContain('Alpaca · active · paper')
     expect(container.textContent).toContain('performance-chart')
     expect(mockUsePortfolioDetail).toHaveBeenCalledWith({
-      workspaceId: 'workspace-1',
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       portfolioIdentity: selectedPortfolioIdentity,

--- a/apps/tradinggoose/widgets/widgets/portfolio_snapshot/components/body.tsx
+++ b/apps/tradinggoose/widgets/widgets/portfolio_snapshot/components/body.tsx
@@ -271,7 +271,6 @@ export function PortfolioSnapshotWidgetBody({
     services,
     portfolioIdentities,
   } = usePortfolioIdentitySelection({
-    workspaceId,
     providerId,
     serviceId: widgetParams?.serviceId,
     portfolioIdentity: widgetParams?.portfolioIdentity,
@@ -282,7 +281,6 @@ export function PortfolioSnapshotWidgetBody({
   })
 
   const snapshotQuery = usePortfolioDetail({
-    workspaceId: workspaceId ?? undefined,
     provider: isProviderReady ? providerId : undefined,
     serviceId: activeServiceId,
     portfolioIdentity: activePortfolioIdentity,
@@ -324,7 +322,6 @@ export function PortfolioSnapshotWidgetBody({
   })
 
   const performanceQuery = usePortfolioPerformance({
-    workspaceId: workspaceId ?? undefined,
     provider: isProviderReady ? providerId : undefined,
     serviceId: activeServiceId,
     portfolioIdentity: activePortfolioIdentity,

--- a/apps/tradinggoose/widgets/widgets/portfolio_snapshot/components/header.tsx
+++ b/apps/tradinggoose/widgets/widgets/portfolio_snapshot/components/header.tsx
@@ -81,7 +81,6 @@ export function PortfolioSnapshotHeaderControls({
 
       {areProviderOptionsReady ? (
         <TradingProviderControls
-          workspaceId={workspaceId}
           providerId={providerId}
           providerOptions={providerOptions}
           serviceId={params?.serviceId}

--- a/apps/tradinggoose/widgets/widgets/quick_order/components/body.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/quick_order/components/body.test.tsx
@@ -511,7 +511,6 @@ describe('QuickOrderWidgetBody', () => {
       side: 'buy',
     })
     expect(mockUsePortfolioDetail).toHaveBeenLastCalledWith({
-      workspaceId: 'workspace-1',
       provider: 'alpaca',
       serviceId: 'alpaca-live',
       portfolioIdentity: undefined,

--- a/apps/tradinggoose/widgets/widgets/quick_order/components/body.tsx
+++ b/apps/tradinggoose/widgets/widgets/quick_order/components/body.tsx
@@ -254,7 +254,6 @@ export function QuickOrderWidgetBody({
     providerOptions.length > 0
   const { accountsQuery, activeServiceId, activePortfolioIdentity, services, portfolioIdentities } =
     usePortfolioIdentitySelection({
-      workspaceId,
       providerId,
       serviceId: quickOrderParams?.serviceId,
       portfolioIdentity: quickOrderParams?.portfolioIdentity,
@@ -264,7 +263,6 @@ export function QuickOrderWidgetBody({
       emitParamsChange: emitQuickOrderParamsChange,
     })
   const accountSnapshotQuery = usePortfolioDetail({
-    workspaceId: workspaceId ?? undefined,
     provider: hasSelectedProvider && areProviderOptionsReady ? providerId : undefined,
     serviceId: activeServiceId,
     portfolioIdentity: activePortfolioIdentity,

--- a/apps/tradinggoose/widgets/widgets/quick_order/components/header.tsx
+++ b/apps/tradinggoose/widgets/widgets/quick_order/components/header.tsx
@@ -79,7 +79,6 @@ export function QuickOrderHeaderControls({
 
       {areProviderOptionsReady ? (
         <TradingProviderControls
-          workspaceId={workspaceId}
           providerId={providerId}
           providerOptions={providerOptions}
           serviceId={params?.serviceId}


### PR DESCRIPTION
## Summary
- Removed `workspaceId` from trading portfolio socket request/payload types, stream keys, and account cache keys.
- Updated trading portfolio hooks and widgets to load broker portfolio data by authenticated user, provider, service, and selected portfolio identity.
- Adjusted focused socket/widget tests to match the simplified portfolio subscription contract.

## Why
Trading broker portfolio discovery now resolves from the signed-in user's OAuth connection account, so requiring `workspaceId` in portfolio socket subscriptions adds unnecessary coupling and can block otherwise valid broker account loading. This keeps workspace context limited to workspace-owned resources such as watchlists and market quote requests.

## Affected Areas
- [x] `apps/tradinggoose`
- [ ] `apps/docs`
- [ ] `packages/*`
- [ ] Workflows / execution
- [x] Realtime / sockets
- [x] Market data / charting
- [ ] Dev tooling / CI / infra
- [ ] Documentation only
- [ ] Other:

## Issue Links( if any )
N/A

## Validation
```bash
git diff --check upstream/staging...HEAD
# passed

cd apps/tradinggoose
bun run test socket-server/trading/portfolio-manager.test.ts widgets/widgets/components/trading-account-selector.test.tsx widgets/widgets/heatmap/components/body.test.tsx widgets/widgets/portfolio_snapshot/components/body.test.tsx widgets/widgets/quick_order/components/body.test.tsx
# 5 test files passed, 46 tests passed

bun run type-check
# passed
```

## Risk / Rollout Notes
- Socket client/server payload contracts changed for trading portfolio subscriptions; deploy the app and realtime socket server together.
- No legacy `workspaceId` fallback was added.
- Backout plan: revert `074b0045` if portfolio account subscriptions regress.

## Config / Data Changes
- Env vars added or changed: None
- Database schema or migration impact: None
- External services or provider behavior changed: None

## Screenshots / Video
N/A - no intended visual changes.

## Checklist
- [x] I kept the change focused and reviewed my own diff
- [x] I validated the change locally and documented the results above
- [x] I updated docs, examples, or copy if behavior/user-facing flows changed
- [x] I called out any env, schema, provider, or rollout impact
- [x] I did not include secrets, tokens, or private credentials in this PR