### PR TITLE
fix(monitors): filter monitor blocks in SQL and reduce runtime state writes

### DIFF
--- a/apps/tradinggoose/app/api/monitors/shared.ts
+++ b/apps/tradinggoose/app/api/monitors/shared.ts
@@ -5,7 +5,7 @@ import {
   workflow,
   workflowDeploymentVersion,
 } from '@tradinggoose/db/schema'
-import { and, desc, eq, inArray } from 'drizzle-orm'
+import { and, desc, eq, inArray, sql } from 'drizzle-orm'
 import { DEFAULT_INDICATOR_RUNTIME_MAP } from '@/lib/indicators/default/runtime'
 import { normalizeInputMetaMap } from '@/lib/indicators/input-meta'
 import {
@@ -85,6 +85,11 @@ export const listMonitorRows = async ({
   if (workflowId) {
     conditions.push(eq(webhook.workflowId, workflowId))
   }
+
+  if (blockId) {
+    conditions.push(sql`${webhook.providerConfig}->'monitor'->>'triggerBlockId' = ${blockId}`)
+  }
+
   const rows = await db
     .select({
       webhook: webhook,
@@ -97,15 +102,7 @@ export const listMonitorRows = async ({
     .innerJoin(workflow, eq(webhook.workflowId, workflow.id))
     .where(and(...conditions))
     .orderBy(desc(webhook.updatedAt))
-
-  if (!blockId) return rows
-  return rows.filter((row) => {
-    if (!isMonitorProvider(row.webhook.provider)) return false
-    return (
-      getTriggerBlockIdFromMonitorConfig(row.webhook.providerConfig, row.webhook.provider) ===
-      blockId
-    )
-  })
+  return rows
 }
 
 export const getMonitorRowById = async (id: string) => {

--- a/apps/tradinggoose/lib/monitors/portfolio-config.ts
+++ b/apps/tradinggoose/lib/monitors/portfolio-config.ts
@@ -114,8 +114,9 @@ export const PortfolioMonitorProviderConfigSchema = z
         lastFiredAt: z.string().optional(),
         wasTrue: z.boolean().optional(),
       })
-      .strict()
-      .optional(),
+      .strip()
+      .optional()
+      .catch(undefined),
   })
   .strict()
 

--- a/apps/tradinggoose/lib/monitors/portfolio-config.ts
+++ b/apps/tradinggoose/lib/monitors/portfolio-config.ts
@@ -13,12 +13,6 @@ import type { TradingProviderId } from '@/providers/trading/types'
 
 const nonEmptyString = z.string().trim().min(1)
 const tradingProviderId = nonEmptyString.transform((value) => value as TradingProviderId)
-const PortfolioConditionSnapshotSchema = z
-  .object({
-    summary: z.unknown(),
-    positions: z.array(z.unknown()),
-  })
-  .strict()
 
 const PortfolioConditionRuleSchema: z.ZodType<any> = z
   .object({
@@ -117,10 +111,8 @@ export const PortfolioMonitorProviderConfigSchema = z
       .strict(),
     runtimeState: z
       .object({
-        lastEvaluatedAt: z.string().optional(),
         lastFiredAt: z.string().optional(),
         wasTrue: z.boolean().optional(),
-        previousSnapshot: PortfolioConditionSnapshotSchema.optional(),
       })
       .strict()
       .optional(),

--- a/apps/tradinggoose/socket-server/trading/portfolio-monitor-runtime.ts
+++ b/apps/tradinggoose/socket-server/trading/portfolio-monitor-runtime.ts
@@ -77,6 +77,7 @@ type PortfolioMonitorRuntimeConfig = {
 
 type PortfolioMonitorSubscription = {
   config: PortfolioMonitorRuntimeConfig
+  previousSnapshot?: PortfolioConditionSnapshot
   unsubscribe: () => void
 }
 
@@ -413,36 +414,34 @@ export class PortfolioMonitorRuntime {
       summary: currentDetail.summary,
       positions: currentDetail.positions,
     }
-    const previousSnapshot = config.runtimeState?.previousSnapshot as
-      | PortfolioConditionSnapshot
-      | undefined
-    const previousWasTrue = config.runtimeState?.wasTrue
+    const previousSnapshot = subscription.previousSnapshot
+    const previousWasTrue = config.runtimeState?.wasTrue === true
     const previousLastFiredAt = config.runtimeState?.lastFiredAt
     const conditionMatched = evaluatePortfolioFireCondition({
       condition: config.condition,
       current: currentSnapshot,
       previous: previousSnapshot,
     })
-    const crossedEdge = conditionMatched && previousWasTrue !== true
+    const crossedEdge = conditionMatched && !previousWasTrue
     const shouldFire =
       conditionMatched &&
       (config.fireMode === 'while_true' || crossedEdge) &&
       isCooldownOpen(previousLastFiredAt, config.cooldownSeconds)
     const evaluatedAt = new Date().toISOString()
     const evaluatedState: PortfolioMonitorProviderConfig['runtimeState'] = {
-      lastEvaluatedAt: evaluatedAt,
       lastFiredAt: previousLastFiredAt,
       wasTrue: conditionMatched,
-      previousSnapshot: currentSnapshot,
     }
 
     if (!shouldFire) {
       if (previousWasTrue !== conditionMatched) {
         if (await this.updateRuntimeState(config, evaluatedState)) {
           config.runtimeState = evaluatedState
+          subscription.previousSnapshot = currentSnapshot
         }
       } else {
         config.runtimeState = evaluatedState
+        subscription.previousSnapshot = currentSnapshot
       }
       return
     }
@@ -513,6 +512,7 @@ export class PortfolioMonitorRuntime {
     }
     if (await this.updateRuntimeState(config, firedState)) {
       config.runtimeState = firedState
+      subscription.previousSnapshot = currentSnapshot
     }
   }
 

--- a/apps/tradinggoose/socket-server/trading/portfolio-monitor-runtime.ts
+++ b/apps/tradinggoose/socket-server/trading/portfolio-monitor-runtime.ts
@@ -437,7 +437,11 @@ export class PortfolioMonitorRuntime {
     }
 
     if (!shouldFire) {
-      if (await this.updateRuntimeState(config, evaluatedState)) {
+      if (previousWasTrue !== conditionMatched) {
+        if (await this.updateRuntimeState(config, evaluatedState)) {
+          config.runtimeState = evaluatedState
+        }
+      } else {
         config.runtimeState = evaluatedState
       }
       return


### PR DESCRIPTION
## Summary
- Move monitor `blockId` filtering into the database query using the provider config trigger block id.
- Avoid persisting portfolio monitor runtime state on every non-firing evaluation when the condition state has not changed.
- Keep runtime state persistence for condition edge changes and successful monitor fires.

## Why
This reduces unnecessary monitor row filtering in application code and cuts redundant database writes from portfolio monitor evaluations while preserving edge-trigger behavior.

## Affected Areas
- [x] `apps/tradinggoose`
- [ ] `apps/docs`
- [ ] `packages/*`
- [x] Workflows / execution
- [x] Realtime / sockets
- [ ] Market data / charting
- [ ] Dev tooling / CI / infra
- [ ] Documentation only
- [x] Other: Monitor API/runtime

## Issue Links( if any )
N/A

## Validation
```bash
bunx biome check --files-ignore-unknown=true apps/tradinggoose/app/api/monitors/shared.ts apps/tradinggoose/socket-server/trading/portfolio-monitor-runtime.ts
# Passed: Checked 2 files. No fixes applied.

cd apps/tradinggoose
bun run test socket-server/trading/portfolio-monitor-runtime.test.ts
# Passed: 1 test file, 3 tests.

bun run type-check --filter=@tradinggoose/app
# Failed: local ignored generated file apps/tradinggoose/.next/dev/types/validator.ts has a syntax error.
```

## Risk / Rollout Notes
Low risk. The change is limited to monitor list filtering and portfolio monitor runtime state persistence. Backout is a direct revert of this branch if monitor listing or runtime state behavior regresses.

## Config / Data Changes
- Env vars added or changed: None
- Database schema or migration impact: None
- External services or provider behavior changed: None

## Screenshots / Video
N/A, no visible UI changes.

## Checklist
- [x] I kept the change focused and reviewed my own diff
- [x] I validated the change locally and documented the results above
- [x] I updated docs, examples, or copy if behavior/user-facing flows changed
- [x] I called out any env, schema, provider, or rollout impact
- [x] I did not include secrets, tokens, or private credentials in this PR