### PR TITLE
feat(ui): add grouped sidebar dropdown menus

### DIFF
--- a/apps/tradinggoose/app/workspace/[workspaceId]/monitor/components/board/kanban.tsx
+++ b/apps/tradinggoose/app/workspace/[workspaceId]/monitor/components/board/kanban.tsx
@@ -557,10 +557,12 @@ export function KanbanBoard({ className, ...props }: ComponentProps<'div'>) {
 }
 
 function KanbanHeader({
+  action,
   columnId,
   count,
   title,
 }: {
+  action?: ReactNode
   columnId: string
   count: number
   title: string
@@ -575,6 +577,7 @@ function KanbanHeader({
           {count}
         </Badge>
       </div>
+      {action ? <div className='ml-3 flex shrink-0 items-center'>{action}</div> : null}
     </header>
   )
 }
@@ -586,6 +589,7 @@ export function KanbanCards({
   className,
   columnId,
   count,
+  headerAction,
   itemIds = [],
   listClassName,
   onDropOverColumn,
@@ -597,6 +601,7 @@ export function KanbanCards({
   beforeCards?: ReactNode
   columnId: string
   count: number
+  headerAction?: ReactNode
   itemIds?: string[]
   listClassName?: string
   onDropOverColumn?: (activeId: string) => void
@@ -638,7 +643,7 @@ export function KanbanCards({
       )}
       ref={setNodeRef}
     >
-      <KanbanHeader columnId={columnId} title={title} count={count} />
+      <KanbanHeader columnId={columnId} title={title} count={count} action={headerAction} />
       {beforeCards}
       <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
         <ul className={cn('min-h-0 flex-1 overflow-y-auto p-3', listClassName)}>{children}</ul>

--- a/apps/tradinggoose/app/workspace/[workspaceId]/monitor/components/board/monitor-board.tsx
+++ b/apps/tradinggoose/app/workspace/[workspaceId]/monitor/components/board/monitor-board.tsx
@@ -251,8 +251,7 @@ export function MonitorBoard({
                     canDrop={canDrop}
                     onDropOverColumn={() => handleDropAtColumn(column)}
                     itemIds={column.items.map((item) => item.logId)}
-                    summary={formatTemplate(copy.shared.itemsCount, { count: column.totalCount })}
-                    metaAction={
+                    headerAction={
                       column.limit ? (
                         <Badge variant='outline' className='text-[10px]'>
                           {formatTemplate(copy.execution.limitLabel, { count: column.limit })}

--- a/apps/tradinggoose/app/workspace/[workspaceId]/monitor/components/board/monitor-kanban.tsx
+++ b/apps/tradinggoose/app/workspace/[workspaceId]/monitor/components/board/monitor-kanban.tsx
@@ -54,8 +54,6 @@ type MonitorKanbanColumnProps = Omit<ComponentProps<typeof KanbanCards>, 'before
   aggregateVariant?: BadgeProps['variant']
   aggregates?: Record<string, number | string | undefined>
   formatAggregateValue?: (field: string, value: number | string | undefined) => ReactNode
-  metaAction?: ReactNode
-  summary: ReactNode
 }
 
 export function MonitorKanbanColumn({
@@ -65,28 +63,22 @@ export function MonitorKanbanColumn({
   aggregates = {},
   children,
   formatAggregateValue,
+  headerAction,
   listClassName,
-  metaAction,
-  summary,
   ...props
 }: MonitorKanbanColumnProps) {
   return (
     <KanbanCards
+      headerAction={headerAction}
       listClassName={cn('space-y-2', listClassName)}
       beforeCards={
-        <>
-          <div className='flex items-center justify-between border-b px-3 py-2'>
-            <div className='text-muted-foreground text-xs'>{summary}</div>
-            {metaAction}
-          </div>
-          <MonitorAggregateBadges
-            entries={aggregates}
-            className={cn('border-b px-3 py-2', aggregateClassName)}
-            variant={aggregateVariant}
-            badgeClassName={aggregateBadgeClassName}
-            formatValue={formatAggregateValue}
-          />
-        </>
+        <MonitorAggregateBadges
+          entries={aggregates}
+          className={cn('border-b px-3 py-2', aggregateClassName)}
+          variant={aggregateVariant}
+          badgeClassName={aggregateBadgeClassName}
+          formatValue={formatAggregateValue}
+        />
       }
       {...props}
     >

--- a/apps/tradinggoose/app/workspace/[workspaceId]/monitor/components/config/monitor-config-board.tsx
+++ b/apps/tradinggoose/app/workspace/[workspaceId]/monitor/components/config/monitor-config-board.tsx
@@ -206,10 +206,7 @@ export function MonitorConfigBoard({
                           canDrop={canDrop}
                           onDropOverColumn={() => handleDropAtBucket(bucket)}
                           itemIds={bucket.cards.map((card) => card.monitorId)}
-                          summary={formatTemplate(copy.shared.monitorsCount, {
-                            count: bucket.cards.length,
-                          })}
-                          metaAction={
+                          headerAction={
                             <Button
                               type='button'
                               variant='ghost'

--- a/apps/tradinggoose/blocks/blocks/agent.test.ts
+++ b/apps/tradinggoose/blocks/blocks/agent.test.ts
@@ -10,8 +10,13 @@ vi.mock('@/providers/ai/utils', () => ({
   getAllModelProviders: vi.fn(() => ({ 'gpt-4o': 'openai_chat' })),
   getHostedModels: vi.fn(() => []),
   getMaxTemperature: vi.fn(() => 1),
+  getProviderFromModel: vi.fn(() => 'openai'),
   getProviderIcon: vi.fn(() => undefined),
   providers: {
+    openai: {
+      name: 'OpenAI',
+      models: ['gpt-4o'],
+    },
     'azure-openai': {
       models: [],
     },

--- a/apps/tradinggoose/blocks/blocks/agent.ts
+++ b/apps/tradinggoose/blocks/blocks/agent.ts
@@ -1,12 +1,13 @@
 import { AgentIcon } from '@/components/icons/icons'
 import { isHosted } from '@/lib/environment'
 import { createLogger } from '@/lib/logs/console/logger'
-import type { BlockConfig } from '@/blocks/types'
+import type { BlockConfig, SubBlockOption, SubBlockOptionGroup } from '@/blocks/types'
 import { AuthMode } from '@/blocks/types'
 import {
   getAllModelProviders,
   getHostedModels,
   getMaxTemperature,
+  getProviderFromModel,
   getProviderIcon,
   MODELS_WITH_REASONING_EFFORT,
   MODELS_WITH_VERBOSITY,
@@ -29,6 +30,42 @@ const getAvailableModels = () => {
   const ollamaModels = providersState.providers.ollama.models
   const openrouterModels = providersState.providers.openrouter.models
   return Array.from(new Set([...baseModels, ...ollamaModels, ...openrouterModels]))
+}
+
+const getAvailableModelOptions = (): SubBlockOption[] => {
+  return getAvailableModels().map((model) => {
+    const providerId = getProviderFromModel(model)
+    const provider = providers[providerId]
+    const icon = provider?.icon ?? getProviderIcon(model)
+
+    return {
+      label: model,
+      id: model,
+      group: providerId,
+      searchLabel: `${model} ${provider?.name ?? providerId}`,
+      ...(icon && { icon }),
+    }
+  })
+}
+
+const getAvailableModelGroups = (): SubBlockOptionGroup[] => {
+  const seenProviderIds = new Set<string>()
+  const groups: SubBlockOptionGroup[] = []
+
+  for (const model of getAvailableModels()) {
+    const providerId = getProviderFromModel(model)
+    if (seenProviderIds.has(providerId)) continue
+
+    const provider = providers[providerId]
+    seenProviderIds.add(providerId)
+    groups.push({
+      id: providerId,
+      label: provider?.name ?? providerId,
+      ...(provider?.icon && { icon: provider.icon }),
+    })
+  }
+
+  return groups
 }
 
 interface AgentResponse extends ToolResponse {
@@ -170,19 +207,14 @@ Create a system prompt appropriately detailed for the request, using clear langu
       layout: 'half',
       placeholder: 'Type or select a model...',
       required: true,
+      dropdownMode: 'sidebar',
+      optionGroups: getAvailableModelGroups,
       value: () => {
         const allModels = getAvailableModels()
         if (allModels.includes('gpt-4o')) return 'gpt-4o'
         return allModels[0]
       },
-      options: () => {
-        const allModels = getAvailableModels()
-
-        return allModels.map((model) => {
-          const icon = getProviderIcon(model)
-          return { label: model, id: model, ...(icon && { icon }) }
-        })
-      },
+      options: getAvailableModelOptions,
     },
     {
       id: 'temperature',

--- a/apps/tradinggoose/blocks/types.ts
+++ b/apps/tradinggoose/blocks/types.ts
@@ -149,6 +149,12 @@ export interface SubBlockOption {
   rightLabel?: string
 }
 
+export interface SubBlockOptionGroup {
+  id: string
+  label: string
+  icon?: React.ComponentType<{ className?: string }>
+}
+
 export interface SubBlockConfig {
   id: string
   title?: string
@@ -193,6 +199,8 @@ export interface SubBlockConfig {
   showCopyButton?: boolean
   enableSearch?: boolean
   searchPlaceholder?: string
+  dropdownMode?: 'default' | 'sidebar'
+  optionGroups?: SubBlockOptionGroup[] | (() => SubBlockOptionGroup[])
   autoSelectFirstOption?: boolean
   connectionDroppable?: boolean
   hidden?: boolean

--- a/apps/tradinggoose/components/listing-selector/selector/dropdown.test.tsx
+++ b/apps/tradinggoose/components/listing-selector/selector/dropdown.test.tsx
@@ -3,8 +3,8 @@
  */
 
 import { act, type ComponentProps } from 'react'
-import { createRoot, type Root } from 'react-dom/client'
 import { NextIntlClientProvider } from 'next-intl'
+import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getPublicCopy } from '@/i18n/public-copy'
 import { ListingSelectorDropdownContent } from './dropdown'
@@ -40,6 +40,9 @@ describe('ListingSelectorDropdownContent localized copy', () => {
       root.render(
         <NextIntlClientProvider locale={locale} messages={getPublicCopy(locale)}>
           <ListingSelectorDropdownContent
+            groups={[{ id: 'all', label: 'All' }]}
+            activeGroupId='all'
+            onActiveGroupChange={vi.fn()}
             results={[]}
             isLoading={false}
             highlightedIndex={-1}

--- a/apps/tradinggoose/components/listing-selector/selector/dropdown.tsx
+++ b/apps/tradinggoose/components/listing-selector/selector/dropdown.tsx
@@ -1,19 +1,19 @@
 'use client'
 
-import {
-  type CSSProperties,
-  type ReactNode,
-  type TouchEvent,
-  useEffect,
-  useRef,
-  type WheelEvent,
-} from 'react'
+import { type ReactNode, type TouchEvent, useEffect, useRef, type WheelEvent } from 'react'
 import { MarketListingRow } from '@/components/listing-selector/listing/row'
-import { useWorkspaceWidgetsMessages } from '@/i18n/workspace-widget-hooks'
+import {
+  type SidebarDropdownGroup,
+  type SidebarDropdownItem,
+  SidebarDropdownMenuContent,
+} from '@/components/ui/sidebar-dropdown-menu'
 import type { ListingOption } from '@/lib/listing/identity'
-import { cn } from '@/lib/utils'
+import { useWorkspaceWidgetsMessages } from '@/i18n/workspace-widget-hooks'
 
 type ListingSelectorDropdownContentProps = {
+  groups: SidebarDropdownGroup[]
+  activeGroupId: string
+  onActiveGroupChange: (groupId: string) => void
   results: ListingOption[]
   isLoading: boolean
   error?: string
@@ -21,12 +21,14 @@ type ListingSelectorDropdownContentProps = {
   onHighlightChange: (index: number) => void
   onSelect: (listing: ListingOption) => void
   renderListing?: (listing: ListingOption) => ReactNode
-  scrollStyle?: CSSProperties
   onWheelCapture?: (event: WheelEvent<HTMLDivElement>) => void
   onTouchMove?: (event: TouchEvent<HTMLDivElement>) => void
 }
 
 export function ListingSelectorDropdownContent({
+  groups,
+  activeGroupId,
+  onActiveGroupChange,
   results,
   isLoading,
   error,
@@ -34,12 +36,21 @@ export function ListingSelectorDropdownContent({
   onHighlightChange,
   onSelect,
   renderListing,
-  scrollStyle,
   onWheelCapture,
   onTouchMove,
 }: ListingSelectorDropdownContentProps) {
   const dropdownRef = useRef<HTMLDivElement>(null)
   const copy = useWorkspaceWidgetsMessages().listingSelector
+  const items: SidebarDropdownItem[] = results.map((listing, index) => ({
+    id: String(index),
+    groupId: activeGroupId,
+    label: listing.name?.trim() || listing.base?.trim() || 'Listing',
+    content: renderListing ? (
+      renderListing(listing)
+    ) : (
+      <MarketListingRow listing={listing} showAssetClass className='w-full' />
+    ),
+  }))
 
   useEffect(() => {
     if (highlightedIndex < 0 || !dropdownRef.current) return
@@ -50,48 +61,27 @@ export function ListingSelectorDropdownContent({
   }, [highlightedIndex])
 
   return (
-    <div className='allow-scroll fade-in-0 zoom-in-95 animate-in rounded-md border bg-popover text-popover-foreground shadow-md'>
-      <div
-        ref={dropdownRef}
-        className='allow-scroll max-h-64 overflow-y-auto p-1'
-        style={scrollStyle ?? { scrollbarWidth: 'thin' }}
-        onMouseLeave={() => onHighlightChange(-1)}
-        onWheelCapture={onWheelCapture}
-        onTouchMove={onTouchMove}
-      >
-        {isLoading ? (
-          <div className='py-6 text-center text-muted-foreground text-sm'>{copy.searching}</div>
-        ) : results.length === 0 ? (
-          <div className='py-6 text-center text-muted-foreground text-sm'>
-            {error || copy.noListingsFound}
-          </div>
-        ) : (
-          results.map((listing, index) => {
-            const isHighlighted = index === highlightedIndex
-            return (
-              <div
-                key={`${listing.listing_type}|${listing.listing_id}|${listing.base_id}|${listing.quote_id}`}
-                data-option-index={index}
-                onMouseEnter={() => onHighlightChange(index)}
-                onMouseDown={(event) => {
-                  event.preventDefault()
-                  onSelect(listing)
-                }}
-                className={cn(
-                  'flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground',
-                  isHighlighted && 'bg-accent text-accent-foreground'
-                )}
-              >
-                {renderListing ? (
-                  renderListing(listing)
-                ) : (
-                  <MarketListingRow listing={listing} showAssetClass className='w-full' />
-                )}
-              </div>
-            )
-          })
-        )}
-      </div>
+    <div
+      ref={dropdownRef}
+      className='allow-scroll fade-in-0 zoom-in-95 animate-in rounded-md border bg-popover text-popover-foreground shadow-md'
+      onMouseLeave={() => onHighlightChange(-1)}
+      onWheelCapture={onWheelCapture}
+      onTouchMove={onTouchMove}
+    >
+      <SidebarDropdownMenuContent
+        groups={groups}
+        items={items}
+        activeGroupId={activeGroupId}
+        highlightedItemId={highlightedIndex >= 0 ? String(highlightedIndex) : null}
+        onActiveGroupChange={onActiveGroupChange}
+        onHighlightItem={(_item, index) => onHighlightChange(index)}
+        onSelectItem={(item) => {
+          const listing = results[Number(item.id)]
+          if (listing) onSelect(listing)
+        }}
+        loadingContent={isLoading ? copy.searching : null}
+        emptyContent={error || copy.noListingsFound}
+      />
     </div>
   )
 }

--- a/apps/tradinggoose/components/listing-selector/selector/input.tsx
+++ b/apps/tradinggoose/components/listing-selector/selector/input.tsx
@@ -2,7 +2,6 @@
 
 import type { ChangeEvent, FocusEvent, KeyboardEvent } from 'react'
 import { useEffect, useRef, useState } from 'react'
-import { ChevronDown } from 'lucide-react'
 import { createPortal } from 'react-dom'
 import {
   triggerCryptoRankUpdate,
@@ -15,10 +14,10 @@ import {
   ListingDisplayRow,
   MarketListingRow,
 } from '@/components/listing-selector/listing/row'
+import { SUPPORTED_MARKET_ASSET_CLASSES } from '@/components/listing-selector/search-utils'
 import { ListingSelectorDropdownContent } from '@/components/listing-selector/selector/dropdown'
 import { requestListingResolution } from '@/components/listing-selector/selector/resolve-request'
 import { useMarketListingSearch } from '@/components/listing-selector/selector/use-listing-search'
-import { Button } from '@/components/ui/button'
 import { formatDisplayText } from '@/components/ui/formatted-text'
 import { Input } from '@/components/ui/input'
 import { checkTagTrigger, TagDropdown } from '@/components/ui/tag-dropdown'
@@ -56,6 +55,21 @@ export interface ListingSearchInputProps {
   onListingTagSelect?: (value: string) => void
 }
 
+const ALL_ASSET_CLASS_FILTER_ID = 'all'
+const LISTING_DROPDOWN_MIN_WIDTH = 420
+const LISTING_DROPDOWN_VIEWPORT_PADDING = 8
+
+const LISTING_ASSET_CLASS_GROUPS = [
+  { id: ALL_ASSET_CLASS_FILTER_ID, label: 'All' },
+  ...SUPPORTED_MARKET_ASSET_CLASSES.map((assetClass) => ({
+    id: assetClass,
+    label:
+      assetClass === 'mutualfund'
+        ? 'Mutual Fund'
+        : assetClass.charAt(0).toUpperCase() + assetClass.slice(1),
+  })),
+]
+
 export function ListingSearchInput({
   instanceId,
   blockId,
@@ -84,6 +98,8 @@ export function ListingSearchInput({
   const hasActivatedOnMountRef = useRef(false)
   const [open, setOpen] = useState(false)
   const [highlightedIndex, setHighlightedIndex] = useState(-1)
+  const [activeAssetClassFilterId, setActiveAssetClassFilterId] =
+    useState(ALL_ASSET_CLASS_FILTER_ID)
   const [showTags, setShowTags] = useState(false)
   const [cursorPosition, setCursorPosition] = useState(0)
   const [variableCommitted, setVariableCommitted] = useState(false)
@@ -113,6 +129,8 @@ export function ListingSearchInput({
   const showPlaceholderOverlay =
     isHeader && !open && !selectedListing && !query?.trim() && !hasUnresolvedSelection
   const hideInputText = showRichOverlay || showTagOverlay || showPlaceholderOverlay
+  const assetClassFilter =
+    activeAssetClassFilterId === ALL_ASSET_CLASS_FILTER_ID ? null : activeAssetClassFilterId
 
   const isVariableListingInput = (value: string) => value.trim().startsWith('<')
 
@@ -172,6 +190,13 @@ export function ListingSearchInput({
     }
 
     onListingChange?.(listing)
+  }
+
+  const handleAssetClassFilterChange = (groupId: string) => {
+    setActiveAssetClassFilterId(groupId)
+    setHighlightedIndex(-1)
+    setOpen(true)
+    inputRef.current?.focus()
   }
 
   const handleTagSelect = (value: string) => {
@@ -307,6 +332,7 @@ export function ListingSearchInput({
     providerType,
     marketProviderId,
     tradingProviderId,
+    assetClassFilter,
     instanceId,
     updateInstance,
     candidateListings,
@@ -408,10 +434,17 @@ export function ListingSearchInput({
       const container = containerRef.current
       if (!container) return
       const rect = container.getBoundingClientRect()
+      const availableWidth = Math.max(0, window.innerWidth - LISTING_DROPDOWN_VIEWPORT_PADDING * 2)
+      const width = Math.min(Math.max(rect.width, LISTING_DROPDOWN_MIN_WIDTH), availableWidth)
+      const viewportLeft = window.scrollX + LISTING_DROPDOWN_VIEWPORT_PADDING
+      const maxLeft = window.scrollX + window.innerWidth - width - LISTING_DROPDOWN_VIEWPORT_PADDING
+      const centeredLeft = rect.left + window.scrollX + (rect.width - width) / 2
+      const left = Math.max(viewportLeft, Math.min(centeredLeft, maxLeft))
+
       setDropdownPosition({
         top: rect.bottom + window.scrollY + 4,
-        left: rect.left + window.scrollX,
-        width: rect.width,
+        left,
+        width,
       })
     }
 
@@ -443,16 +476,16 @@ export function ListingSearchInput({
       onWheel={(event) => event.stopPropagation()}
     >
       <ListingSelectorDropdownContent
+        groups={LISTING_ASSET_CLASS_GROUPS}
+        activeGroupId={activeAssetClassFilterId}
+        onActiveGroupChange={handleAssetClassFilterChange}
         results={results}
         isLoading={isLoading}
         error={error}
         highlightedIndex={highlightedIndex}
         onHighlightChange={setHighlightedIndex}
         onSelect={handleSelect}
-        renderListing={(listing) => (
-          <ListingDisplayRow listing={listing} showSecondary={isHeader} />
-        )}
-        scrollStyle={{ scrollbarWidth: 'thin', overscrollBehavior: 'contain' }}
+        renderListing={(listing) => <ListingDisplayRow listing={listing} showSecondary />}
         onWheelCapture={(event) => event.stopPropagation()}
         onTouchMove={(event) => event.stopPropagation()}
       />
@@ -472,8 +505,8 @@ export function ListingSearchInput({
           name={`listing-search-${instanceId}`}
           className={cn(
             isHeader
-              ? widgetHeaderControlClassName('w-full justify-center pr-9 font-medium text-sm')
-              : ['w-full pr-10', compact ? 'h-8 text-sm' : 'h-10'],
+              ? widgetHeaderControlClassName('w-full justify-center font-medium text-sm')
+              : ['w-full', compact ? 'h-8 text-sm' : 'h-10'],
             hideInputText && 'text-transparent caret-transparent placeholder:text-transparent'
           )}
           placeholder={isHeader ? 'Search listings...' : 'Select listing'}
@@ -523,34 +556,6 @@ export function ListingSearchInput({
             </div>
           </div>
         ) : null}
-        <Button
-          type='button'
-          variant='ghost'
-          size='sm'
-          className='-translate-y-1/2 absolute top-1/2 right-1 z-10 h-6 w-6 bg-transparent p-0'
-          disabled={disabled}
-          onMouseDown={(event) => {
-            event.preventDefault()
-            if (disabled) return
-            setOpen((prev) => {
-              const next = !prev
-              if (!next) {
-                setShowTags(false)
-              }
-              return next
-            })
-            if (!open) {
-              inputRef.current?.focus()
-            }
-          }}
-        >
-          <ChevronDown
-            className={cn(
-              'h-4 w-4 opacity-0 transition-transform',
-              open && 'rotate-180 opacity-50'
-            )}
-          />
-        </Button>
       </div>
 
       {listingDropdown && portalTarget && dropdownPosition

--- a/apps/tradinggoose/components/listing-selector/selector/search-request.ts
+++ b/apps/tradinggoose/components/listing-selector/selector/search-request.ts
@@ -1,7 +1,7 @@
 import {
   type ParsedMarketQuery,
-  SUPPORTED_MARKET_ASSET_CLASSES,
   parseCategorizedSearchQuery,
+  SUPPORTED_MARKET_ASSET_CLASSES,
   serializeArrayParam,
 } from '@/components/listing-selector/search-utils'
 import type { ProviderSearchConfig } from '@/components/listing-selector/selector/use-provider-config'
@@ -14,17 +14,19 @@ export type MarketListingSearchRequest = {
 export function buildMarketSearchRequest(args: {
   rawQuery: string
   providerConfig: ProviderSearchConfig
+  assetClassFilter?: string | null
 }): MarketListingSearchRequest {
-  const { rawQuery, providerConfig } = args
+  const { rawQuery, providerConfig, assetClassFilter } = args
   const trimmed = rawQuery.trim()
 
   const queryParams: Record<string, string> = {}
   const filtersPayload: Record<string, unknown> = {}
   const parsedQuery: ParsedMarketQuery = trimmed ? parseCategorizedSearchQuery(trimmed) : {}
+  const requestedAssetClass = assetClassFilter?.trim().toLowerCase() || parsedQuery.assetClass
   if (
-    parsedQuery.assetClass &&
+    requestedAssetClass &&
     providerConfig.assetClasses.length &&
-    !providerConfig.assetClasses.includes(parsedQuery.assetClass)
+    !providerConfig.assetClasses.includes(requestedAssetClass)
   ) {
     return {
       queryParams,
@@ -32,8 +34,8 @@ export function buildMarketSearchRequest(args: {
     }
   }
 
-  const resolvedAssetClasses = parsedQuery.assetClass
-    ? [parsedQuery.assetClass]
+  const resolvedAssetClasses = requestedAssetClass
+    ? [requestedAssetClass]
     : providerConfig.assetClasses.length
       ? providerConfig.assetClasses
       : [...SUPPORTED_MARKET_ASSET_CLASSES]

--- a/apps/tradinggoose/components/listing-selector/selector/use-listing-search.test.tsx
+++ b/apps/tradinggoose/components/listing-selector/selector/use-listing-search.test.tsx
@@ -104,6 +104,34 @@ describe('useMarketListingSearch', () => {
     )
   })
 
+  it('scopes market searches to the selected asset class filter', async () => {
+    const updateInstance = vi.fn()
+
+    fetchListingsMock.mockResolvedValue([])
+
+    await act(async () => {
+      root.render(
+        <HookHarness
+          open
+          query=''
+          providerType='market'
+          assetClassFilter='crypto'
+          instanceId='test-selector'
+          updateInstance={updateInstance}
+        />
+      )
+      await Promise.resolve()
+    })
+
+    expect(fetchListingsMock).toHaveBeenCalledTimes(1)
+    expect(fetchListingsMock).toHaveBeenCalledWith(
+      {
+        filters: JSON.stringify({ limit: 50, asset_class: ['crypto'] }),
+      },
+      expect.any(AbortSignal)
+    )
+  })
+
   it('does not let explicit asset prefixes bypass combined provider criteria', async () => {
     const updateInstance = vi.fn()
 
@@ -281,15 +309,16 @@ describe('useMarketListingSearch', () => {
     })
   })
 
-  it('filters scoped candidate listings without calling market search', async () => {
+  it('filters scoped candidate listings by selected asset class without calling market search', async () => {
     const updateInstance = vi.fn()
 
     await act(async () => {
       root.render(
         <HookHarness
           open
-          query='btc'
+          query=''
           providerType='market'
+          assetClassFilter='crypto'
           instanceId='test-selector'
           updateInstance={updateInstance}
           candidateListings={[

--- a/apps/tradinggoose/components/listing-selector/selector/use-listing-search.ts
+++ b/apps/tradinggoose/components/listing-selector/selector/use-listing-search.ts
@@ -19,6 +19,7 @@ type UseMarketListingSearchOptions = {
   providerType?: 'market' | 'trading'
   marketProviderId?: string
   tradingProviderId?: string
+  assetClassFilter?: string | null
   instanceId: string
   updateInstance: UpdateInstance
   candidateListings?: ListingOption[]
@@ -44,6 +45,17 @@ const listingMatchesQuery = (listing: ListingOption, query: string): boolean => 
     .includes(query)
 }
 
+const listingMatchesAssetClass = (
+  listing: ListingOption,
+  assetClassFilter?: string | null
+): boolean => {
+  if (!assetClassFilter) return true
+  const normalizedFilter = assetClassFilter.trim().toLowerCase()
+  const listingAssetClass = listing.assetClass?.trim().toLowerCase()
+  if (listingAssetClass) return listingAssetClass === normalizedFilter
+  return listing.listing_type === normalizedFilter
+}
+
 export function useMarketListingSearch({
   open,
   query,
@@ -51,6 +63,7 @@ export function useMarketListingSearch({
   providerType = 'market',
   marketProviderId,
   tradingProviderId,
+  assetClassFilter,
   instanceId,
   updateInstance,
   candidateListings,
@@ -113,8 +126,10 @@ export function useMarketListingSearch({
       }
 
       updateInstance(instanceId, {
-        results: candidateListings.filter((listing) =>
-          listingMatchesQuery(listing, trimmedQuery.toLowerCase())
+        results: candidateListings.filter(
+          (listing) =>
+            listingMatchesAssetClass(listing, assetClassFilter) &&
+            listingMatchesQuery(listing, trimmedQuery.toLowerCase())
         ),
         isLoading: false,
         error: candidateListingsError,
@@ -134,6 +149,7 @@ export function useMarketListingSearch({
     const { queryParams, requestKey } = buildMarketSearchRequest({
       rawQuery: debouncedQuery,
       providerConfig,
+      assetClassFilter,
     })
     if (Object.keys(queryParams).length === 0) {
       abortInFlightRequest()
@@ -180,6 +196,7 @@ export function useMarketListingSearch({
     providerType,
     marketProviderId,
     tradingProviderId,
+    assetClassFilter,
     providerConfig,
     instanceId,
     updateInstance,

--- a/apps/tradinggoose/components/ui/dropdown-menu.tsx
+++ b/apps/tradinggoose/components/ui/dropdown-menu.tsx
@@ -50,9 +50,10 @@ DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayNam
 const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
+>(({ className, collisionPadding = 8, ...props }, ref) => (
   <DropdownMenuPrimitive.SubContent
     ref={ref}
+    collisionPadding={collisionPadding}
     className={cn(
       'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=closed]:animate-out data-[state=open]:animate-in',
       className
@@ -75,6 +76,7 @@ const DropdownMenuContent = React.forwardRef<
     {
       className,
       sideOffset = 4,
+      collisionPadding = 8,
       avoidCollisions,
       sticky = 'always',
       align = 'auto',
@@ -94,6 +96,7 @@ const DropdownMenuContent = React.forwardRef<
       <DropdownMenuPrimitive.Content
         ref={ref}
         sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
         avoidCollisions={resolvedAvoidCollisions}
         sticky={sticky as any}
         align={resolvedAlign}

--- a/apps/tradinggoose/components/ui/popover.tsx
+++ b/apps/tradinggoose/components/ui/popover.tsx
@@ -22,6 +22,7 @@ export const PopoverEnvironmentProvider = ({
 const Popover = PopoverPrimitive.Root
 
 const PopoverTrigger = PopoverPrimitive.Trigger
+const PopoverAnchor = PopoverPrimitive.Anchor
 
 type PopoverContentProps = React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
   container?: React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Portal>['container']
@@ -38,6 +39,7 @@ const PopoverContent = React.forwardRef<
       className,
       align = 'center',
       sideOffset = 4,
+      collisionPadding = 8,
       container,
       scale,
       zIndex,
@@ -68,6 +70,7 @@ const PopoverContent = React.forwardRef<
           ref={ref}
           align={align}
           sideOffset={scaledSideOffset}
+          collisionPadding={collisionPadding}
           className={cn(
             'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=closed]:animate-out data-[state=open]:animate-in',
             className
@@ -85,4 +88,4 @@ const PopoverContent = React.forwardRef<
 )
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 
-export { Popover, PopoverTrigger, PopoverContent }
+export { Popover, PopoverAnchor, PopoverTrigger, PopoverContent }

--- a/apps/tradinggoose/components/ui/sidebar-dropdown-menu.tsx
+++ b/apps/tradinggoose/components/ui/sidebar-dropdown-menu.tsx
@@ -73,7 +73,7 @@ export function SidebarDropdownMenuContent({
                     aria-label={Icon ? group.label : undefined}
                     data-active={isActive ? 'true' : undefined}
                     className={cn(
-                      'flex h-8 w-full min-w-0 items-center rounded-sm text-muted-foreground text-xs transition-colors hover:bg-accent hover:text-accent-foreground data-[active=true]:bg-accent data-[active=true]:text-accent-foreground',
+                      'flex h-8 w-full min-w-0 items-center rounded-sm text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-accent-foreground data-[active=true]:bg-muted data-[active=true]:text-accent-foreground',
                       Icon ? 'w-8 shrink-0 justify-center px-0' : 'gap-2 px-2 text-left'
                     )}
                     onMouseDown={(event) => event.preventDefault()}

--- a/apps/tradinggoose/components/ui/sidebar-dropdown-menu.tsx
+++ b/apps/tradinggoose/components/ui/sidebar-dropdown-menu.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import type { ComponentType, MouseEvent, ReactNode } from 'react'
+import { Check } from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+export type SidebarDropdownGroup = {
+  id: string
+  label: string
+  icon?: ComponentType<{ className?: string }>
+}
+
+export type SidebarDropdownItem = {
+  id: string
+  groupId: string
+  label: string
+  selected?: boolean
+  icon?: ReactNode
+  content?: ReactNode
+}
+
+interface SidebarDropdownMenuContentProps {
+  groups: SidebarDropdownGroup[]
+  items: SidebarDropdownItem[]
+  activeGroupId?: string | null
+  highlightedItemId?: string | null
+  onActiveGroupChange: (groupId: string) => void
+  onSelectItem: (item: SidebarDropdownItem, event: MouseEvent<HTMLButtonElement>) => void
+  onHighlightItem?: (item: SidebarDropdownItem, index: number) => void
+  loadingContent?: ReactNode
+  emptyContent: ReactNode
+}
+
+export function SidebarDropdownMenuContent({
+  groups,
+  items,
+  activeGroupId,
+  highlightedItemId,
+  onActiveGroupChange,
+  onSelectItem,
+  onHighlightItem,
+  loadingContent,
+  emptyContent,
+}: SidebarDropdownMenuContentProps) {
+  const resolvedActiveGroupId = activeGroupId ?? groups[0]?.id ?? ''
+  const visibleItems = items.filter((item) => item.groupId === resolvedActiveGroupId)
+  const hasGroups = groups.length > 0
+  const sidebarShowsOnlyIcons = groups.every((group) => group.icon)
+
+  return (
+    <div className='flex h-full max-h-[inherit] min-h-0 flex-col'>
+      <div className='flex min-h-0 flex-1 overflow-hidden'>
+        {hasGroups ? (
+          <div
+            className={cn(
+              'shrink-0 border-border/70 border-r p-1',
+              sidebarShowsOnlyIcons ? 'w-12' : 'w-24'
+            )}
+          >
+            <div
+              className={cn(
+                'allow-scroll flex h-56 min-w-0 flex-col gap-1 overflow-y-auto items-center [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'
+              )}
+            >
+              {groups.map((group) => {
+                const Icon = group.icon
+                const isActive = group.id === resolvedActiveGroupId
+                const groupButton = (
+                  <button
+                    key={group.id}
+                    type='button'
+                    aria-label={Icon ? group.label : undefined}
+                    data-active={isActive ? 'true' : undefined}
+                    className={cn(
+                      'flex h-8 w-full min-w-0 items-center rounded-sm text-muted-foreground text-xs transition-colors hover:bg-accent hover:text-accent-foreground data-[active=true]:bg-accent data-[active=true]:text-accent-foreground',
+                      Icon ? 'w-8 shrink-0 justify-center px-0' : 'gap-2 px-2 text-left'
+                    )}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => onActiveGroupChange(group.id)}
+                  >
+                    {Icon ? (
+                      <span className='flex h-4 w-4 shrink-0 items-center justify-center [&_img]:h-3.5 [&_img]:w-3.5 [&_svg]:h-3.5 [&_svg]:w-3.5'>
+                        <Icon className='h-3.5 w-3.5 shrink-0' />
+                      </span>
+                    ) : (
+                      <span className='min-w-0 flex-1 truncate'>{group.label}</span>
+                    )}
+                  </button>
+                )
+
+                if (!Icon) return groupButton
+
+                return (
+                  <Tooltip key={group.id}>
+                    <TooltipTrigger asChild>{groupButton}</TooltipTrigger>
+                    <TooltipContent side='left'>{group.label}</TooltipContent>
+                  </Tooltip>
+                )
+              })}
+            </div>
+          </div>
+        ) : null}
+        <div className='allow-scroll h-56 min-w-0 flex-1 overflow-y-auto px-2 py-2'>
+          {loadingContent ? (
+            <div className='px-2 py-4 text-center text-muted-foreground text-xs'>
+              {loadingContent}
+            </div>
+          ) : visibleItems.length === 0 ? (
+            <div className='px-2 py-4 text-center text-muted-foreground text-xs'>
+              {emptyContent}
+            </div>
+          ) : (
+            <div className='flex w-full min-w-0 flex-col gap-1'>
+              {visibleItems.map((item, index) => (
+                <button
+                  key={item.id}
+                  type='button'
+                  data-option-index={index}
+                  data-highlighted={highlightedItemId === item.id ? 'true' : undefined}
+                  className='relative flex w-full min-w-0 cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-left text-muted-foreground text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground data-[highlighted=true]:bg-accent data-[highlighted=true]:text-accent-foreground'
+                  onMouseDown={(event) => event.preventDefault()}
+                  onMouseEnter={() => onHighlightItem?.(item, index)}
+                  onClick={(event) => onSelectItem(item, event)}
+                >
+                  {item.content ? (
+                    <div className='min-w-0 flex-1'>{item.content}</div>
+                  ) : (
+                    <>
+                      {item.icon}
+                      <span className='min-w-0 flex-1 truncate'>{item.label}</span>
+                      {item.selected ? <Check className='h-4 w-4 flex-shrink-0' /> : null}
+                    </>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/tradinggoose/widgets/widgets/components/pine-indicator-dropdown.tsx
+++ b/apps/tradinggoose/widgets/widgets/components/pine-indicator-dropdown.tsx
@@ -1,36 +1,31 @@
 'use client'
 
-import { type KeyboardEvent, useEffect, useMemo, useState } from 'react'
-import { Activity, Check, ChevronDown, Loader2, Search } from 'lucide-react'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Activity, ChevronDown, Home, Loader2, User } from 'lucide-react'
 import { Input } from '@/components/ui/input'
-import { ScrollArea } from '@/components/ui/scroll-area'
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
+import {
+  type SidebarDropdownGroup,
+  type SidebarDropdownItem,
+  SidebarDropdownMenuContent,
+} from '@/components/ui/sidebar-dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { useWorkspaceWidgetsMessages } from '@/i18n/workspace-widget-hooks'
+import { widgetHeaderControlClassName } from '@/components/widget-header-control'
 import { getStableVibrantColor } from '@/lib/colors'
 import { DEFAULT_INDICATORS_META } from '@/lib/indicators/default'
 import { cn } from '@/lib/utils'
 import { useIndicators } from '@/hooks/queries/indicators'
+import { useWorkspaceWidgetsMessages } from '@/i18n/workspace-widget-hooks'
 import { useIndicatorsStore } from '@/stores/indicators/store'
-import {
-  widgetHeaderControlClassName,
-  widgetHeaderMenuContentClassName,
-  widgetHeaderMenuItemClassName,
-  widgetHeaderMenuTextClassName,
-} from '@/components/widget-header-control'
 
 const FALLBACK_COLOR = '#3972F6'
-const DROPDOWN_MAX_HEIGHT = '20rem'
-const DROPDOWN_VIEWPORT_HEIGHT = '14rem'
+
+type IndicatorFilterId = 'default' | 'custom'
 
 type IndicatorOption = {
   id: string
   name: string
+  source: IndicatorFilterId
   color?: string
 }
 
@@ -72,6 +67,11 @@ export function IndicatorDropdown({
   const [internalValue, setInternalValue] = useState<string[]>([])
   const [loadError, setLoadError] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
+  const [dropdownOpen, setDropdownOpen] = useState(false)
+  const [activeFilterId, setActiveFilterId] = useState<IndicatorFilterId>(
+    includeDefaults ? 'default' : 'custom'
+  )
+  const inputRef = useRef<HTMLInputElement>(null)
 
   const isMultiSelect = selectionMode === 'multiple'
 
@@ -102,6 +102,7 @@ export function IndicatorDropdown({
         ? DEFAULT_INDICATORS_META.map((indicator) => ({
             id: indicator.id,
             name: indicator.name,
+            source: 'default' as const,
             color: getStableVibrantColor(indicator.id),
           }))
         : [],
@@ -113,6 +114,7 @@ export function IndicatorDropdown({
       workspaceIndicators.map((indicator) => ({
         id: indicator.id,
         name: indicator.name || indicator.id,
+        source: 'custom' as const,
         color: indicator.color,
       })),
     [workspaceIndicators]
@@ -125,7 +127,8 @@ export function IndicatorDropdown({
 
   const isControlled = typeof value !== 'undefined'
   const selectedIndicatorIds = isControlled ? (value ?? []) : internalValue
-  const selectedIndicatorSet = new Set(selectedIndicatorIds)
+  const firstSelectedIndicatorId = selectedIndicatorIds[0] ?? null
+  const selectedIndicatorSet = useMemo(() => new Set(selectedIndicatorIds), [selectedIndicatorIds])
   const selectedIndicatorId = !isMultiSelect ? (selectedIndicatorIds[0] ?? null) : null
   const selectedIndicator = !isMultiSelect
     ? indicatorOptions.find((indicator) => indicator.id === selectedIndicatorId)
@@ -156,10 +159,12 @@ export function IndicatorDropdown({
   useEffect(() => {
     setLoadError(null)
     setSearchQuery('')
+    setDropdownOpen(false)
+    setActiveFilterId(includeDefaults ? 'default' : 'custom')
     if (!isControlled) {
       setInternalValue([])
     }
-  }, [workspaceId, isControlled])
+  }, [workspaceId, isControlled, includeDefaults])
 
   useEffect(() => {
     if (queryError) {
@@ -173,23 +178,13 @@ export function IndicatorDropdown({
     }
   }, [indicatorOptions.length, loadError])
 
-  const filteredDefaultIndicators = useMemo(() => {
-    const query = searchQuery.trim().toLowerCase()
-    if (!query) return defaultIndicatorOptions
-    return defaultIndicatorOptions.filter((option) => option.name?.toLowerCase().includes(query))
-  }, [defaultIndicatorOptions, searchQuery])
-
-  const filteredCustomIndicators = useMemo(() => {
-    const query = searchQuery.trim().toLowerCase()
-    if (!query) return customIndicatorOptions
-    return customIndicatorOptions.filter((option) => option.name?.toLowerCase().includes(query))
-  }, [customIndicatorOptions, searchQuery])
-
-  const handleSearchInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Escape') {
-      return
-    }
-  }
+  const selectedFilterId = useMemo<IndicatorFilterId>(() => {
+    if (!includeDefaults) return 'custom'
+    if (!firstSelectedIndicatorId) return 'default'
+    return defaultIndicatorOptions.some((option) => option.id === firstSelectedIndicatorId)
+      ? 'default'
+      : 'custom'
+  }, [defaultIndicatorOptions, firstSelectedIndicatorId, includeDefaults])
 
   const handleSelectionChange = (nextIds: string[]) => {
     if (isControlled) {
@@ -228,6 +223,7 @@ export function IndicatorDropdown({
     if (selectedIndicatorIds.length === 1) return first.name
     return `${first.name} +${selectedIndicatorIds.length - 1}`
   }, [copy.placeholder, indicatorOptions, placeholder, selectedIndicatorIds])
+  const hasSelection = selectedIndicatorIds.length > 0
 
   const colorBadge = (
     <div
@@ -245,217 +241,204 @@ export function IndicatorDropdown({
     </div>
   )
 
-  const labelContent =
-    selectedIndicatorIds.length > 0 ? (
-      <span className='min-w-0 flex-1 truncate text-left font-medium text-foreground text-sm'>
-        {selectionLabel}
-      </span>
-    ) : (
-      <span className='min-w-0 flex-1 truncate text-left font-medium text-muted-foreground text-sm'>
-        {selectionLabel}
-      </span>
-    )
+  const indicatorGroups = useMemo<SidebarDropdownGroup[]>(() => {
+    const groups: SidebarDropdownGroup[] = []
+    if (includeDefaults) {
+      groups.push({
+        id: 'default',
+        label: copy.defaultIndicators,
+        icon: Home,
+      })
+    }
+    groups.push({
+      id: 'custom',
+      label: copy.customIndicators,
+      icon: User,
+    })
+    return groups
+  }, [copy.customIndicators, copy.defaultIndicators, includeDefaults])
 
-  const chevronClassName =
-    'h-4 w-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180'
+  const shouldShowLoadingState = (isLoading || isFetching) && !hasIndicators
+  const emptyContent = (() => {
+    if (loadError && !hasIndicators) {
+      return (
+        <div className='space-y-2 text-xs'>
+          <p className='text-destructive'>{loadError}</p>
+          <button
+            type='button'
+            className='font-semibold text-primary text-xs hover:underline'
+            onClick={handleRetry}
+          >
+            {copy.retry}
+          </button>
+        </div>
+      )
+    }
+
+    if (searchQuery.trim()) return copy.noIndicatorsFound
+    return copy.noIndicatorsAvailableYet
+  })()
+
+  const loadingContent = (
+    <div className='flex items-center justify-center gap-1 text-muted-foreground text-xs'>
+      <Loader2 className='h-3.5 w-3.5 animate-spin' />
+      {copy.loadingIndicators}
+    </div>
+  )
+
+  const normalizedSearchQuery = searchQuery.trim().toLowerCase()
+  const sidebarItems = useMemo<SidebarDropdownItem[]>(
+    () =>
+      indicatorOptions
+        .filter((option) => {
+          if (!normalizedSearchQuery) return true
+          return option.name.toLowerCase().includes(normalizedSearchQuery)
+        })
+        .map((option) => ({
+          id: option.id,
+          groupId: option.source,
+          label: option.name,
+          selected: selectedIndicatorSet.has(option.id),
+          icon: (
+            <div
+              className='h-5 w-5 rounded-xs p-0.5'
+              style={{
+                backgroundColor: `${option.color ?? FALLBACK_COLOR}20`,
+              }}
+              aria-hidden='true'
+            >
+              <Activity
+                className='h-4 w-4 text-muted-foreground'
+                aria-hidden='true'
+                style={{ color: option.color ?? FALLBACK_COLOR }}
+              />
+            </div>
+          ),
+        })),
+    [indicatorOptions, normalizedSearchQuery, selectedIndicatorSet]
+  )
+
+  const visibleIndicatorGroups = useMemo(() => {
+    if (!normalizedSearchQuery) return indicatorGroups
+    const groupIds = new Set(sidebarItems.map((item) => item.groupId))
+    return indicatorGroups.filter((group) => groupIds.has(group.id))
+  }, [indicatorGroups, normalizedSearchQuery, sidebarItems])
+
+  const displayedActiveFilterId = visibleIndicatorGroups.some(
+    (group) => group.id === activeFilterId
+  )
+    ? activeFilterId
+    : (visibleIndicatorGroups[0]?.id ?? null)
+
+  const setOpen = (open: boolean) => {
+    setDropdownOpen(open)
+    if (open) {
+      setActiveFilterId(selectedFilterId)
+      return
+    }
+    setSearchQuery('')
+  }
+
+  const triggerValue = dropdownOpen ? searchQuery : hasSelection ? selectionLabel : ''
+  const triggerPlaceholder = dropdownOpen ? copy.searchPlaceholder : selectionLabel
 
   return (
-    <DropdownMenu modal={false}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className='inline-flex'>
-            <DropdownMenuTrigger asChild>
-              <button
-                type='button'
+    <Popover open={dropdownOpen} onOpenChange={setOpen}>
+      <PopoverAnchor asChild>
+        <div className='relative inline-flex min-w-[220px]'>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Input
+                ref={inputRef}
                 disabled={isDropdownDisabled}
+                value={triggerValue}
+                placeholder={triggerPlaceholder}
                 className={widgetHeaderControlClassName(
                   cn(
-                    'group flex min-w-[220px] items-center justify-between gap-2',
+                    'h-7 min-w-[220px] truncate rounded-sm py-1 pr-8 pl-8 font-medium text-sm focus-visible:ring-0 focus-visible:ring-offset-0',
+                    !hasSelection && !dropdownOpen && 'text-muted-foreground',
                     triggerClassName
                   )
                 )}
+                role='combobox'
+                aria-expanded={dropdownOpen}
                 aria-haspopup='listbox'
-              >
-                {isLoading ? (
-                  <Loader2 className='h-4 w-4 animate-spin text-muted-foreground' />
-                ) : (
-                  colorBadge
-                )}
-                {labelContent}
-                <ChevronDown className={chevronClassName} aria-hidden='true' />
-              </button>
-            </DropdownMenuTrigger>
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side='top'>{tooltipText}</TooltipContent>
-      </Tooltip>
-      <DropdownMenuContent
+                onFocus={() => setOpen(true)}
+                onChange={(event) => {
+                  setSearchQuery(event.target.value)
+                  if (!dropdownOpen) {
+                    setOpen(true)
+                  }
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === 'Escape') {
+                    setOpen(false)
+                    inputRef.current?.blur()
+                  }
+                }}
+              />
+            </TooltipTrigger>
+            <TooltipContent side='top'>{tooltipText}</TooltipContent>
+          </Tooltip>
+          <div className='-translate-y-1/2 pointer-events-none absolute top-1/2 left-2 flex'>
+            {isLoading ? (
+              <Loader2 className='h-4 w-4 animate-spin text-muted-foreground' />
+            ) : (
+              colorBadge
+            )}
+          </div>
+          <button
+            type='button'
+            tabIndex={-1}
+            disabled={isDropdownDisabled}
+            className='-translate-y-1/2 absolute top-1/2 right-1 flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground disabled:cursor-not-allowed'
+            onMouseDown={(event) => {
+              event.preventDefault()
+              if (isDropdownDisabled) return
+              const nextOpen = !dropdownOpen
+              setOpen(nextOpen)
+              if (nextOpen) {
+                inputRef.current?.focus()
+              } else {
+                inputRef.current?.blur()
+              }
+            }}
+            aria-label={dropdownOpen ? 'Close indicators' : 'Open indicators'}
+          >
+            <ChevronDown
+              className={cn('h-4 w-4 transition-transform', dropdownOpen && 'rotate-180')}
+              aria-hidden='true'
+            />
+          </button>
+        </div>
+      </PopoverAnchor>
+      <PopoverContent
+        align='start'
         sideOffset={6}
         className={cn(
-          widgetHeaderMenuContentClassName,
-          'max-h-[20rem] w-[240px] overflow-hidden p-0 shadow-lg',
+          'w-80 max-w-[calc(100vw-2rem)] overflow-hidden rounded-md p-0 shadow-lg',
           menuClassName
         )}
-        style={{ maxHeight: DROPDOWN_MAX_HEIGHT }}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        onCloseAutoFocus={(event) => event.preventDefault()}
         onWheel={(event) => event.stopPropagation()}
       >
-        <div className='flex h-full max-h-[inherit] flex-col'>
-          <div className='border-border/70 border-b p-2'>
-            <div className='flex items-center gap-1 rounded-md border bg-background px-2 py-1.5 text-muted-foreground text-sm'>
-              <Search className='h-3.5 w-3.5 shrink-0' />
-                <Input
-                  value={searchQuery}
-                  onChange={(event) => setSearchQuery(event.target.value)}
-                  placeholder={copy.searchPlaceholder}
-                  className='h-6 border-0 bg-transparent px-0 text-foreground text-xs placeholder:text-muted-foreground focus-visible:ring-0 focus-visible:ring-offset-0'
-                onKeyDown={handleSearchInputKeyDown}
-                autoComplete='off'
-                autoCorrect='off'
-                spellCheck='false'
-                disabled={isDropdownDisabled}
-              />
-            </div>
-          </div>
-          <div className='h-full min-h-0 flex-1 overflow-hidden'>
-            <ScrollArea
-              className={cn(
-                'h-full w-full px-2 py-2',
-                '[&_[data-radix-scroll-area-viewport]>div]:!block',
-                '[&_[data-radix-scroll-area-viewport]>div]:w-full',
-                '[&_[data-radix-scroll-area-viewport]>div]:max-w-full',
-                '[&_[data-radix-scroll-area-viewport]>div]:overflow-hidden'
-              )}
-              style={{
-                height: DROPDOWN_VIEWPORT_HEIGHT,
-              }}
-            >
-              {(() => {
-                if (!workspaceId) {
-                  return (
-                    <p className='px-2 py-4 text-center text-muted-foreground text-xs'>
-                      {copy.selectWorkspaceFirst}
-                    </p>
-                  )
-                }
-
-                const hasFilteredIndicators =
-                  filteredDefaultIndicators.length > 0 || filteredCustomIndicators.length > 0
-
-                if (loadError && !hasIndicators) {
-                  return (
-                    <div className='space-y-2 px-3 py-2 text-xs'>
-                      <p className='text-destructive'>{loadError}</p>
-                      <button
-                        type='button'
-                        className='font-semibold text-primary text-xs hover:underline'
-                        onClick={handleRetry}
-                      >
-                        {copy.retry}
-                      </button>
-                    </div>
-                  )
-                }
-
-                const shouldShowLoadingState = (isLoading || isFetching) && !hasIndicators
-                if (shouldShowLoadingState) {
-                  return (
-                    <div className='flex items-center gap-1 px-3 py-2 text-muted-foreground text-xs'>
-                      <Loader2 className='h-3.5 w-3.5 animate-spin' />
-                      {copy.loadingIndicators}
-                    </div>
-                  )
-                }
-
-                if (!hasIndicators) {
-                  return (
-                    <p className='px-2 py-4 text-center text-muted-foreground text-xs'>
-                      {copy.noIndicatorsAvailableYet}
-                    </p>
-                  )
-                }
-
-                if (!hasFilteredIndicators) {
-                  return (
-                    <p className='px-2 py-4 text-center text-muted-foreground text-xs'>
-                      {searchQuery.trim() ? copy.noIndicatorsFound : copy.noIndicatorsAvailableYet}
-                    </p>
-                  )
-                }
-
-                const sections = [
-                  {
-                    key: 'default',
-                    label: filteredDefaultIndicators.length > 0 ? copy.defaultIndicators : null,
-                    items: filteredDefaultIndicators,
-                  },
-                  {
-                    key: 'custom',
-                    label: filteredDefaultIndicators.length > 0 ? copy.customIndicators : null,
-                    items: filteredCustomIndicators,
-                  },
-                ].filter((section) => section.items.length > 0)
-
-                return (
-                  <div className='flex w-full min-w-0 flex-col gap-2'>
-                    {loadError ? (
-                      <div className='space-y-1 px-2 py-1 text-destructive text-xs'>
-                        <p>{loadError}</p>
-                        <button
-                          type='button'
-                          className='font-semibold text-[10px] text-primary hover:underline'
-                          onClick={handleRetry}
-                        >
-                          {copy.retry}
-                        </button>
-                      </div>
-                    ) : null}
-                    {sections.map((section) => (
-                      <div key={section.key} className='flex w-full min-w-0 flex-col gap-1'>
-                        {section.label ? (
-                          <div className='px-2 pt-1 text-[10px] text-muted-foreground uppercase tracking-wide'>
-                            {section.label}
-                          </div>
-                        ) : null}
-                        {section.items.map((option) => {
-                          const isSelected = selectedIndicatorSet.has(option.id)
-                          return (
-                            <DropdownMenuItem
-                              key={option.id}
-                              className={cn(widgetHeaderMenuItemClassName, 'items-center gap-2')}
-                              onSelect={(event) => {
-                                if (isMultiSelect) {
-                                  event.preventDefault()
-                                }
-                                handleToggleIndicator(option.id)
-                              }}
-                            >
-                              <div
-                                className='h-5 w-5 rounded-xs p-0.5'
-                                style={{
-                                  backgroundColor: `${option.color ?? FALLBACK_COLOR}20`,
-                                }}
-                                aria-hidden='true'
-                              >
-                                <Activity
-                                  className='h-4 w-4 text-muted-foreground'
-                                  aria-hidden='true'
-                                  style={{ color: option.color ?? FALLBACK_COLOR }}
-                                />
-                              </div>
-                              <span className={widgetHeaderMenuTextClassName}>{option.name}</span>
-                              {isSelected && <Check className='h-4 w-4 text-foreground' />}
-                            </DropdownMenuItem>
-                          )
-                        })}
-                      </div>
-                    ))}
-                  </div>
-                )
-              })()}
-            </ScrollArea>
-          </div>
-        </div>
-      </DropdownMenuContent>
-    </DropdownMenu>
+        <SidebarDropdownMenuContent
+          groups={visibleIndicatorGroups}
+          items={sidebarItems}
+          activeGroupId={displayedActiveFilterId}
+          onActiveGroupChange={(groupId) => setActiveFilterId(groupId as IndicatorFilterId)}
+          onSelectItem={(item) => {
+            handleToggleIndicator(item.id)
+            if (!isMultiSelect) {
+              setOpen(false)
+              inputRef.current?.blur()
+            }
+          }}
+          loadingContent={shouldShowLoadingState ? loadingContent : null}
+          emptyContent={emptyContent}
+        />
+      </PopoverContent>
+    </Popover>
   )
 }

--- a/apps/tradinggoose/widgets/widgets/components/pine-indicator-dropdown.tsx
+++ b/apps/tradinggoose/widgets/widgets/components/pine-indicator-dropdown.tsx
@@ -106,7 +106,7 @@ export function IndicatorDropdown({
             color: getStableVibrantColor(indicator.id),
           }))
         : [],
-    [includeDefaults, widgetsCopy]
+    [includeDefaults]
   )
 
   const customIndicatorOptions = useMemo<IndicatorOption[]>(
@@ -260,6 +260,8 @@ export function IndicatorDropdown({
 
   const shouldShowLoadingState = (isLoading || isFetching) && !hasIndicators
   const emptyContent = (() => {
+    if (!workspaceId) return copy.selectWorkspaceFirst
+
     if (loadError && !hasIndicators) {
       return (
         <div className='space-y-2 text-xs'>

--- a/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-block/components/sub-block/components/combobox.tsx
+++ b/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-block/components/sub-block/components/combobox.tsx
@@ -36,6 +36,23 @@ interface ComboBoxProps {
   config: SubBlockConfig
 }
 
+const getOptionValue = (option: string | SubBlockOption) =>
+  typeof option === 'string' ? option : String(option.value ?? option.id)
+
+const getOptionLabel = (option: string | SubBlockOption) =>
+  typeof option === 'string' ? option : option.label
+
+const getOptionGroup = (option: string | SubBlockOption) =>
+  typeof option === 'string' ? 'Options' : (option.group ?? 'Options')
+
+const getOptionSearchText = (option: string | SubBlockOption) => {
+  if (typeof option === 'string') return option
+  return option.searchLabel ?? option.label
+}
+
+const getOptionIcon = (option: string | SubBlockOption) =>
+  typeof option === 'string' ? null : (option.icon ?? null)
+
 export function ComboBox({
   options,
   defaultValue,
@@ -78,27 +95,6 @@ export function ComboBox({
     return typeof options === 'function' ? options() : options
   }, [options])
 
-  const getOptionValue = (option: string | SubBlockOption) => {
-    return typeof option === 'string' ? option : String(option.value ?? option.id)
-  }
-
-  const getOptionLabel = (option: string | SubBlockOption) => {
-    return typeof option === 'string' ? option : option.label
-  }
-
-  const getOptionGroup = (option: string | SubBlockOption) => {
-    return typeof option === 'string' ? 'Options' : (option.group ?? 'Options')
-  }
-
-  const getOptionSearchText = (option: string | SubBlockOption) => {
-    if (typeof option === 'string') return option
-    return option.searchLabel ?? option.label
-  }
-
-  const getOptionIcon = (option: string | SubBlockOption) => {
-    return typeof option === 'string' ? null : (option.icon ?? null)
-  }
-
   const selectedOption = useMemo(() => {
     if (value === null || value === undefined) return undefined
 
@@ -107,7 +103,7 @@ export function ComboBox({
       const optionLabel = getOptionLabel(opt)
       return optionValue === value || optionLabel === value
     })
-  }, [evaluatedOptions, value, getOptionLabel, getOptionValue])
+  }, [evaluatedOptions, value])
 
   // Get the default option value (prefer gpt-4o, then provided defaultValue, then first option)
   const defaultOptionValue = useMemo(() => {
@@ -128,7 +124,7 @@ export function ComboBox({
     }
 
     return undefined
-  }, [defaultValue, evaluatedOptions, getOptionValue, subBlockId])
+  }, [defaultValue, evaluatedOptions, subBlockId])
 
   // Mark store as initialized on first render
   useEffect(() => {
@@ -171,7 +167,7 @@ export function ComboBox({
       const search = currentValue.toLowerCase()
       return label.includes(search) || optionValue.includes(search) || searchLabel.includes(search)
     })
-  }, [evaluatedOptions, value, open, getOptionLabel, getOptionValue, getOptionSearchText, hasTyped])
+  }, [evaluatedOptions, value, open, hasTyped])
 
   const configuredSidebarGroups = useMemo<SidebarDropdownGroup[]>(() => {
     const optionGroups = config.optionGroups
@@ -192,7 +188,7 @@ export function ComboBox({
           icon: Icon ? <Icon className='h-3 w-3 shrink-0' /> : null,
         }
       }),
-    [displayValue, filteredOptions, getOptionGroup, getOptionIcon, getOptionLabel, getOptionValue]
+    [displayValue, filteredOptions]
   )
 
   const sidebarGroups = useMemo<SidebarDropdownGroup[]>(() => {
@@ -580,6 +576,7 @@ export function ComboBox({
                     setActiveSidebarGroupId(groupId)
                     setHighlightedIndex(-1)
                   }}
+                  onHighlightItem={(_item, index) => setHighlightedIndex(index)}
                   onSelectItem={(item) => handleSelect(item.id)}
                   loadingContent={null}
                   emptyContent={translateWorkflowLabel(locale, 'noMatchingOptionsFound')}

--- a/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-block/components/sub-block/components/combobox.tsx
+++ b/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-block/components/sub-block/components/combobox.tsx
@@ -6,10 +6,15 @@ import { Button } from '@/components/ui/button'
 import { checkEnvVarTrigger, EnvVarDropdown } from '@/components/ui/env-var-dropdown'
 import { formatDisplayText } from '@/components/ui/formatted-text'
 import { Input } from '@/components/ui/input'
+import {
+  type SidebarDropdownGroup,
+  type SidebarDropdownItem,
+  SidebarDropdownMenuContent,
+} from '@/components/ui/sidebar-dropdown-menu'
 import { checkTagTrigger, TagDropdown } from '@/components/ui/tag-dropdown'
 import { createLogger } from '@/lib/logs/console/logger'
 import { cn } from '@/lib/utils'
-import type { SubBlockConfig } from '@/blocks/types'
+import type { SubBlockConfig, SubBlockOption } from '@/blocks/types'
 import { useTagSelection } from '@/hooks/use-tag-selection'
 import { useAccessibleReferencePrefixes } from '@/hooks/workflow/use-accessible-reference-prefixes'
 import { translateWorkflowLabel } from '@/i18n/block-editor'
@@ -20,9 +25,7 @@ import { useWorkspaceId } from '@/widgets/widgets/editor_workflow/context/workfl
 const logger = createLogger('ComboBox')
 
 interface ComboBoxProps {
-  options:
-    | Array<string | { label: string; id: string }>
-    | (() => Array<string | { label: string; id: string }>)
+  options: Array<string | SubBlockOption> | (() => Array<string | SubBlockOption>)
   defaultValue?: string
   blockId: string
   subBlockId: string
@@ -55,6 +58,7 @@ export function ComboBox({
   const [searchTerm, setSearchTerm] = useState('')
   const [cursorPosition, setCursorPosition] = useState(0)
   const [activeSourceBlockId, setActiveSourceBlockId] = useState<string | null>(null)
+  const [activeSidebarGroupId, setActiveSidebarGroupId] = useState<string | null>(null)
   const [highlightedIndex, setHighlightedIndex] = useState(-1)
   const [hasTyped, setHasTyped] = useState(false)
 
@@ -67,19 +71,43 @@ export function ComboBox({
   const reactFlowInstance = useReactFlow()
 
   const value = propValue !== undefined ? propValue : storeValue
+  const displayValue = value?.toString() ?? ''
 
   // Evaluate options if it's a function
   const evaluatedOptions = useMemo(() => {
     return typeof options === 'function' ? options() : options
   }, [options])
 
-  const getOptionValue = (option: string | { label: string; id: string }) => {
-    return typeof option === 'string' ? option : option.id
+  const getOptionValue = (option: string | SubBlockOption) => {
+    return typeof option === 'string' ? option : String(option.value ?? option.id)
   }
 
-  const getOptionLabel = (option: string | { label: string; id: string }) => {
+  const getOptionLabel = (option: string | SubBlockOption) => {
     return typeof option === 'string' ? option : option.label
   }
+
+  const getOptionGroup = (option: string | SubBlockOption) => {
+    return typeof option === 'string' ? 'Options' : (option.group ?? 'Options')
+  }
+
+  const getOptionSearchText = (option: string | SubBlockOption) => {
+    if (typeof option === 'string') return option
+    return option.searchLabel ?? option.label
+  }
+
+  const getOptionIcon = (option: string | SubBlockOption) => {
+    return typeof option === 'string' ? null : (option.icon ?? null)
+  }
+
+  const selectedOption = useMemo(() => {
+    if (value === null || value === undefined) return undefined
+
+    return evaluatedOptions.find((opt) => {
+      const optionValue = getOptionValue(opt)
+      const optionLabel = getOptionLabel(opt)
+      return optionValue === value || optionLabel === value
+    })
+  }, [evaluatedOptions, value, getOptionLabel, getOptionValue])
 
   // Get the default option value (prefer gpt-4o, then provided defaultValue, then first option)
   const defaultOptionValue = useMemo(() => {
@@ -139,10 +167,65 @@ export function ComboBox({
     return evaluatedOptions.filter((option) => {
       const label = getOptionLabel(option).toLowerCase()
       const optionValue = getOptionValue(option).toLowerCase()
+      const searchLabel = getOptionSearchText(option).toLowerCase()
       const search = currentValue.toLowerCase()
-      return label.includes(search) || optionValue.includes(search)
+      return label.includes(search) || optionValue.includes(search) || searchLabel.includes(search)
     })
-  }, [evaluatedOptions, value, open, getOptionLabel, getOptionValue, hasTyped])
+  }, [evaluatedOptions, value, open, getOptionLabel, getOptionValue, getOptionSearchText, hasTyped])
+
+  const configuredSidebarGroups = useMemo<SidebarDropdownGroup[]>(() => {
+    const optionGroups = config.optionGroups
+    if (!optionGroups) return []
+    return typeof optionGroups === 'function' ? optionGroups() : optionGroups
+  }, [config.optionGroups])
+
+  const sidebarItems = useMemo<SidebarDropdownItem[]>(
+    () =>
+      filteredOptions.map((option) => {
+        const optionValue = getOptionValue(option)
+        const Icon = getOptionIcon(option)
+        return {
+          id: optionValue,
+          groupId: getOptionGroup(option),
+          label: getOptionLabel(option),
+          selected: displayValue === optionValue || displayValue === getOptionLabel(option),
+          icon: Icon ? <Icon className='h-3 w-3 shrink-0' /> : null,
+        }
+      }),
+    [displayValue, filteredOptions, getOptionGroup, getOptionIcon, getOptionLabel, getOptionValue]
+  )
+
+  const sidebarGroups = useMemo<SidebarDropdownGroup[]>(() => {
+    const groupIds = Array.from(new Set(sidebarItems.map((item) => item.groupId)))
+    if (configuredSidebarGroups.length === 0) {
+      return groupIds.map((groupId) => ({ id: groupId, label: groupId }))
+    }
+
+    const configuredGroupIds = new Set(configuredSidebarGroups.map((group) => group.id))
+    return [
+      ...configuredSidebarGroups.filter((group) => groupIds.includes(group.id)),
+      ...groupIds
+        .filter((groupId) => !configuredGroupIds.has(groupId))
+        .map((groupId) => ({ id: groupId, label: groupId })),
+    ]
+  }, [configuredSidebarGroups, sidebarItems])
+
+  const usesSidebarMode = config.dropdownMode === 'sidebar'
+  const selectedSidebarGroupId = selectedOption ? getOptionGroup(selectedOption) : null
+  const currentSidebarGroupId =
+    activeSidebarGroupId && sidebarGroups.some((group) => group.id === activeSidebarGroupId)
+      ? activeSidebarGroupId
+      : null
+  const currentSelectedSidebarGroupId =
+    selectedSidebarGroupId && sidebarGroups.some((group) => group.id === selectedSidebarGroupId)
+      ? selectedSidebarGroupId
+      : null
+  const resolvedActiveSidebarGroupId =
+    currentSidebarGroupId ?? currentSelectedSidebarGroupId ?? sidebarGroups[0]?.id ?? null
+  const activeSidebarItems = useMemo(
+    () => sidebarItems.filter((item) => item.groupId === resolvedActiveSidebarGroupId),
+    [resolvedActiveSidebarGroupId, sidebarItems]
+  )
 
   // Event handlers
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -222,23 +305,33 @@ export function ComboBox({
 
     if (e.key === 'ArrowDown') {
       e.preventDefault()
+      const optionCount = usesSidebarMode ? activeSidebarItems.length : filteredOptions.length
       if (!open) {
         setOpen(true)
         setHighlightedIndex(0)
       } else {
-        setHighlightedIndex((prev) => (prev < filteredOptions.length - 1 ? prev + 1 : 0))
+        setHighlightedIndex((prev) => (prev < optionCount - 1 ? prev + 1 : 0))
       }
     }
 
     if (e.key === 'ArrowUp') {
       e.preventDefault()
       if (open) {
-        setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : filteredOptions.length - 1))
+        const optionCount = usesSidebarMode ? activeSidebarItems.length : filteredOptions.length
+        setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : optionCount - 1))
       }
     }
 
     if (e.key === 'Enter' && open && highlightedIndex >= 0) {
       e.preventDefault()
+      if (usesSidebarMode) {
+        const selectedItem = activeSidebarItems[highlightedIndex]
+        if (selectedItem) {
+          handleSelect(selectedItem.id)
+        }
+        return
+      }
+
       const selectedOption = filteredOptions[highlightedIndex]
       if (selectedOption) {
         handleSelect(getOptionValue(selectedOption))
@@ -392,17 +485,6 @@ export function ComboBox({
     }
   }, [open])
 
-  // Display value with formatting
-  const displayValue = value?.toString() ?? ''
-  const selectedOption = useMemo(() => {
-    if (value === null || value === undefined) return undefined
-
-    return evaluatedOptions.find((opt) => {
-      const optionValue = getOptionValue(opt)
-      const optionLabel = getOptionLabel(opt)
-      return optionValue === value || optionLabel === value
-    })
-  }, [evaluatedOptions, value])
   const SelectedIcon =
     selectedOption && typeof selectedOption === 'object' && 'icon' in selectedOption
       ? (selectedOption.icon as React.ComponentType<{ className?: string }>)
@@ -472,15 +554,37 @@ export function ComboBox({
 
       {/* Dropdown */}
       {open && (
-        <div className='absolute top-full left-0 z-[100] mt-1 w-full min-w-[286px] overflow-visible'>
+        <div
+          className={cn(
+            'absolute top-full left-0 z-[100] mt-1 w-full overflow-visible',
+            usesSidebarMode ? 'min-w-80' : 'min-w-60'
+          )}
+        >
           <div className='allow-scroll fade-in-0 zoom-in-95 animate-in rounded-md border bg-popover text-popover-foreground shadow-lg'>
             <div
               ref={dropdownRef}
-              className='allow-scroll max-h-48 overflow-y-auto p-1'
+              className={cn(
+                'allow-scroll',
+                usesSidebarMode ? 'overflow-hidden p-0' : 'max-h-48 overflow-y-auto p-1'
+              )}
               style={{ scrollbarWidth: 'thin' }}
               onMouseLeave={() => setHighlightedIndex(-1)}
             >
-              {filteredOptions.length === 0 ? (
+              {usesSidebarMode ? (
+                <SidebarDropdownMenuContent
+                  groups={sidebarGroups}
+                  items={sidebarItems}
+                  activeGroupId={resolvedActiveSidebarGroupId}
+                  highlightedItemId={activeSidebarItems[highlightedIndex]?.id ?? null}
+                  onActiveGroupChange={(groupId) => {
+                    setActiveSidebarGroupId(groupId)
+                    setHighlightedIndex(-1)
+                  }}
+                  onSelectItem={(item) => handleSelect(item.id)}
+                  loadingContent={null}
+                  emptyContent={translateWorkflowLabel(locale, 'noMatchingOptionsFound')}
+                />
+              ) : filteredOptions.length === 0 ? (
                 <div className='py-6 text-center text-muted-foreground text-sm'>
                   {translateWorkflowLabel(locale, 'noMatchingOptionsFound')}
                 </div>

--- a/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-editor/panel/node-editor-panel.tsx
+++ b/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-editor/panel/node-editor-panel.tsx
@@ -42,6 +42,9 @@ const PARALLEL_TYPE_OPTIONS: Array<{ value: ParallelType; label: string }> = [
   { value: 'collection', label: 'Parallel Each' },
 ]
 
+const panelClassName =
+  'allow-scroll !m-2 max-h-[calc(100%-1rem)] min-w-0 w-[calc(100%-1rem)] max-w-96 overflow-y-auto rounded-lg border bg-card shadow-md'
+
 export function NodeEditorPanel({ selectedNodeId }: NodeEditorPanelProps) {
   const { workflowEditorCopy, workflowInspectorCopy, getLocalizedDefaultBlockName } =
     useWorkflowI18n()
@@ -124,12 +127,7 @@ export function NodeEditorPanel({ selectedNodeId }: NodeEditorPanelProps) {
     renamingBlockIdRef.current = null
     setIsRenaming(false)
     setEditedName('')
-  }, [
-    collaborativeUpdateBlockName,
-    editedName,
-    isRenaming,
-    selectedBlock,
-  ])
+  }, [collaborativeUpdateBlockName, editedName, isRenaming, selectedBlock])
 
   const handleCancelRename = useCallback(() => {
     renamingBlockIdRef.current = null
@@ -364,7 +362,7 @@ export function NodeEditorPanel({ selectedNodeId }: NodeEditorPanelProps) {
     return (
       <Panel
         position='top-right'
-        className='allow-scroll max-h-[calc(100%-2rem)] w-96 overflow-y-auto rounded-lg border bg-card p-4 shadow-md'
+        className={`${panelClassName} p-4`}
         onMouseDown={stopPanelEvent}
         onPointerDown={stopPanelEvent}
         onClick={stopPanelEvent}
@@ -382,7 +380,7 @@ export function NodeEditorPanel({ selectedNodeId }: NodeEditorPanelProps) {
     return (
       <Panel
         position='top-right'
-        className='allow-scroll max-h-[calc(100%-2rem)] w-96 overflow-y-auto rounded-lg border bg-card p-4 shadow-md'
+        className={`${panelClassName} p-4`}
         onMouseDown={stopPanelEvent}
         onPointerDown={stopPanelEvent}
         onClick={stopPanelEvent}
@@ -401,7 +399,7 @@ export function NodeEditorPanel({ selectedNodeId }: NodeEditorPanelProps) {
   return (
     <Panel
       position='top-right'
-      className='allow-scroll max-h-[calc(100%-2rem)] w-96 overflow-y-auto rounded-lg border bg-card px-4 pb-4 shadow-md'
+      className={`${panelClassName} px-4 pb-4`}
       onMouseDown={stopPanelEvent}
       onPointerDown={stopPanelEvent}
       onClick={stopPanelEvent}


### PR DESCRIPTION
## Summary
- Add a shared sidebar dropdown menu for grouped option lists.
- Update listing search to support asset-class sidebar filters and pass that filter into remote and local listing searches.
- Move indicator and agent model selectors to grouped sidebar dropdowns for default/custom indicators and provider-grouped models.
- Move monitor kanban actions into column headers and clean up shared workflow panel styling.

## Why
Large dropdowns are harder to scan when options come from multiple categories. Grouped sidebar navigation makes listing, indicator, and model selection more discoverable while keeping the UI compact.

## Affected Areas
- [x] `apps/tradinggoose`
- [ ] `apps/docs`
- [ ] `packages/*`
- [x] Workflows / execution
- [ ] Realtime / sockets
- [x] Market data / charting
- [ ] Dev tooling / CI / infra
- [ ] Documentation only
- [x] Other: shared UI dropdown components and monitor board headers

## Issue Links( if any )
None.

## Validation
```bash
cd apps/tradinggoose
bun run test blocks/blocks/agent.test.ts components/listing-selector/selector/dropdown.test.tsx components/listing-selector/selector/use-listing-search.test.tsx
# 3 test files passed, 16 tests passed

bun run type-check
# tsc --noEmit completed successfully
```

## Risk / Rollout Notes
Visible UI change affecting dropdown interactions in listing search, indicator selection, agent model selection, and monitor kanban headers. Backout plan is to revert this branch if grouped dropdown behavior regresses selection or keyboard navigation.

## Config / Data Changes
- Env vars added or changed: None.
- Database schema or migration impact: None.
- External services or provider behavior changed: None.

## Screenshots / Video
<img width="600" height="495" alt="image" src="https://github.com/user-attachments/assets/15c82828-2d38-4795-ba48-21b8f1eba346" />


## Checklist
- [x] I kept the change focused and reviewed my own diff
- [x] I validated the change locally and documented the results above
- [ ] I updated docs, examples, or copy if behavior/user-facing flows changed
- [x] I called out any env, schema, provider, or rollout impact
- [x] I did not include secrets, tokens, or private credentials in this PR