### PR TITLE
fix: settle Stripe subscription deletes and render sidebar profile trigger

### DIFF
--- a/apps/tradinggoose/components/ui/sidebar.tsx
+++ b/apps/tradinggoose/components/ui/sidebar.tsx
@@ -367,7 +367,7 @@ const SidebarRail = React.forwardRef<
       if (typeof ref === 'function') {
         ref(node)
       } else if (ref) {
-        ; (ref as React.MutableRefObject<HTMLButtonElement | null>).current = node
+        ;(ref as React.MutableRefObject<HTMLButtonElement | null>).current = node
       }
       dragRef.current = node
     },
@@ -589,7 +589,7 @@ const SidebarMenuItem = React.forwardRef<HTMLLIElement, React.ComponentProps<'li
 SidebarMenuItem.displayName = 'SidebarMenuItem'
 
 const sidebarMenuButtonVariants = cva(
-  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>*:first-child]:shrink-0 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -692,7 +692,7 @@ const SidebarMenuAction = React.forwardRef<
         'peer-data-[size=lg]/menu-button:top-2.5',
         'group-data-[collapsible=icon]:hidden',
         showOnHover &&
-        'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground md:opacity-0',
+          'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground md:opacity-0',
         className
       )}
       {...props}

--- a/apps/tradinggoose/global-navbar/components/user-menu.test.tsx
+++ b/apps/tradinggoose/global-navbar/components/user-menu.test.tsx
@@ -229,6 +229,18 @@ describe('UserMenu language selector', () => {
     expect(getThemeButton('主题：系统')).toBeInTheDocument()
   })
 
+  it('renders the compact avatar trigger outside a sidebar context', async () => {
+    await act(async () => {
+      renderUserMenu(root, 'en')
+      await flush()
+    })
+
+    const button = getUserMenuButton(container)
+    expect(button.textContent).toBe('AL')
+    expect(container.querySelector('[data-sidebar="menu"]')).toBeNull()
+    expect(container.querySelector('button[data-sidebar="menu-button"]')).toBeNull()
+  })
+
   it('renders the sidebar trigger with user details inside the global navbar sidebar', async () => {
     await act(async () => {
       renderUserMenu(root, 'en', { sidebarTrigger: true })

--- a/apps/tradinggoose/global-navbar/components/user-menu.test.tsx
+++ b/apps/tradinggoose/global-navbar/components/user-menu.test.tsx
@@ -4,6 +4,7 @@ import { act } from 'react'
 import { NextIntlClientProvider } from 'next-intl'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SidebarProvider } from '@/components/ui/sidebar'
 import { getPublicCopy } from '@/i18n/public-copy'
 import type { LocaleCode } from '@/i18n/utils'
 import { UserMenu } from './user-menu'
@@ -94,17 +95,22 @@ vi.mock('@/global-navbar/settings-modal/components/help/help-modal', () => ({
 function renderUserMenu(
   root: Root,
   locale: LocaleCode,
-  options: { canAccessSystemAdmin?: boolean } = {}
+  options: { canAccessSystemAdmin?: boolean; sidebarTrigger?: boolean } = {}
 ) {
+  const userMenu = (
+    <UserMenu
+      userName='Ada Lovelace'
+      userEmail='ada@example.com'
+      userId='user-1'
+      onOpenSettings={mockOpenSettings}
+      canAccessSystemAdmin={options.canAccessSystemAdmin}
+      sidebarTrigger={options.sidebarTrigger}
+    />
+  )
+
   root.render(
     <NextIntlClientProvider locale={locale} messages={getPublicCopy(locale)}>
-      <UserMenu
-        userName='Ada Lovelace'
-        userEmail='ada@example.com'
-        userId='user-1'
-        onOpenSettings={mockOpenSettings}
-        canAccessSystemAdmin={options.canAccessSystemAdmin}
-      />
+      {options.sidebarTrigger ? <SidebarProvider>{userMenu}</SidebarProvider> : userMenu}
     </NextIntlClientProvider>
   )
 }
@@ -223,15 +229,23 @@ describe('UserMenu language selector', () => {
     expect(getThemeButton('主题：系统')).toBeInTheDocument()
   })
 
-  it('renders the avatar trigger without a sidebar provider', async () => {
+  it('renders the sidebar trigger with user details inside the global navbar sidebar', async () => {
     await act(async () => {
-      renderUserMenu(root, 'en')
+      renderUserMenu(root, 'en', { sidebarTrigger: true })
       await flush()
     })
 
     const button = getUserMenuButton(container)
-    expect(button.textContent).toBe('AL')
-    expect(container.querySelector('button[data-sidebar="menu-button"]')).toBeNull()
+    expect(button.getAttribute('data-sidebar')).toBe('menu-button')
+    expect(button.textContent).toContain('Ada Lovelace')
+    expect(button.textContent).toContain('ada@example.com')
+
+    await act(async () => {
+      await openMenu(button)
+    })
+
+    const menu = document.body.querySelector('[role="menu"]')
+    expect(menu?.className).toContain('w-[var(--radix-dropdown-menu-trigger-width)]')
   })
 
   it('owns the system admin menu item for authorized users', async () => {

--- a/apps/tradinggoose/global-navbar/components/user-menu.tsx
+++ b/apps/tradinggoose/global-navbar/components/user-menu.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react'
 import {
   Check,
   ChevronDown,
+  ChevronsUpDown,
   CreditCard,
   KeyRound,
   LifeBuoy,
@@ -29,15 +30,12 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar'
 import {
   widgetHeaderControlClassName,
   widgetHeaderMenuContentClassName,
   widgetHeaderMenuItemClassName,
 } from '@/components/widget-header-control'
-import { HelpModal } from '@/global-navbar/settings-modal/components/help/help-modal'
-import type { SettingsSection } from '@/global-navbar/settings-modal/types'
-import { useOrganizationBilling, useOrganizations } from '@/hooks/queries/organization'
-import { useSubscriptionData } from '@/hooks/queries/subscription'
 import { signOut } from '@/lib/auth-client'
 import { openBillingPortal } from '@/lib/billing/billing-portal'
 import { isHosted } from '@/lib/environment'
@@ -46,6 +44,10 @@ import { getOrganizationAccessState } from '@/lib/organization/access'
 import { getUserRole } from '@/lib/organization/helpers'
 import { getSubscriptionStatus } from '@/lib/subscription/helpers'
 import { cn } from '@/lib/utils'
+import { HelpModal } from '@/global-navbar/settings-modal/components/help/help-modal'
+import type { SettingsSection } from '@/global-navbar/settings-modal/types'
+import { useOrganizationBilling, useOrganizations } from '@/hooks/queries/organization'
+import { useSubscriptionData } from '@/hooks/queries/subscription'
 import { replaceLocaleDocument, usePathname, useRouter } from '@/i18n/navigation'
 import { getLocaleDisplayName, isLocaleCode, type LocaleCode, locales } from '@/i18n/utils'
 import { clearUserData } from '@/stores'
@@ -73,6 +75,7 @@ interface UserMenuProps {
   userId?: string | null
   onOpenSettings: (section: SettingsSection) => void
   canAccessSystemAdmin?: boolean
+  sidebarTrigger?: boolean
 }
 
 export function UserMenu({
@@ -83,6 +86,7 @@ export function UserMenu({
   userId,
   onOpenSettings,
   canAccessSystemAdmin = false,
+  sidebarTrigger = false,
 }: UserMenuProps) {
   const router = useRouter()
   const locale = useLocale() as LocaleCode
@@ -338,10 +342,16 @@ export function UserMenu({
       <AvatarFallback className='rounded-lg'>{getInitials(displayUserName)}</AvatarFallback>
     </Avatar>
   )
+  const triggerLabel = `${displayUserName} ${userMenuCopy.accountDetail}`
 
   const menuContent = (
     <DropdownMenuContent
-      className='max-h-(--radix-dropdown-menu-content-available-height) w-64 overflow-y-auto overflow-x-hidden rounded-lg'
+      className={cn(
+        'max-h-(--radix-dropdown-menu-content-available-height) overflow-y-auto overflow-x-hidden',
+        sidebarTrigger
+          ? 'w-[var(--radix-dropdown-menu-trigger-width)] min-w-56 max-w-[calc(100vw-2rem)] rounded-md'
+          : 'w-64 rounded-lg'
+      )}
       sideOffset={6}
     >
       <DropdownMenuGroup>
@@ -573,15 +583,37 @@ export function UserMenu({
   return (
     <>
       <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button
-            type='button'
-            aria-label={`${displayUserName} ${userMenuCopy.accountDetail}`}
-            className='inline-flex h-8 w-8 items-center justify-center rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
-          >
-            {avatar}
-          </button>
-        </DropdownMenuTrigger>
+        {sidebarTrigger ? (
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <DropdownMenuTrigger asChild>
+                <SidebarMenuButton
+                  variant='default'
+                  size='lg'
+                  aria-label={triggerLabel}
+                  className='data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground'
+                >
+                  {avatar}
+                  <div className='grid flex-1 text-left text-sm leading-tight'>
+                    <span className='truncate font-semibold'>{displayUserName}</span>
+                    <span className='truncate text-xs'>{userEmail}</span>
+                  </div>
+                  <ChevronsUpDown className='ml-auto size-4' />
+                </SidebarMenuButton>
+              </DropdownMenuTrigger>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        ) : (
+          <DropdownMenuTrigger asChild>
+            <button
+              type='button'
+              aria-label={triggerLabel}
+              className='inline-flex h-8 w-8 items-center justify-center rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+            >
+              {avatar}
+            </button>
+          </DropdownMenuTrigger>
+        )}
         {menuContent}
       </DropdownMenu>
       <HelpModal open={isHelpModalOpen} onOpenChange={setIsHelpModalOpen} />

--- a/apps/tradinggoose/global-navbar/global-navbar.tsx
+++ b/apps/tradinggoose/global-navbar/global-navbar.tsx
@@ -291,6 +291,7 @@ export function GlobalNavbar({
                 userAvatarVersion={userAvatarVersion}
                 onOpenSettings={openSettings}
                 canAccessSystemAdmin={isSystemAdmin && navigationMode !== 'admin'}
+                sidebarTrigger
               />
             </SidebarFooter>
             <SidebarRail />

--- a/apps/tradinggoose/lib/auth.ts
+++ b/apps/tradinggoose/lib/auth.ts
@@ -28,16 +28,12 @@ import {
   renderPasswordResetEmail,
 } from '@/components/emails/render-email'
 import { sendBillingTierWelcomeEmail } from '@/lib/billing'
-import { localizeUrl } from '@/i18n/utils'
 import { authorizeSubscriptionReference } from '@/lib/billing/authorization'
 import {
   ensureDefaultUserSubscription,
   getEffectiveSubscription,
 } from '@/lib/billing/core/subscription'
-import {
-  handleNewUser,
-  resetUserDefaultUsageToOnboardingAllowanceBalance,
-} from '@/lib/billing/core/usage'
+import { handleNewUser } from '@/lib/billing/core/usage'
 import {
   ensureOrganizationForOrganizationSubscription,
   syncSubscriptionUsageLimits,
@@ -55,11 +51,11 @@ import {
   handleInvoicePaymentSucceeded,
 } from '@/lib/billing/webhooks/invoices'
 import {
+  handleStripeSubscriptionDeleted,
   handleSubscriptionCreated,
-  handleSubscriptionDeleted,
 } from '@/lib/billing/webhooks/subscription'
-import { addVerifiedUserEmailToAudience, sendEmail } from '@/lib/email/mailer'
 import { resolveEmailLocale } from '@/lib/email/locale'
+import { addVerifiedUserEmailToAudience, sendEmail } from '@/lib/email/mailer'
 import { quickValidateEmail } from '@/lib/email/validation'
 import { env, getEnv } from '@/lib/env'
 import { isEmailVerificationEnabled } from '@/lib/environment'
@@ -86,6 +82,7 @@ import {
 } from '@/lib/system-services/stripe-runtime'
 import { getResolvedSystemSettings } from '@/lib/system-settings/service'
 import { getBaseUrl } from '@/lib/urls/utils'
+import { localizeUrl } from '@/i18n/utils'
 import { resolveAlpacaTradingBaseUrl } from '@/providers/trading/alpaca/config'
 import { resolveTradierBaseUrl } from '@/providers/trading/tradier/client'
 import { SSO_TRUSTED_PROVIDERS } from './sso/consts'
@@ -1688,65 +1685,6 @@ export const auth = betterAuth({
             })
           }
         },
-        onSubscriptionDeleted: async ({
-          event,
-          stripeSubscription,
-          subscription,
-        }: {
-          event: Stripe.Event
-          stripeSubscription: Stripe.Subscription
-          subscription: any
-        }) => {
-          logger.info('[onSubscriptionDeleted] Subscription deleted', {
-            subscriptionId: subscription.id,
-            referenceType: subscription.referenceType,
-            referenceId: subscription.referenceId,
-          })
-
-          try {
-            await syncSubscriptionBillingTierFromStripeSubscription(
-              subscription.id,
-              stripeSubscription || (event.data.object as Stripe.Subscription | undefined)
-            )
-
-            const hydratedSubscription = await getHydratedSubscriptionById(subscription.id)
-            const subscriptionRecord = hydratedSubscription ?? { ...subscription, tier: null }
-
-            await handleSubscriptionDeleted(subscriptionRecord)
-
-            const { billingEnabled } = await getBillingGateState()
-            const nextSubscriptionRecord =
-              billingEnabled && subscriptionRecord.referenceType === 'user'
-                ? await ensureDefaultUserSubscription(subscriptionRecord.referenceId)
-                : subscriptionRecord
-
-            if (
-              nextSubscriptionRecord.referenceType === 'user' &&
-              nextSubscriptionRecord.tier?.isDefault &&
-              !nextSubscriptionRecord.stripeSubscriptionId
-            ) {
-              await resetUserDefaultUsageToOnboardingAllowanceBalance(
-                nextSubscriptionRecord.referenceId
-              )
-            }
-
-            await syncSubscriptionUsageLimits(nextSubscriptionRecord)
-
-            logger.info('[onSubscriptionDeleted] Reconciled subscription usage limits', {
-              subscriptionId: subscription.id,
-              referenceType: subscription.referenceType,
-              referenceId: subscription.referenceId,
-            })
-          } catch (error) {
-            logger.error('[onSubscriptionDeleted] Failed to handle subscription deletion', {
-              subscriptionId: subscription.id,
-              referenceType: subscription.referenceType,
-              referenceId: subscription.referenceId,
-              error,
-            })
-            throw error
-          }
-        },
       },
       onEvent: async (event: Stripe.Event) => {
         logger.info('[onEvent] Received Stripe webhook', {
@@ -1772,7 +1710,10 @@ export const auth = betterAuth({
               await handleManualEnterpriseSubscription(event)
               break
             }
-            // Note: customer.subscription.deleted is handled by better-auth's onSubscriptionDeleted callback above
+            case 'customer.subscription.deleted': {
+              await handleStripeSubscriptionDeleted(event)
+              break
+            }
             default:
               logger.info('[onEvent] Ignoring unsupported webhook event', {
                 eventId: event.id,

--- a/apps/tradinggoose/lib/billing/core/billing.ts
+++ b/apps/tradinggoose/lib/billing/core/billing.ts
@@ -205,13 +205,21 @@ export async function calculateSubscriptionOverage(sub: {
       })
     }
   } else if (sub.tier) {
-    const usage = await getUserUsageData(sub.referenceId)
+    const [stats] = await db
+      .select({
+        currentPeriodCost: userStats.currentPeriodCost,
+        totalCost: userStats.totalCost,
+      })
+      .from(userStats)
+      .where(eq(userStats.userId, sub.referenceId))
+      .limit(1)
+    const currentUsage = parseDecimal(stats?.currentPeriodCost ?? stats?.totalCost)
     const { usageAllowance } = getBillingTierPricing(sub.tier)
-    totalOverage = Math.max(0, usage.currentUsage - usageAllowance)
+    totalOverage = Math.max(0, currentUsage - usageAllowance)
 
     logger.info('Calculated individual-tier overage', {
       subscriptionId: sub.id,
-      totalIndividualUsage: usage.currentUsage,
+      totalIndividualUsage: currentUsage,
       usageAllowance,
       totalOverage,
     })

--- a/apps/tradinggoose/lib/billing/core/subscription.test.ts
+++ b/apps/tradinggoose/lib/billing/core/subscription.test.ts
@@ -208,42 +208,45 @@ describe('subscription billing helpers', () => {
       stripeSubscriptionId: 'stripe_sub_123',
       tier: { id: 'tier_default' },
     }
-    mockDb.select.mockImplementationOnce(() => createSelectQueryMock([row], 'limit'))
+    mockDb.select.mockImplementationOnce(() => createSelectQueryMock([row], 'where'))
 
-    const { getUniqueSubscriptionByStripeSubscriptionId } = await import('./subscription')
+    const { getSubscriptionByStripeSubscriptionId } = await import('./subscription')
 
-    await expect(getUniqueSubscriptionByStripeSubscriptionId('stripe_sub_123')).resolves.toBe(row)
+    await expect(getSubscriptionByStripeSubscriptionId('stripe_sub_123')).resolves.toBe(row)
     expect(mockEq).toHaveBeenCalledWith('subscription.stripeSubscriptionId', 'stripe_sub_123')
     expect(mockHydrateSubscriptionsWithTiers).toHaveBeenCalledWith([row])
+    expect(mockSelectEffectiveSubscription).toHaveBeenCalledWith([row])
   })
 
-  it('rejects duplicate local rows for one Stripe subscription id', async () => {
+  it('returns the effective subscription when duplicate local rows share one Stripe subscription id', async () => {
+    const olderSubscription = { id: 'sub_1', stripeSubscriptionId: 'stripe_sub_123' }
+    const effectiveSubscription = { id: 'sub_2', stripeSubscriptionId: 'stripe_sub_123' }
     mockDb.select.mockImplementationOnce(() =>
-      createSelectQueryMock(
-        [
-          { id: 'sub_1', stripeSubscriptionId: 'stripe_sub_123' },
-          { id: 'sub_2', stripeSubscriptionId: 'stripe_sub_123' },
-        ],
-        'limit'
-      )
+      createSelectQueryMock([olderSubscription, effectiveSubscription], 'where')
     )
+    mockSelectEffectiveSubscription.mockReturnValueOnce(effectiveSubscription)
 
-    const { getUniqueSubscriptionByStripeSubscriptionId } = await import('./subscription')
+    const { getSubscriptionByStripeSubscriptionId } = await import('./subscription')
 
-    await expect(getUniqueSubscriptionByStripeSubscriptionId('stripe_sub_123')).rejects.toThrow(
-      'Multiple local subscriptions found for Stripe subscription stripe_sub_123'
+    await expect(getSubscriptionByStripeSubscriptionId('stripe_sub_123')).resolves.toBe(
+      effectiveSubscription
     )
-    expect(mockHydrateSubscriptionsWithTiers).not.toHaveBeenCalled()
+    expect(mockHydrateSubscriptionsWithTiers).toHaveBeenCalledWith([
+      olderSubscription,
+      effectiveSubscription,
+    ])
+    expect(mockSelectEffectiveSubscription).toHaveBeenCalledWith([
+      olderSubscription,
+      effectiveSubscription,
+    ])
   })
 
   it('returns null for an untracked Stripe subscription id', async () => {
-    mockDb.select.mockImplementationOnce(() => createSelectQueryMock([], 'limit'))
+    mockDb.select.mockImplementationOnce(() => createSelectQueryMock([], 'where'))
 
-    const { getUniqueSubscriptionByStripeSubscriptionId } = await import('./subscription')
+    const { getSubscriptionByStripeSubscriptionId } = await import('./subscription')
 
-    await expect(getUniqueSubscriptionByStripeSubscriptionId('stripe_sub_missing')).resolves.toBe(
-      null
-    )
+    await expect(getSubscriptionByStripeSubscriptionId('stripe_sub_missing')).resolves.toBe(null)
     expect(mockHydrateSubscriptionsWithTiers).toHaveBeenCalledWith([])
   })
 

--- a/apps/tradinggoose/lib/billing/core/subscription.test.ts
+++ b/apps/tradinggoose/lib/billing/core/subscription.test.ts
@@ -47,6 +47,7 @@ vi.mock('@tradinggoose/db/schema', () => ({
     id: 'subscription.id',
     referenceType: 'subscription.referenceType',
     referenceId: 'subscription.referenceId',
+    stripeSubscriptionId: 'subscription.stripeSubscriptionId',
     status: 'subscription.status',
   },
   user: {
@@ -199,6 +200,45 @@ describe('subscription billing helpers', () => {
         referenceId: 'user_123',
       })
     ).rejects.toBeInstanceOf(MissingBillingSubscriptionError)
+  })
+
+  it('returns the exact local subscription for a Stripe subscription id', async () => {
+    const row = {
+      id: 'sub_123',
+      stripeSubscriptionId: 'stripe_sub_123',
+      tier: { id: 'tier_default' },
+    }
+    mockDb.select.mockImplementationOnce(() => createSelectQueryMock([row], 'limit'))
+
+    const { getUniqueSubscriptionByStripeSubscriptionId } = await import('./subscription')
+
+    await expect(getUniqueSubscriptionByStripeSubscriptionId('stripe_sub_123')).resolves.toBe(row)
+    expect(mockEq).toHaveBeenCalledWith('subscription.stripeSubscriptionId', 'stripe_sub_123')
+    expect(mockHydrateSubscriptionsWithTiers).toHaveBeenCalledWith([row])
+  })
+
+  it('returns null for an untracked Stripe subscription id', async () => {
+    mockDb.select.mockImplementationOnce(() => createSelectQueryMock([], 'limit'))
+
+    const { getUniqueSubscriptionByStripeSubscriptionId } = await import('./subscription')
+
+    await expect(getUniqueSubscriptionByStripeSubscriptionId('stripe_sub_missing')).resolves.toBe(
+      null
+    )
+    expect(mockHydrateSubscriptionsWithTiers).toHaveBeenCalledWith([])
+  })
+
+  it('rejects duplicate local rows for one Stripe subscription id', async () => {
+    mockDb.select.mockImplementationOnce(() =>
+      createSelectQueryMock([{ id: 'sub_1' }, { id: 'sub_2' }], 'limit')
+    )
+
+    const { getUniqueSubscriptionByStripeSubscriptionId } = await import('./subscription')
+
+    await expect(getUniqueSubscriptionByStripeSubscriptionId('stripe_sub_123')).rejects.toThrow(
+      'Multiple local subscriptions found for Stripe subscription stripe_sub_123'
+    )
+    expect(mockHydrateSubscriptionsWithTiers).not.toHaveBeenCalled()
   })
 
   it('seeds onboarding allowance into user stats on billing-enable backfill', async () => {

--- a/apps/tradinggoose/lib/billing/core/subscription.test.ts
+++ b/apps/tradinggoose/lib/billing/core/subscription.test.ts
@@ -208,41 +208,17 @@ describe('subscription billing helpers', () => {
       stripeSubscriptionId: 'stripe_sub_123',
       tier: { id: 'tier_default' },
     }
-    mockDb.select.mockImplementationOnce(() => createSelectQueryMock([row], 'where'))
+    mockDb.select.mockImplementationOnce(() => createSelectQueryMock([row], 'limit'))
 
     const { getSubscriptionByStripeSubscriptionId } = await import('./subscription')
 
     await expect(getSubscriptionByStripeSubscriptionId('stripe_sub_123')).resolves.toBe(row)
     expect(mockEq).toHaveBeenCalledWith('subscription.stripeSubscriptionId', 'stripe_sub_123')
     expect(mockHydrateSubscriptionsWithTiers).toHaveBeenCalledWith([row])
-    expect(mockSelectEffectiveSubscription).toHaveBeenCalledWith([row])
-  })
-
-  it('returns the effective subscription when duplicate local rows share one Stripe subscription id', async () => {
-    const olderSubscription = { id: 'sub_1', stripeSubscriptionId: 'stripe_sub_123' }
-    const effectiveSubscription = { id: 'sub_2', stripeSubscriptionId: 'stripe_sub_123' }
-    mockDb.select.mockImplementationOnce(() =>
-      createSelectQueryMock([olderSubscription, effectiveSubscription], 'where')
-    )
-    mockSelectEffectiveSubscription.mockReturnValueOnce(effectiveSubscription)
-
-    const { getSubscriptionByStripeSubscriptionId } = await import('./subscription')
-
-    await expect(getSubscriptionByStripeSubscriptionId('stripe_sub_123')).resolves.toBe(
-      effectiveSubscription
-    )
-    expect(mockHydrateSubscriptionsWithTiers).toHaveBeenCalledWith([
-      olderSubscription,
-      effectiveSubscription,
-    ])
-    expect(mockSelectEffectiveSubscription).toHaveBeenCalledWith([
-      olderSubscription,
-      effectiveSubscription,
-    ])
   })
 
   it('returns null for an untracked Stripe subscription id', async () => {
-    mockDb.select.mockImplementationOnce(() => createSelectQueryMock([], 'where'))
+    mockDb.select.mockImplementationOnce(() => createSelectQueryMock([], 'limit'))
 
     const { getSubscriptionByStripeSubscriptionId } = await import('./subscription')
 

--- a/apps/tradinggoose/lib/billing/core/subscription.test.ts
+++ b/apps/tradinggoose/lib/billing/core/subscription.test.ts
@@ -228,19 +228,6 @@ describe('subscription billing helpers', () => {
     expect(mockHydrateSubscriptionsWithTiers).toHaveBeenCalledWith([])
   })
 
-  it('rejects duplicate local rows for one Stripe subscription id', async () => {
-    mockDb.select.mockImplementationOnce(() =>
-      createSelectQueryMock([{ id: 'sub_1' }, { id: 'sub_2' }], 'limit')
-    )
-
-    const { getUniqueSubscriptionByStripeSubscriptionId } = await import('./subscription')
-
-    await expect(getUniqueSubscriptionByStripeSubscriptionId('stripe_sub_123')).rejects.toThrow(
-      'Multiple local subscriptions found for Stripe subscription stripe_sub_123'
-    )
-    expect(mockHydrateSubscriptionsWithTiers).not.toHaveBeenCalled()
-  })
-
   it('seeds onboarding allowance into user stats on billing-enable backfill', async () => {
     const insertCalls: Array<{
       values: Record<string, unknown>

--- a/apps/tradinggoose/lib/billing/core/subscription.test.ts
+++ b/apps/tradinggoose/lib/billing/core/subscription.test.ts
@@ -217,6 +217,25 @@ describe('subscription billing helpers', () => {
     expect(mockHydrateSubscriptionsWithTiers).toHaveBeenCalledWith([row])
   })
 
+  it('rejects duplicate local rows for one Stripe subscription id', async () => {
+    mockDb.select.mockImplementationOnce(() =>
+      createSelectQueryMock(
+        [
+          { id: 'sub_1', stripeSubscriptionId: 'stripe_sub_123' },
+          { id: 'sub_2', stripeSubscriptionId: 'stripe_sub_123' },
+        ],
+        'limit'
+      )
+    )
+
+    const { getUniqueSubscriptionByStripeSubscriptionId } = await import('./subscription')
+
+    await expect(getUniqueSubscriptionByStripeSubscriptionId('stripe_sub_123')).rejects.toThrow(
+      'Multiple local subscriptions found for Stripe subscription stripe_sub_123'
+    )
+    expect(mockHydrateSubscriptionsWithTiers).not.toHaveBeenCalled()
+  })
+
   it('returns null for an untracked Stripe subscription id', async () => {
     mockDb.select.mockImplementationOnce(() => createSelectQueryMock([], 'limit'))
 

--- a/apps/tradinggoose/lib/billing/core/subscription.ts
+++ b/apps/tradinggoose/lib/billing/core/subscription.ts
@@ -119,23 +119,16 @@ export async function requireActiveSubscriptionForReference(
   return activeSubscription
 }
 
-export async function getUniqueSubscriptionByStripeSubscriptionId(
+export async function getSubscriptionByStripeSubscriptionId(
   stripeSubscriptionId: string
 ): Promise<SubscriptionWithTier | null> {
   const rows = await db
     .select()
     .from(subscription)
     .where(eq(subscription.stripeSubscriptionId, stripeSubscriptionId))
-    .limit(2)
-
-  if (rows.length > 1) {
-    throw new Error(
-      `Multiple local subscriptions found for Stripe subscription ${stripeSubscriptionId}`
-    )
-  }
 
   const hydratedSubscriptions = await hydrateSubscriptionsWithTiers(rows)
-  return hydratedSubscriptions[0] ?? null
+  return selectEffectiveSubscription(hydratedSubscriptions)
 }
 
 export async function getEffectiveSubscription(

--- a/apps/tradinggoose/lib/billing/core/subscription.ts
+++ b/apps/tradinggoose/lib/billing/core/subscription.ts
@@ -119,6 +119,25 @@ export async function requireActiveSubscriptionForReference(
   return activeSubscription
 }
 
+export async function getUniqueSubscriptionByStripeSubscriptionId(
+  stripeSubscriptionId: string
+): Promise<SubscriptionWithTier | null> {
+  const rows = await db
+    .select()
+    .from(subscription)
+    .where(eq(subscription.stripeSubscriptionId, stripeSubscriptionId))
+    .limit(2)
+
+  if (rows.length > 1) {
+    throw new Error(
+      `Multiple local subscriptions found for Stripe subscription ${stripeSubscriptionId}`
+    )
+  }
+
+  const hydratedSubscriptions = await hydrateSubscriptionsWithTiers(rows)
+  return hydratedSubscriptions[0] ?? null
+}
+
 export async function getEffectiveSubscription(
   userId: string
 ): Promise<SubscriptionWithTier | null> {

--- a/apps/tradinggoose/lib/billing/core/subscription.ts
+++ b/apps/tradinggoose/lib/billing/core/subscription.ts
@@ -126,9 +126,10 @@ export async function getSubscriptionByStripeSubscriptionId(
     .select()
     .from(subscription)
     .where(eq(subscription.stripeSubscriptionId, stripeSubscriptionId))
+    .limit(1)
 
   const hydratedSubscriptions = await hydrateSubscriptionsWithTiers(rows)
-  return selectEffectiveSubscription(hydratedSubscriptions)
+  return hydratedSubscriptions[0] ?? null
 }
 
 export async function getEffectiveSubscription(

--- a/apps/tradinggoose/lib/billing/core/subscription.ts
+++ b/apps/tradinggoose/lib/billing/core/subscription.ts
@@ -126,7 +126,13 @@ export async function getUniqueSubscriptionByStripeSubscriptionId(
     .select()
     .from(subscription)
     .where(eq(subscription.stripeSubscriptionId, stripeSubscriptionId))
-    .limit(1)
+    .limit(2)
+
+  if (rows.length > 1) {
+    throw new Error(
+      `Multiple local subscriptions found for Stripe subscription ${stripeSubscriptionId}`
+    )
+  }
 
   const hydratedSubscriptions = await hydrateSubscriptionsWithTiers(rows)
   return hydratedSubscriptions[0] ?? null

--- a/apps/tradinggoose/lib/billing/core/subscription.ts
+++ b/apps/tradinggoose/lib/billing/core/subscription.ts
@@ -126,13 +126,7 @@ export async function getUniqueSubscriptionByStripeSubscriptionId(
     .select()
     .from(subscription)
     .where(eq(subscription.stripeSubscriptionId, stripeSubscriptionId))
-    .limit(2)
-
-  if (rows.length > 1) {
-    throw new Error(
-      `Multiple local subscriptions found for Stripe subscription ${stripeSubscriptionId}`
-    )
-  }
+    .limit(1)
 
   const hydratedSubscriptions = await hydrateSubscriptionsWithTiers(rows)
   return hydratedSubscriptions[0] ?? null

--- a/apps/tradinggoose/lib/billing/core/usage.ts
+++ b/apps/tradinggoose/lib/billing/core/usage.ts
@@ -20,8 +20,8 @@ import {
   toBillingTierSummary,
 } from '@/lib/billing/tiers'
 import type { BillingData, UsageData, UsageLimitInfo } from '@/lib/billing/types'
-import { sendEmail } from '@/lib/email/mailer'
 import { resolveEmailLocale } from '@/lib/email/locale'
+import { sendEmail } from '@/lib/email/mailer'
 import { getEmailPreferences } from '@/lib/email/unsubscribe'
 import { createLogger } from '@/lib/logs/console/logger'
 import { getBaseUrl } from '@/lib/urls/utils'
@@ -121,11 +121,12 @@ export async function decrementGrantedOnboardingAllowanceByCurrentPeriodUsage(
 }
 
 export async function resetUserDefaultUsageToOnboardingAllowanceBalance(
-  userId: string
+  userId: string,
+  dbClient: Pick<typeof db, 'select' | 'update'> = db
 ): Promise<void> {
   const [{ onboardingAllowanceUsd }, statsRecords] = await Promise.all([
     getResolvedBillingSettings(),
-    db
+    dbClient
       .select({ grantedOnboardingAllowanceUsd: userStats.grantedOnboardingAllowanceUsd })
       .from(userStats)
       .where(eq(userStats.userId, userId))
@@ -141,7 +142,7 @@ export async function resetUserDefaultUsageToOnboardingAllowanceBalance(
     parseNonNegativeBillingAmount(statsRecords[0].grantedOnboardingAllowanceUsd) ?? 0
   const usedOnboardingAllowance = Math.max(onboardingAllowance - grantedAllowance, 0)
 
-  await db
+  await dbClient
     .update(userStats)
     .set({
       customUsageLimit: onboardingAllowance.toString(),

--- a/apps/tradinggoose/lib/billing/webhooks/enterprise.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/enterprise.ts
@@ -6,14 +6,15 @@ import {
   getEmailSubject,
   renderEnterpriseSubscriptionEmail,
 } from '@/components/emails/render-email'
+import { getUniqueSubscriptionByStripeSubscriptionId } from '@/lib/billing/core/subscription'
 import {
   getTierIncludedUsageLimit,
   isOrganizationBillingTier,
   requireBillingTierById,
 } from '@/lib/billing/tiers'
 import { resolveBillingTierForPersistence } from '@/lib/billing/tiers/persistence'
-import { sendEmail } from '@/lib/email/mailer'
 import { resolveEmailLocale } from '@/lib/email/locale'
+import { sendEmail } from '@/lib/email/mailer'
 import { createLogger } from '@/lib/logs/console/logger'
 import type { EnterpriseSubscriptionMetadata } from '../types'
 
@@ -137,13 +138,9 @@ export async function handleManualEnterpriseSubscription(event: Stripe.Event) {
     metadata: metadataJson,
   }
 
-  const existing = await db
-    .select({ id: subscription.id })
-    .from(subscription)
-    .where(eq(subscription.stripeSubscriptionId, stripeSubscription.id))
-    .limit(1)
+  const existing = await getUniqueSubscriptionByStripeSubscriptionId(stripeSubscription.id)
 
-  if (existing.length > 0) {
+  if (existing) {
     await db
       .update(subscription)
       .set({
@@ -161,7 +158,7 @@ export async function handleManualEnterpriseSubscription(event: Stripe.Event) {
         trialEnd: subscriptionRow.trialEnd,
         metadata: subscriptionRow.metadata,
       })
-      .where(eq(subscription.stripeSubscriptionId, stripeSubscription.id))
+      .where(eq(subscription.id, existing.id))
   } else {
     await db.insert(subscription).values(subscriptionRow)
   }
@@ -193,7 +190,7 @@ export async function handleManualEnterpriseSubscription(event: Stripe.Event) {
   }
 
   logger.info('[subscription.created] Upserted enterprise subscription', {
-    subscriptionId: existing[0]?.id || subscriptionRow.id,
+    subscriptionId: existing?.id || subscriptionRow.id,
     referenceType: subscriptionRow.referenceType,
     referenceId: subscriptionRow.referenceId,
     subscriptionKey: subscriptionRow.plan,
@@ -230,7 +227,11 @@ export async function handleManualEnterpriseSubscription(event: Stripe.Event) {
       const org = orgDetails[0]
       const locale = await resolveEmailLocale({ userId: user.id, email: user.email })
 
-      const html = await renderEnterpriseSubscriptionEmail(user.name || user.email, user.email, locale)
+      const html = await renderEnterpriseSubscriptionEmail(
+        user.name || user.email,
+        user.email,
+        locale
+      )
 
       const emailResult = await sendEmail({
         to: user.email,

--- a/apps/tradinggoose/lib/billing/webhooks/enterprise.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/enterprise.ts
@@ -6,7 +6,7 @@ import {
   getEmailSubject,
   renderEnterpriseSubscriptionEmail,
 } from '@/components/emails/render-email'
-import { getUniqueSubscriptionByStripeSubscriptionId } from '@/lib/billing/core/subscription'
+import { getSubscriptionByStripeSubscriptionId } from '@/lib/billing/core/subscription'
 import {
   getTierIncludedUsageLimit,
   isOrganizationBillingTier,
@@ -138,7 +138,7 @@ export async function handleManualEnterpriseSubscription(event: Stripe.Event) {
     metadata: metadataJson,
   }
 
-  const existing = await getUniqueSubscriptionByStripeSubscriptionId(stripeSubscription.id)
+  const existing = await getSubscriptionByStripeSubscriptionId(stripeSubscription.id)
 
   if (existing) {
     await db

--- a/apps/tradinggoose/lib/billing/webhooks/enterprise.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/enterprise.ts
@@ -6,7 +6,6 @@ import {
   getEmailSubject,
   renderEnterpriseSubscriptionEmail,
 } from '@/components/emails/render-email'
-import { getSubscriptionByStripeSubscriptionId } from '@/lib/billing/core/subscription'
 import {
   getTierIncludedUsageLimit,
   isOrganizationBillingTier,
@@ -138,9 +137,13 @@ export async function handleManualEnterpriseSubscription(event: Stripe.Event) {
     metadata: metadataJson,
   }
 
-  const existing = await getSubscriptionByStripeSubscriptionId(stripeSubscription.id)
+  const existingRows = await db
+    .select({ id: subscription.id })
+    .from(subscription)
+    .where(eq(subscription.stripeSubscriptionId, stripeSubscription.id))
+  const subscriptionId = existingRows[0]?.id || subscriptionRow.id
 
-  if (existing) {
+  if (existingRows.length > 0) {
     await db
       .update(subscription)
       .set({
@@ -158,7 +161,7 @@ export async function handleManualEnterpriseSubscription(event: Stripe.Event) {
         trialEnd: subscriptionRow.trialEnd,
         metadata: subscriptionRow.metadata,
       })
-      .where(eq(subscription.id, existing.id))
+      .where(eq(subscription.stripeSubscriptionId, stripeSubscription.id))
   } else {
     await db.insert(subscription).values(subscriptionRow)
   }
@@ -190,7 +193,7 @@ export async function handleManualEnterpriseSubscription(event: Stripe.Event) {
   }
 
   logger.info('[subscription.created] Upserted enterprise subscription', {
-    subscriptionId: existing?.id || subscriptionRow.id,
+    subscriptionId,
     referenceType: subscriptionRow.referenceType,
     referenceId: subscriptionRow.referenceId,
     subscriptionKey: subscriptionRow.plan,

--- a/apps/tradinggoose/lib/billing/webhooks/enterprise.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/enterprise.ts
@@ -137,16 +137,12 @@ export async function handleManualEnterpriseSubscription(event: Stripe.Event) {
     metadata: metadataJson,
   }
 
-  const existingRows = await db
-    .select({ id: subscription.id })
-    .from(subscription)
-    .where(eq(subscription.stripeSubscriptionId, stripeSubscription.id))
-  const subscriptionId = existingRows[0]?.id || subscriptionRow.id
-
-  if (existingRows.length > 0) {
-    await db
-      .update(subscription)
-      .set({
+  const [persistedSubscription] = await db
+    .insert(subscription)
+    .values(subscriptionRow)
+    .onConflictDoUpdate({
+      target: subscription.stripeSubscriptionId,
+      set: {
         plan: subscriptionRow.plan,
         billingTierId: subscriptionRow.billingTierId,
         referenceType: subscriptionRow.referenceType,
@@ -160,11 +156,10 @@ export async function handleManualEnterpriseSubscription(event: Stripe.Event) {
         trialStart: subscriptionRow.trialStart,
         trialEnd: subscriptionRow.trialEnd,
         metadata: subscriptionRow.metadata,
-      })
-      .where(eq(subscription.stripeSubscriptionId, stripeSubscription.id))
-  } else {
-    await db.insert(subscription).values(subscriptionRow)
-  }
+      },
+    })
+    .returning({ id: subscription.id })
+  const subscriptionId = persistedSubscription?.id || subscriptionRow.id
 
   if (billingTierRecord.usageScope === 'pooled') {
     const organizationUsageLimit = getTierIncludedUsageLimit(billingTierRecord) || monthlyPrice

--- a/apps/tradinggoose/lib/billing/webhooks/invoices.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/invoices.ts
@@ -3,7 +3,6 @@ import {
   member,
   organizationBillingLedger,
   organizationMemberBillingLedger,
-  subscription as subscriptionTable,
   user,
   userStats,
 } from '@tradinggoose/db/schema'
@@ -12,15 +11,15 @@ import type Stripe from 'stripe'
 import { getEmailSubject, renderPaymentFailedEmail } from '@/components/emails/render-email'
 import { calculateSubscriptionOverage } from '@/lib/billing/core/billing'
 import { getOrganizationBillingLedger } from '@/lib/billing/core/organization'
+import { getUniqueSubscriptionByStripeSubscriptionId } from '@/lib/billing/core/subscription'
 import { requireStripeClient } from '@/lib/billing/stripe-client'
 import {
   type BillingTierRecord,
-  hydrateSubscriptionsWithTiers,
   isOrganizationSubscription,
   usesIndividualBillingLedger,
 } from '@/lib/billing/tiers'
-import { sendEmail } from '@/lib/email/mailer'
 import { resolveEmailLocale } from '@/lib/email/locale'
+import { sendEmail } from '@/lib/email/mailer'
 import { quickValidateEmail } from '@/lib/email/validation'
 import { createLogger } from '@/lib/logs/console/logger'
 import { getBaseUrl } from '@/lib/urls/utils'
@@ -42,17 +41,6 @@ function parseDecimal(value: string | number | null | undefined): number {
 type SubscriptionUsageScope = {
   referenceId: string
   tier?: BillingTierRecord | null
-}
-
-async function getHydratedSubscriptionByStripeSubscriptionId(stripeSubscriptionId: string) {
-  const records = await db
-    .select()
-    .from(subscriptionTable)
-    .where(eq(subscriptionTable.stripeSubscriptionId, stripeSubscriptionId))
-    .limit(1)
-
-  const hydratedSubscriptions = await hydrateSubscriptionsWithTiers(records)
-  return hydratedSubscriptions[0] ?? null
 }
 
 /**
@@ -354,7 +342,7 @@ export async function handleInvoicePaymentSucceeded(event: Stripe.Event) {
       })
       return
     }
-    const sub = await getHydratedSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
+    const sub = await getUniqueSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
     if (!sub) return
 
     // Only reset usage here if the tenant was previously blocked; otherwise invoice.created already reset it
@@ -457,7 +445,7 @@ export async function handleInvoicePaymentFailed(event: Stripe.Event) {
         stripeSubscriptionId,
       })
 
-      const sub = await getHydratedSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
+      const sub = await getUniqueSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
 
       if (sub) {
         if (isOrganizationSubscription(sub)) {
@@ -530,7 +518,7 @@ export async function handleInvoiceFinalized(event: Stripe.Event) {
     }
     if (invoice.billing_reason && invoice.billing_reason !== 'subscription_cycle') return
 
-    const sub = await getHydratedSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
+    const sub = await getUniqueSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
     if (!sub) return
 
     const stripe = requireStripeClient()

--- a/apps/tradinggoose/lib/billing/webhooks/invoices.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/invoices.ts
@@ -11,7 +11,7 @@ import type Stripe from 'stripe'
 import { getEmailSubject, renderPaymentFailedEmail } from '@/components/emails/render-email'
 import { calculateSubscriptionOverage } from '@/lib/billing/core/billing'
 import { getOrganizationBillingLedger } from '@/lib/billing/core/organization'
-import { getUniqueSubscriptionByStripeSubscriptionId } from '@/lib/billing/core/subscription'
+import { getSubscriptionByStripeSubscriptionId } from '@/lib/billing/core/subscription'
 import { requireStripeClient } from '@/lib/billing/stripe-client'
 import {
   type BillingTierRecord,
@@ -342,7 +342,7 @@ export async function handleInvoicePaymentSucceeded(event: Stripe.Event) {
       })
       return
     }
-    const sub = await getUniqueSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
+    const sub = await getSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
     if (!sub) return
 
     // Only reset usage here if the tenant was previously blocked; otherwise invoice.created already reset it
@@ -445,7 +445,7 @@ export async function handleInvoicePaymentFailed(event: Stripe.Event) {
         stripeSubscriptionId,
       })
 
-      const sub = await getUniqueSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
+      const sub = await getSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
 
       if (sub) {
         if (isOrganizationSubscription(sub)) {
@@ -518,7 +518,7 @@ export async function handleInvoiceFinalized(event: Stripe.Event) {
     }
     if (invoice.billing_reason && invoice.billing_reason !== 'subscription_cycle') return
 
-    const sub = await getUniqueSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
+    const sub = await getSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
     if (!sub) return
 
     const stripe = requireStripeClient()

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
@@ -6,25 +6,44 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   mockAnd,
+  mockCalculateSubscriptionOverage,
   mockDb,
   mockDecrementGrantedOnboardingAllowanceByCurrentPeriodUsage,
+  mockEnsureDefaultUserSubscription,
   mockEq,
+  mockGetBilledOverageForSubscription,
+  mockGetResolvedBillingSettings,
+  mockHydrateSubscriptionsWithTiers,
   mockIsPaidBillingTier,
   mockNe,
+  mockRequireStripeClient,
   mockResetUsageForSubscription,
+  mockResetUserDefaultUsageToOnboardingAllowanceBalance,
+  mockSyncSubscriptionBillingTierFromStripeSubscription,
 } = vi.hoisted(() => ({
   mockAnd: vi.fn(),
+  mockCalculateSubscriptionOverage: vi.fn(),
   mockDb: {
     select: vi.fn(),
+    transaction: vi.fn(),
+    update: vi.fn(),
   },
   mockDecrementGrantedOnboardingAllowanceByCurrentPeriodUsage: vi.fn(),
+  mockEnsureDefaultUserSubscription: vi.fn(),
   mockEq: vi.fn((field: unknown, value: unknown) => ({ field, value })),
+  mockGetBilledOverageForSubscription: vi.fn(),
+  mockGetResolvedBillingSettings: vi.fn(),
+  mockHydrateSubscriptionsWithTiers: vi.fn(async (rows) => rows),
   mockIsPaidBillingTier: vi.fn(),
   mockNe: vi.fn((field: unknown, value: unknown) => ({ field, value })),
+  mockRequireStripeClient: vi.fn(),
   mockResetUsageForSubscription: vi.fn(),
+  mockResetUserDefaultUsageToOnboardingAllowanceBalance: vi.fn(),
+  mockSyncSubscriptionBillingTierFromStripeSubscription: vi.fn(),
 }))
 
 let otherActiveSubscriptions: Array<Record<string, unknown>> = []
+let updateCalls: Array<Record<string, unknown>> = []
 
 vi.mock('@tradinggoose/db', () => ({
   db: mockDb,
@@ -34,6 +53,7 @@ vi.mock('@tradinggoose/db/schema', () => ({
   subscription: {
     referenceType: 'subscription.referenceType',
     referenceId: 'subscription.referenceId',
+    stripeSubscriptionId: 'subscription.stripeSubscriptionId',
     status: 'subscription.status',
     id: 'subscription.id',
   },
@@ -48,23 +68,39 @@ vi.mock('drizzle-orm', () => ({
 vi.mock('@/lib/billing/core/usage', () => ({
   decrementGrantedOnboardingAllowanceByCurrentPeriodUsage:
     mockDecrementGrantedOnboardingAllowanceByCurrentPeriodUsage,
+  resetUserDefaultUsageToOnboardingAllowanceBalance:
+    mockResetUserDefaultUsageToOnboardingAllowanceBalance,
+}))
+
+vi.mock('@/lib/billing/core/subscription', () => ({
+  ensureDefaultUserSubscription: mockEnsureDefaultUserSubscription,
+}))
+
+vi.mock('@/lib/billing/settings', () => ({
+  getResolvedBillingSettings: mockGetResolvedBillingSettings,
 }))
 
 vi.mock('@/lib/billing/tiers', () => ({
+  hydrateSubscriptionsWithTiers: mockHydrateSubscriptionsWithTiers,
   isPaidBillingTier: mockIsPaidBillingTier,
 }))
 
+vi.mock('@/lib/billing/tiers/persistence', () => ({
+  syncSubscriptionBillingTierFromStripeSubscription:
+    mockSyncSubscriptionBillingTierFromStripeSubscription,
+}))
+
 vi.mock('@/lib/billing/webhooks/invoices', () => ({
-  getBilledOverageForSubscription: vi.fn(),
+  getBilledOverageForSubscription: mockGetBilledOverageForSubscription,
   resetUsageForSubscription: mockResetUsageForSubscription,
 }))
 
 vi.mock('@/lib/billing/core/billing', () => ({
-  calculateSubscriptionOverage: vi.fn(),
+  calculateSubscriptionOverage: mockCalculateSubscriptionOverage,
 }))
 
 vi.mock('@/lib/billing/stripe-client', () => ({
-  requireStripeClient: vi.fn(),
+  requireStripeClient: mockRequireStripeClient,
 }))
 
 vi.mock('@/lib/logs/console/logger', () => ({
@@ -75,13 +111,77 @@ vi.mock('@/lib/logs/console/logger', () => ({
   }),
 }))
 
-function createSelectQueryMock(result: unknown) {
+function createSelectQueryMock(result: unknown, terminal: 'where' | 'limit' = 'where') {
   const query = {
     from: vi.fn(() => query),
-    where: vi.fn(() => Promise.resolve(result)),
+    where: vi.fn(() => (terminal === 'where' ? Promise.resolve(result) : query)),
+    limit: vi.fn(() => Promise.resolve(result)),
   }
 
   return query
+}
+
+function createUpdateQueryMock() {
+  const query = {
+    set: vi.fn((values: Record<string, unknown>) => {
+      updateCalls.push(values)
+      return query
+    }),
+    where: vi.fn(() => Promise.resolve()),
+  }
+
+  return query
+}
+
+function createDeletedStripeSubscription() {
+  return {
+    id: 'sub_stripe_123',
+    cancel_at_period_end: true,
+    metadata: {
+      referenceId: 'user-1',
+      subscriptionId: 'metadata_is_not_identity',
+      userId: 'user-1',
+    },
+    items: {
+      data: [
+        {
+          current_period_start: 1778910924,
+          current_period_end: 1781589324,
+        },
+      ],
+    },
+  }
+}
+
+function createDeletedSubscriptionEvent() {
+  return {
+    id: 'evt_deleted',
+    data: {
+      object: createDeletedStripeSubscription(),
+    },
+  }
+}
+
+function createDefaultSubscription(
+  overrides: Partial<{
+    metadata: Record<string, unknown>
+    status: string
+    stripeSubscriptionId: string | null
+  }> = {}
+) {
+  return {
+    id: 'sub_default_user-1',
+    referenceType: 'user',
+    referenceId: 'user-1',
+    status: overrides.status ?? 'active',
+    stripeSubscriptionId: overrides.stripeSubscriptionId ?? null,
+    metadata: overrides.metadata ?? { source: 'default-tier' },
+    tier: {
+      id: 'tier_default',
+      isDefault: true,
+      displayName: 'Pay As You Go',
+    },
+  }
 }
 
 describe('handleSubscriptionCreated', () => {
@@ -89,8 +189,15 @@ describe('handleSubscriptionCreated', () => {
     vi.resetModules()
     vi.clearAllMocks()
 
+    updateCalls = []
     otherActiveSubscriptions = []
     mockDb.select.mockImplementation(() => createSelectQueryMock(otherActiveSubscriptions))
+    mockDb.transaction.mockImplementation(async (callback) => callback(mockDb))
+    mockDb.update.mockImplementation(() => createUpdateQueryMock())
+    mockCalculateSubscriptionOverage.mockResolvedValue(0)
+    mockGetBilledOverageForSubscription.mockResolvedValue(0)
+    mockGetResolvedBillingSettings.mockResolvedValue({ billingEnabled: true })
+    mockRequireStripeClient.mockReturnValue({})
     mockIsPaidBillingTier.mockReturnValue(false)
   })
 
@@ -153,5 +260,69 @@ describe('handleSubscriptionCreated', () => {
 
     expect(mockDecrementGrantedOnboardingAllowanceByCurrentPeriodUsage).not.toHaveBeenCalled()
     expect(mockResetUsageForSubscription).not.toHaveBeenCalled()
+  })
+})
+
+describe('handleStripeSubscriptionDeleted', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    updateCalls = []
+    mockDb.select.mockImplementation(() => createSelectQueryMock([]))
+    mockDb.transaction.mockImplementation(async (callback) => callback(mockDb))
+    mockDb.update.mockImplementation(() => createUpdateQueryMock())
+    mockCalculateSubscriptionOverage.mockResolvedValue(0)
+    mockGetBilledOverageForSubscription.mockResolvedValue(0)
+    mockGetResolvedBillingSettings.mockResolvedValue({ billingEnabled: true })
+    mockHydrateSubscriptionsWithTiers.mockImplementation(async (rows) => rows)
+    mockRequireStripeClient.mockReturnValue({})
+    mockSyncSubscriptionBillingTierFromStripeSubscription.mockResolvedValue(undefined)
+    mockResetUserDefaultUsageToOnboardingAllowanceBalance.mockResolvedValue(undefined)
+    mockResetUsageForSubscription.mockResolvedValue(undefined)
+  })
+
+  it('settles a deleted Stripe PAYG subscription by Stripe subscription id before restoring default PAYG', async () => {
+    const stripeBackedSubscription = createDefaultSubscription({
+      status: 'canceled',
+      stripeSubscriptionId: 'sub_stripe_123',
+    })
+    const defaultSubscription = createDefaultSubscription()
+    mockDb.select
+      .mockImplementationOnce(() => createSelectQueryMock([stripeBackedSubscription], 'limit'))
+      .mockImplementationOnce(() => createSelectQueryMock([stripeBackedSubscription], 'limit'))
+    mockEnsureDefaultUserSubscription.mockResolvedValue(defaultSubscription)
+
+    const { handleStripeSubscriptionDeleted } = await import('./subscription')
+    await handleStripeSubscriptionDeleted(createDeletedSubscriptionEvent() as any)
+
+    expect(mockEq).toHaveBeenCalledWith('subscription.stripeSubscriptionId', 'sub_stripe_123')
+    expect(mockEq).not.toHaveBeenCalledWith('subscription.id', 'metadata_is_not_identity')
+    expect(mockSyncSubscriptionBillingTierFromStripeSubscription).toHaveBeenCalledWith(
+      'sub_default_user-1',
+      expect.objectContaining({ id: 'sub_stripe_123' })
+    )
+    expect(mockCalculateSubscriptionOverage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'sub_default_user-1',
+        referenceId: 'user-1',
+        status: 'canceled',
+        stripeSubscriptionId: 'sub_stripe_123',
+      })
+    )
+    expect(mockEnsureDefaultUserSubscription).toHaveBeenCalledWith('user-1', mockDb)
+    expect(mockResetUserDefaultUsageToOnboardingAllowanceBalance).toHaveBeenCalledWith(
+      'user-1',
+      mockDb
+    )
+    expect(mockCalculateSubscriptionOverage.mock.invocationCallOrder[0]).toBeLessThan(
+      mockEnsureDefaultUserSubscription.mock.invocationCallOrder[0]
+    )
+    expect(updateCalls).toContainEqual(
+      expect.objectContaining({
+        status: 'canceled',
+        stripeSubscriptionId: 'sub_stripe_123',
+      })
+    )
   })
 })

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
@@ -346,11 +346,9 @@ describe('handleStripeSubscriptionDeleted', () => {
     )
   })
 
-  it('rejects deleted Stripe subscription events without a local subscription row', async () => {
+  it('skips deleted Stripe subscription events without a local subscription row', async () => {
     const { handleStripeSubscriptionDeleted } = await import('./subscription')
-    await expect(
-      handleStripeSubscriptionDeleted(createDeletedSubscriptionEvent() as any)
-    ).rejects.toThrow('No local subscription found for deleted Stripe subscription sub_stripe_123')
+    await handleStripeSubscriptionDeleted(createDeletedSubscriptionEvent() as any)
 
     expect(mockSyncSubscriptionBillingTierFromStripeSubscription).not.toHaveBeenCalled()
     expect(mockCalculateSubscriptionOverage).not.toHaveBeenCalled()

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
@@ -164,19 +164,21 @@ function createDeletedSubscriptionEvent() {
 
 function createDefaultSubscription(
   overrides: Partial<{
+    id: string
     metadata: Record<string, unknown>
     status: string
     stripeSubscriptionId: string | null
+    tier: Record<string, unknown>
   }> = {}
 ) {
   return {
-    id: 'sub_default_user-1',
+    id: overrides.id ?? 'sub_default_user-1',
     referenceType: 'user',
     referenceId: 'user-1',
     status: overrides.status ?? 'active',
     stripeSubscriptionId: overrides.stripeSubscriptionId ?? null,
     metadata: overrides.metadata ?? { source: 'default-tier' },
-    tier: {
+    tier: overrides.tier ?? {
       id: 'tier_default',
       isDefault: true,
       displayName: 'Pay As You Go',
@@ -323,6 +325,35 @@ describe('handleStripeSubscriptionDeleted', () => {
         status: 'canceled',
         stripeSubscriptionId: 'sub_stripe_123',
       })
+    )
+  })
+
+  it('does not reset onboarding usage when another personal subscription remains entitled', async () => {
+    const canceledSubscription = createDefaultSubscription({
+      status: 'canceled',
+      stripeSubscriptionId: 'sub_stripe_123',
+    })
+    const replacementSubscription = createDefaultSubscription({
+      id: 'sub_replacement',
+      stripeSubscriptionId: 'sub_stripe_replacement',
+      tier: {
+        id: 'tier_pro',
+        isDefault: false,
+        displayName: 'Pro',
+      },
+    })
+    mockDb.select
+      .mockImplementationOnce(() => createSelectQueryMock([canceledSubscription], 'limit'))
+      .mockImplementationOnce(() => createSelectQueryMock([canceledSubscription], 'limit'))
+    mockEnsureDefaultUserSubscription.mockResolvedValue(replacementSubscription)
+
+    const { handleStripeSubscriptionDeleted } = await import('./subscription')
+    await handleStripeSubscriptionDeleted(createDeletedSubscriptionEvent() as any)
+
+    expect(mockEnsureDefaultUserSubscription).toHaveBeenCalledWith('user-1', mockDb)
+    expect(mockResetUserDefaultUsageToOnboardingAllowanceBalance).not.toHaveBeenCalled()
+    expect(mockCalculateSubscriptionOverage.mock.invocationCallOrder[0]).toBeLessThan(
+      mockEnsureDefaultUserSubscription.mock.invocationCallOrder[0]
     )
   })
 })

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
@@ -332,6 +332,9 @@ describe('handleStripeSubscriptionDeleted', () => {
       mockDb
     )
     expect(mockSyncSubscriptionUsageLimits).toHaveBeenCalledWith(defaultSubscription)
+    expect(mockDb.update.mock.invocationCallOrder[0]).toBeLessThan(
+      mockCalculateSubscriptionOverage.mock.invocationCallOrder[0]
+    )
     expect(mockCalculateSubscriptionOverage.mock.invocationCallOrder[0]).toBeLessThan(
       mockEnsureDefaultUserSubscription.mock.invocationCallOrder[0]
     )
@@ -376,6 +379,12 @@ describe('handleStripeSubscriptionDeleted', () => {
     )
 
     expect(mockSyncSubscriptionBillingTierFromStripeSubscription).toHaveBeenCalled()
+    expect(updateCalls).toContainEqual(
+      expect.objectContaining({
+        status: 'canceled',
+        stripeSubscriptionId: 'sub_stripe_123',
+      })
+    )
     expect(mockCalculateSubscriptionOverage).not.toHaveBeenCalled()
     expect(mockEnsureDefaultUserSubscription).not.toHaveBeenCalled()
     expect(mockSyncSubscriptionUsageLimits).not.toHaveBeenCalled()

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
@@ -13,7 +13,7 @@ const {
   mockEq,
   mockGetBilledOverageForSubscription,
   mockGetResolvedBillingSettings,
-  mockGetUniqueSubscriptionByStripeSubscriptionId,
+  mockGetSubscriptionByStripeSubscriptionId,
   mockIsPaidBillingTier,
   mockNe,
   mockRequireStripeClient,
@@ -34,7 +34,7 @@ const {
   mockEq: vi.fn((field: unknown, value: unknown) => ({ field, value })),
   mockGetBilledOverageForSubscription: vi.fn(),
   mockGetResolvedBillingSettings: vi.fn(),
-  mockGetUniqueSubscriptionByStripeSubscriptionId: vi.fn(),
+  mockGetSubscriptionByStripeSubscriptionId: vi.fn(),
   mockIsPaidBillingTier: vi.fn(),
   mockNe: vi.fn((field: unknown, value: unknown) => ({ field, value })),
   mockRequireStripeClient: vi.fn(),
@@ -76,7 +76,7 @@ vi.mock('@/lib/billing/core/usage', () => ({
 
 vi.mock('@/lib/billing/core/subscription', () => ({
   ensureDefaultUserSubscription: mockEnsureDefaultUserSubscription,
-  getUniqueSubscriptionByStripeSubscriptionId: mockGetUniqueSubscriptionByStripeSubscriptionId,
+  getSubscriptionByStripeSubscriptionId: mockGetSubscriptionByStripeSubscriptionId,
 }))
 
 vi.mock('@/lib/billing/settings', () => ({
@@ -290,7 +290,7 @@ describe('handleStripeSubscriptionDeleted', () => {
     mockCalculateSubscriptionOverage.mockResolvedValue(0)
     mockGetBilledOverageForSubscription.mockResolvedValue(0)
     mockGetResolvedBillingSettings.mockResolvedValue({ billingEnabled: true })
-    mockGetUniqueSubscriptionByStripeSubscriptionId.mockResolvedValue(null)
+    mockGetSubscriptionByStripeSubscriptionId.mockResolvedValue(null)
     mockRequireStripeClient.mockReturnValue({})
     mockSyncSubscriptionBillingTierFromStripeSubscription.mockResolvedValue(undefined)
     mockSyncSubscriptionUsageLimits.mockResolvedValue(undefined)
@@ -304,7 +304,7 @@ describe('handleStripeSubscriptionDeleted', () => {
       stripeSubscriptionId: 'sub_stripe_123',
     })
     const defaultSubscription = createDefaultSubscription()
-    mockGetUniqueSubscriptionByStripeSubscriptionId
+    mockGetSubscriptionByStripeSubscriptionId
       .mockResolvedValueOnce(stripeBackedSubscription)
       .mockResolvedValueOnce(stripeBackedSubscription)
     mockEnsureDefaultUserSubscription.mockResolvedValue(defaultSubscription)
@@ -312,7 +312,7 @@ describe('handleStripeSubscriptionDeleted', () => {
     const { handleStripeSubscriptionDeleted } = await import('./subscription')
     await handleStripeSubscriptionDeleted(createDeletedSubscriptionEvent() as any)
 
-    expect(mockGetUniqueSubscriptionByStripeSubscriptionId).toHaveBeenCalledWith('sub_stripe_123')
+    expect(mockGetSubscriptionByStripeSubscriptionId).toHaveBeenCalledWith('sub_stripe_123')
     expect(mockEq).not.toHaveBeenCalledWith('subscription.id', 'metadata_is_not_identity')
     expect(mockSyncSubscriptionBillingTierFromStripeSubscription).toHaveBeenCalledWith(
       'sub_default_user-1',
@@ -364,7 +364,7 @@ describe('handleStripeSubscriptionDeleted', () => {
       status: 'canceled',
       stripeSubscriptionId: 'sub_stripe_123',
     })
-    mockGetUniqueSubscriptionByStripeSubscriptionId
+    mockGetSubscriptionByStripeSubscriptionId
       .mockResolvedValueOnce(stripeBackedSubscription)
       .mockResolvedValueOnce(null)
 
@@ -395,7 +395,7 @@ describe('handleStripeSubscriptionDeleted', () => {
         displayName: 'Pro',
       },
     })
-    mockGetUniqueSubscriptionByStripeSubscriptionId
+    mockGetSubscriptionByStripeSubscriptionId
       .mockResolvedValueOnce(canceledSubscription)
       .mockResolvedValueOnce(canceledSubscription)
     mockEnsureDefaultUserSubscription.mockResolvedValue(replacementSubscription)
@@ -425,7 +425,7 @@ describe('handleStripeSubscriptionDeleted', () => {
         displayName: 'Team',
       },
     })
-    mockGetUniqueSubscriptionByStripeSubscriptionId
+    mockGetSubscriptionByStripeSubscriptionId
       .mockResolvedValueOnce(organizationSubscription)
       .mockResolvedValueOnce(organizationSubscription)
 
@@ -442,7 +442,7 @@ describe('handleStripeSubscriptionDeleted', () => {
     )
 
     expect(mockEnsureDefaultUserSubscription).not.toHaveBeenCalled()
-    expect(mockGetUniqueSubscriptionByStripeSubscriptionId).toHaveBeenCalledWith('sub_stripe_123')
+    expect(mockGetSubscriptionByStripeSubscriptionId).toHaveBeenCalledWith('sub_stripe_123')
     expect(mockResetUserDefaultUsageToOnboardingAllowanceBalance).not.toHaveBeenCalled()
     expect(mockSyncSubscriptionUsageLimits).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
@@ -139,11 +139,16 @@ function createUpdateQueryMock() {
   return query
 }
 
-function createDeletedStripeSubscription() {
+function createDeletedStripeSubscription(
+  overrides: Partial<{
+    id: string
+    metadata: Record<string, string>
+  }> = {}
+) {
   return {
-    id: 'sub_stripe_123',
+    id: overrides.id ?? 'sub_stripe_123',
     cancel_at_period_end: true,
-    metadata: {
+    metadata: overrides.metadata ?? {
       referenceId: 'user-1',
       subscriptionId: 'metadata_is_not_identity',
       userId: 'user-1',
@@ -159,11 +164,11 @@ function createDeletedStripeSubscription() {
   }
 }
 
-function createDeletedSubscriptionEvent() {
+function createDeletedSubscriptionEvent(stripeSubscription = createDeletedStripeSubscription()) {
   return {
     id: 'evt_deleted',
     data: {
-      object: createDeletedStripeSubscription(),
+      object: stripeSubscription,
     },
   }
 }
@@ -341,9 +346,11 @@ describe('handleStripeSubscriptionDeleted', () => {
     )
   })
 
-  it('ignores deleted Stripe subscription events without a local subscription row', async () => {
+  it('rejects deleted Stripe subscription events without a local subscription row', async () => {
     const { handleStripeSubscriptionDeleted } = await import('./subscription')
-    await handleStripeSubscriptionDeleted(createDeletedSubscriptionEvent() as any)
+    await expect(
+      handleStripeSubscriptionDeleted(createDeletedSubscriptionEvent() as any)
+    ).rejects.toThrow('No local subscription found for deleted Stripe subscription sub_stripe_123')
 
     expect(mockSyncSubscriptionBillingTierFromStripeSubscription).not.toHaveBeenCalled()
     expect(mockCalculateSubscriptionOverage).not.toHaveBeenCalled()
@@ -425,9 +432,19 @@ describe('handleStripeSubscriptionDeleted', () => {
       .mockResolvedValueOnce(organizationSubscription)
 
     const { handleStripeSubscriptionDeleted } = await import('./subscription')
-    await handleStripeSubscriptionDeleted(createDeletedSubscriptionEvent() as any)
+    await handleStripeSubscriptionDeleted(
+      createDeletedSubscriptionEvent(
+        createDeletedStripeSubscription({
+          metadata: {
+            referenceType: 'organization',
+            referenceId: 'org-1',
+          },
+        })
+      ) as any
+    )
 
     expect(mockEnsureDefaultUserSubscription).not.toHaveBeenCalled()
+    expect(mockGetUniqueSubscriptionByStripeSubscriptionId).toHaveBeenCalledWith('sub_stripe_123')
     expect(mockResetUserDefaultUsageToOnboardingAllowanceBalance).not.toHaveBeenCalled()
     expect(mockSyncSubscriptionUsageLimits).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
@@ -20,6 +20,7 @@ const {
   mockResetUsageForSubscription,
   mockResetUserDefaultUsageToOnboardingAllowanceBalance,
   mockSyncSubscriptionBillingTierFromStripeSubscription,
+  mockSyncSubscriptionUsageLimits,
 } = vi.hoisted(() => ({
   mockAnd: vi.fn(),
   mockCalculateSubscriptionOverage: vi.fn(),
@@ -40,6 +41,7 @@ const {
   mockResetUsageForSubscription: vi.fn(),
   mockResetUserDefaultUsageToOnboardingAllowanceBalance: vi.fn(),
   mockSyncSubscriptionBillingTierFromStripeSubscription: vi.fn(),
+  mockSyncSubscriptionUsageLimits: vi.fn(),
 }))
 
 let otherActiveSubscriptions: Array<Record<string, unknown>> = []
@@ -88,6 +90,10 @@ vi.mock('@/lib/billing/tiers', () => ({
 vi.mock('@/lib/billing/tiers/persistence', () => ({
   syncSubscriptionBillingTierFromStripeSubscription:
     mockSyncSubscriptionBillingTierFromStripeSubscription,
+}))
+
+vi.mock('@/lib/billing/organization', () => ({
+  syncSubscriptionUsageLimits: mockSyncSubscriptionUsageLimits,
 }))
 
 vi.mock('@/lib/billing/webhooks/invoices', () => ({
@@ -166,6 +172,8 @@ function createDefaultSubscription(
   overrides: Partial<{
     id: string
     metadata: Record<string, unknown>
+    referenceId: string
+    referenceType: 'user' | 'organization'
     status: string
     stripeSubscriptionId: string | null
     tier: Record<string, unknown>
@@ -173,8 +181,8 @@ function createDefaultSubscription(
 ) {
   return {
     id: overrides.id ?? 'sub_default_user-1',
-    referenceType: 'user',
-    referenceId: 'user-1',
+    referenceType: overrides.referenceType ?? 'user',
+    referenceId: overrides.referenceId ?? 'user-1',
     status: overrides.status ?? 'active',
     stripeSubscriptionId: overrides.stripeSubscriptionId ?? null,
     metadata: overrides.metadata ?? { source: 'default-tier' },
@@ -280,6 +288,7 @@ describe('handleStripeSubscriptionDeleted', () => {
     mockGetUniqueSubscriptionByStripeSubscriptionId.mockResolvedValue(null)
     mockRequireStripeClient.mockReturnValue({})
     mockSyncSubscriptionBillingTierFromStripeSubscription.mockResolvedValue(undefined)
+    mockSyncSubscriptionUsageLimits.mockResolvedValue(undefined)
     mockResetUserDefaultUsageToOnboardingAllowanceBalance.mockResolvedValue(undefined)
     mockResetUsageForSubscription.mockResolvedValue(undefined)
   })
@@ -317,8 +326,12 @@ describe('handleStripeSubscriptionDeleted', () => {
       'user-1',
       mockDb
     )
+    expect(mockSyncSubscriptionUsageLimits).toHaveBeenCalledWith(defaultSubscription)
     expect(mockCalculateSubscriptionOverage.mock.invocationCallOrder[0]).toBeLessThan(
       mockEnsureDefaultUserSubscription.mock.invocationCallOrder[0]
+    )
+    expect(mockEnsureDefaultUserSubscription.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSyncSubscriptionUsageLimits.mock.invocationCallOrder[0]
     )
     expect(updateCalls).toContainEqual(
       expect.objectContaining({
@@ -337,6 +350,7 @@ describe('handleStripeSubscriptionDeleted', () => {
     expect(mockResetUsageForSubscription).not.toHaveBeenCalled()
     expect(mockEnsureDefaultUserSubscription).not.toHaveBeenCalled()
     expect(mockResetUserDefaultUsageToOnboardingAllowanceBalance).not.toHaveBeenCalled()
+    expect(mockSyncSubscriptionUsageLimits).not.toHaveBeenCalled()
     expect(updateCalls).toEqual([])
   })
 
@@ -359,6 +373,7 @@ describe('handleStripeSubscriptionDeleted', () => {
     expect(mockSyncSubscriptionBillingTierFromStripeSubscription).toHaveBeenCalled()
     expect(mockCalculateSubscriptionOverage).not.toHaveBeenCalled()
     expect(mockEnsureDefaultUserSubscription).not.toHaveBeenCalled()
+    expect(mockSyncSubscriptionUsageLimits).not.toHaveBeenCalled()
   })
 
   it('does not reset onboarding usage when another personal subscription remains entitled', async () => {
@@ -385,8 +400,42 @@ describe('handleStripeSubscriptionDeleted', () => {
 
     expect(mockEnsureDefaultUserSubscription).toHaveBeenCalledWith('user-1', mockDb)
     expect(mockResetUserDefaultUsageToOnboardingAllowanceBalance).not.toHaveBeenCalled()
+    expect(mockSyncSubscriptionUsageLimits).toHaveBeenCalledWith(replacementSubscription)
     expect(mockCalculateSubscriptionOverage.mock.invocationCallOrder[0]).toBeLessThan(
       mockEnsureDefaultUserSubscription.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('syncs usage limits for organization members after deleting an organization subscription', async () => {
+    const organizationSubscription = createDefaultSubscription({
+      id: 'sub_org',
+      referenceType: 'organization',
+      referenceId: 'org-1',
+      status: 'canceled',
+      stripeSubscriptionId: 'sub_stripe_123',
+      tier: {
+        id: 'tier_team',
+        isDefault: false,
+        ownerType: 'organization',
+        displayName: 'Team',
+      },
+    })
+    mockGetUniqueSubscriptionByStripeSubscriptionId
+      .mockResolvedValueOnce(organizationSubscription)
+      .mockResolvedValueOnce(organizationSubscription)
+
+    const { handleStripeSubscriptionDeleted } = await import('./subscription')
+    await handleStripeSubscriptionDeleted(createDeletedSubscriptionEvent() as any)
+
+    expect(mockEnsureDefaultUserSubscription).not.toHaveBeenCalled()
+    expect(mockResetUserDefaultUsageToOnboardingAllowanceBalance).not.toHaveBeenCalled()
+    expect(mockSyncSubscriptionUsageLimits).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'sub_org',
+        referenceType: 'organization',
+        referenceId: 'org-1',
+        status: 'canceled',
+      })
     )
   })
 })

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
@@ -13,7 +13,7 @@ const {
   mockEq,
   mockGetBilledOverageForSubscription,
   mockGetResolvedBillingSettings,
-  mockHydrateSubscriptionsWithTiers,
+  mockGetUniqueSubscriptionByStripeSubscriptionId,
   mockIsPaidBillingTier,
   mockNe,
   mockRequireStripeClient,
@@ -33,7 +33,7 @@ const {
   mockEq: vi.fn((field: unknown, value: unknown) => ({ field, value })),
   mockGetBilledOverageForSubscription: vi.fn(),
   mockGetResolvedBillingSettings: vi.fn(),
-  mockHydrateSubscriptionsWithTiers: vi.fn(async (rows) => rows),
+  mockGetUniqueSubscriptionByStripeSubscriptionId: vi.fn(),
   mockIsPaidBillingTier: vi.fn(),
   mockNe: vi.fn((field: unknown, value: unknown) => ({ field, value })),
   mockRequireStripeClient: vi.fn(),
@@ -74,6 +74,7 @@ vi.mock('@/lib/billing/core/usage', () => ({
 
 vi.mock('@/lib/billing/core/subscription', () => ({
   ensureDefaultUserSubscription: mockEnsureDefaultUserSubscription,
+  getUniqueSubscriptionByStripeSubscriptionId: mockGetUniqueSubscriptionByStripeSubscriptionId,
 }))
 
 vi.mock('@/lib/billing/settings', () => ({
@@ -81,7 +82,6 @@ vi.mock('@/lib/billing/settings', () => ({
 }))
 
 vi.mock('@/lib/billing/tiers', () => ({
-  hydrateSubscriptionsWithTiers: mockHydrateSubscriptionsWithTiers,
   isPaidBillingTier: mockIsPaidBillingTier,
 }))
 
@@ -277,7 +277,7 @@ describe('handleStripeSubscriptionDeleted', () => {
     mockCalculateSubscriptionOverage.mockResolvedValue(0)
     mockGetBilledOverageForSubscription.mockResolvedValue(0)
     mockGetResolvedBillingSettings.mockResolvedValue({ billingEnabled: true })
-    mockHydrateSubscriptionsWithTiers.mockImplementation(async (rows) => rows)
+    mockGetUniqueSubscriptionByStripeSubscriptionId.mockResolvedValue(null)
     mockRequireStripeClient.mockReturnValue({})
     mockSyncSubscriptionBillingTierFromStripeSubscription.mockResolvedValue(undefined)
     mockResetUserDefaultUsageToOnboardingAllowanceBalance.mockResolvedValue(undefined)
@@ -290,15 +290,15 @@ describe('handleStripeSubscriptionDeleted', () => {
       stripeSubscriptionId: 'sub_stripe_123',
     })
     const defaultSubscription = createDefaultSubscription()
-    mockDb.select
-      .mockImplementationOnce(() => createSelectQueryMock([stripeBackedSubscription], 'limit'))
-      .mockImplementationOnce(() => createSelectQueryMock([stripeBackedSubscription], 'limit'))
+    mockGetUniqueSubscriptionByStripeSubscriptionId
+      .mockResolvedValueOnce(stripeBackedSubscription)
+      .mockResolvedValueOnce(stripeBackedSubscription)
     mockEnsureDefaultUserSubscription.mockResolvedValue(defaultSubscription)
 
     const { handleStripeSubscriptionDeleted } = await import('./subscription')
     await handleStripeSubscriptionDeleted(createDeletedSubscriptionEvent() as any)
 
-    expect(mockEq).toHaveBeenCalledWith('subscription.stripeSubscriptionId', 'sub_stripe_123')
+    expect(mockGetUniqueSubscriptionByStripeSubscriptionId).toHaveBeenCalledWith('sub_stripe_123')
     expect(mockEq).not.toHaveBeenCalledWith('subscription.id', 'metadata_is_not_identity')
     expect(mockSyncSubscriptionBillingTierFromStripeSubscription).toHaveBeenCalledWith(
       'sub_default_user-1',
@@ -345,9 +345,9 @@ describe('handleStripeSubscriptionDeleted', () => {
       status: 'canceled',
       stripeSubscriptionId: 'sub_stripe_123',
     })
-    mockDb.select
-      .mockImplementationOnce(() => createSelectQueryMock([stripeBackedSubscription], 'limit'))
-      .mockImplementationOnce(() => createSelectQueryMock([], 'limit'))
+    mockGetUniqueSubscriptionByStripeSubscriptionId
+      .mockResolvedValueOnce(stripeBackedSubscription)
+      .mockResolvedValueOnce(null)
 
     const { handleStripeSubscriptionDeleted } = await import('./subscription')
     await expect(
@@ -375,9 +375,9 @@ describe('handleStripeSubscriptionDeleted', () => {
         displayName: 'Pro',
       },
     })
-    mockDb.select
-      .mockImplementationOnce(() => createSelectQueryMock([canceledSubscription], 'limit'))
-      .mockImplementationOnce(() => createSelectQueryMock([canceledSubscription], 'limit'))
+    mockGetUniqueSubscriptionByStripeSubscriptionId
+      .mockResolvedValueOnce(canceledSubscription)
+      .mockResolvedValueOnce(canceledSubscription)
     mockEnsureDefaultUserSubscription.mockResolvedValue(replacementSubscription)
 
     const { handleStripeSubscriptionDeleted } = await import('./subscription')

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
@@ -271,7 +271,7 @@ describe('handleStripeSubscriptionDeleted', () => {
     vi.clearAllMocks()
 
     updateCalls = []
-    mockDb.select.mockImplementation(() => createSelectQueryMock([]))
+    mockDb.select.mockImplementation(() => createSelectQueryMock([], 'limit'))
     mockDb.transaction.mockImplementation(async (callback) => callback(mockDb))
     mockDb.update.mockImplementation(() => createUpdateQueryMock())
     mockCalculateSubscriptionOverage.mockResolvedValue(0)
@@ -326,6 +326,39 @@ describe('handleStripeSubscriptionDeleted', () => {
         stripeSubscriptionId: 'sub_stripe_123',
       })
     )
+  })
+
+  it('ignores deleted Stripe subscription events without a local subscription row', async () => {
+    const { handleStripeSubscriptionDeleted } = await import('./subscription')
+    await handleStripeSubscriptionDeleted(createDeletedSubscriptionEvent() as any)
+
+    expect(mockSyncSubscriptionBillingTierFromStripeSubscription).not.toHaveBeenCalled()
+    expect(mockCalculateSubscriptionOverage).not.toHaveBeenCalled()
+    expect(mockResetUsageForSubscription).not.toHaveBeenCalled()
+    expect(mockEnsureDefaultUserSubscription).not.toHaveBeenCalled()
+    expect(mockResetUserDefaultUsageToOnboardingAllowanceBalance).not.toHaveBeenCalled()
+    expect(updateCalls).toEqual([])
+  })
+
+  it('rejects when a matched subscription disappears during deletion settlement', async () => {
+    const stripeBackedSubscription = createDefaultSubscription({
+      status: 'canceled',
+      stripeSubscriptionId: 'sub_stripe_123',
+    })
+    mockDb.select
+      .mockImplementationOnce(() => createSelectQueryMock([stripeBackedSubscription], 'limit'))
+      .mockImplementationOnce(() => createSelectQueryMock([], 'limit'))
+
+    const { handleStripeSubscriptionDeleted } = await import('./subscription')
+    await expect(
+      handleStripeSubscriptionDeleted(createDeletedSubscriptionEvent() as any)
+    ).rejects.toThrow(
+      'Local subscription disappeared while settling deleted Stripe subscription sub_stripe_123'
+    )
+
+    expect(mockSyncSubscriptionBillingTierFromStripeSubscription).toHaveBeenCalled()
+    expect(mockCalculateSubscriptionOverage).not.toHaveBeenCalled()
+    expect(mockEnsureDefaultUserSubscription).not.toHaveBeenCalled()
   })
 
   it('does not reset onboarding usage when another personal subscription remains entitled', async () => {

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.ts
@@ -1,10 +1,21 @@
 import { db } from '@tradinggoose/db'
 import { subscription } from '@tradinggoose/db/schema'
 import { and, eq, ne } from 'drizzle-orm'
+import type Stripe from 'stripe'
 import { calculateSubscriptionOverage } from '@/lib/billing/core/billing'
-import { decrementGrantedOnboardingAllowanceByCurrentPeriodUsage } from '@/lib/billing/core/usage'
+import { ensureDefaultUserSubscription } from '@/lib/billing/core/subscription'
+import {
+  decrementGrantedOnboardingAllowanceByCurrentPeriodUsage,
+  resetUserDefaultUsageToOnboardingAllowanceBalance,
+} from '@/lib/billing/core/usage'
+import { getResolvedBillingSettings } from '@/lib/billing/settings'
 import { requireStripeClient } from '@/lib/billing/stripe-client'
-import { type BillingTierRecord, isPaidBillingTier } from '@/lib/billing/tiers'
+import {
+  type BillingTierRecord,
+  hydrateSubscriptionsWithTiers,
+  isPaidBillingTier,
+} from '@/lib/billing/tiers'
+import { syncSubscriptionBillingTierFromStripeSubscription } from '@/lib/billing/tiers/persistence'
 import {
   getBilledOverageForSubscription,
   resetUsageForSubscription,
@@ -21,6 +32,30 @@ type TieredSubscriptionLifecycleRecord = {
   stripeSubscriptionId?: string | null
   seats?: number | null
   tier?: BillingTierRecord | null
+}
+
+function getStripeSubscriptionPeriod(stripeSubscription: Stripe.Subscription) {
+  const item = stripeSubscription.items.data[0]
+  if (!item) {
+    return {}
+  }
+
+  return {
+    periodStart: new Date(item.current_period_start * 1000),
+    periodEnd: new Date(item.current_period_end * 1000),
+  }
+}
+
+async function getSubscriptionForDeletedStripeSubscription(
+  stripeSubscription: Stripe.Subscription
+) {
+  const records = await db
+    .select()
+    .from(subscription)
+    .where(eq(subscription.stripeSubscriptionId, stripeSubscription.id))
+    .limit(1)
+  const hydratedSubscriptions = await hydrateSubscriptionsWithTiers(records)
+  return hydratedSubscriptions[0] ?? null
 }
 
 /**
@@ -182,8 +217,8 @@ export async function handleSubscriptionDeleted(subscription: TieredSubscription
           { idempotencyKey: itemIdemKey }
         )
 
-        // Finalize the invoice (this will trigger payment collection)
-        if (overageInvoice.id) {
+        // Finalize only draft invoices; duplicate webhook deliveries can return the prior invoice.
+        if (overageInvoice.id && overageInvoice.status === 'draft') {
           await stripe.invoices.finalizeInvoice(overageInvoice.id)
         }
 
@@ -234,4 +269,59 @@ export async function handleSubscriptionDeleted(subscription: TieredSubscription
     })
     throw error
   }
+}
+
+export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
+  const stripeSubscription = event.data.object as Stripe.Subscription
+  const stripeSubscriptionId = stripeSubscription.id
+
+  const resolvedSubscription = await getSubscriptionForDeletedStripeSubscription(stripeSubscription)
+
+  if (!resolvedSubscription) {
+    throw new Error(
+      `No local subscription found for deleted Stripe subscription ${stripeSubscriptionId}`
+    )
+  }
+
+  await syncSubscriptionBillingTierFromStripeSubscription(
+    resolvedSubscription.id,
+    stripeSubscription
+  )
+
+  const hydratedSubscription =
+    (await getSubscriptionForDeletedStripeSubscription(stripeSubscription)) ?? resolvedSubscription
+
+  const subscriptionToSettle = {
+    ...hydratedSubscription,
+    stripeSubscriptionId,
+    status: 'canceled',
+  }
+
+  await handleSubscriptionDeleted(subscriptionToSettle)
+
+  await db
+    .update(subscription)
+    .set({
+      ...getStripeSubscriptionPeriod(stripeSubscription),
+      stripeSubscriptionId,
+      status: 'canceled',
+      cancelAtPeriodEnd: stripeSubscription.cancel_at_period_end,
+    })
+    .where(eq(subscription.id, hydratedSubscription.id))
+
+  const { billingEnabled } = await getResolvedBillingSettings()
+  if (billingEnabled && subscriptionToSettle.referenceType === 'user') {
+    await db.transaction(async (tx) => {
+      await ensureDefaultUserSubscription(subscriptionToSettle.referenceId, tx)
+      await resetUserDefaultUsageToOnboardingAllowanceBalance(subscriptionToSettle.referenceId, tx)
+    })
+  }
+
+  logger.info('Settled deleted Stripe subscription', {
+    eventId: event.id,
+    subscriptionId: subscriptionToSettle.id,
+    referenceType: subscriptionToSettle.referenceType,
+    referenceId: subscriptionToSettle.referenceId,
+    stripeSubscriptionId,
+  })
 }

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.ts
@@ -3,18 +3,17 @@ import { subscription } from '@tradinggoose/db/schema'
 import { and, eq, ne } from 'drizzle-orm'
 import type Stripe from 'stripe'
 import { calculateSubscriptionOverage } from '@/lib/billing/core/billing'
-import { ensureDefaultUserSubscription } from '@/lib/billing/core/subscription'
+import {
+  ensureDefaultUserSubscription,
+  getUniqueSubscriptionByStripeSubscriptionId,
+} from '@/lib/billing/core/subscription'
 import {
   decrementGrantedOnboardingAllowanceByCurrentPeriodUsage,
   resetUserDefaultUsageToOnboardingAllowanceBalance,
 } from '@/lib/billing/core/usage'
 import { getResolvedBillingSettings } from '@/lib/billing/settings'
 import { requireStripeClient } from '@/lib/billing/stripe-client'
-import {
-  type BillingTierRecord,
-  hydrateSubscriptionsWithTiers,
-  isPaidBillingTier,
-} from '@/lib/billing/tiers'
+import { type BillingTierRecord, isPaidBillingTier } from '@/lib/billing/tiers'
 import { syncSubscriptionBillingTierFromStripeSubscription } from '@/lib/billing/tiers/persistence'
 import {
   getBilledOverageForSubscription,
@@ -44,18 +43,6 @@ function getStripeSubscriptionPeriod(stripeSubscription: Stripe.Subscription) {
     periodStart: new Date(item.current_period_start * 1000),
     periodEnd: new Date(item.current_period_end * 1000),
   }
-}
-
-async function getSubscriptionForDeletedStripeSubscription(
-  stripeSubscription: Stripe.Subscription
-) {
-  const records = await db
-    .select()
-    .from(subscription)
-    .where(eq(subscription.stripeSubscriptionId, stripeSubscription.id))
-    .limit(1)
-  const hydratedSubscriptions = await hydrateSubscriptionsWithTiers(records)
-  return hydratedSubscriptions[0] ?? null
 }
 
 /**
@@ -275,7 +262,8 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
   const stripeSubscription = event.data.object as Stripe.Subscription
   const stripeSubscriptionId = stripeSubscription.id
 
-  const resolvedSubscription = await getSubscriptionForDeletedStripeSubscription(stripeSubscription)
+  const resolvedSubscription =
+    await getUniqueSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
 
   if (!resolvedSubscription) {
     logger.warn('Deleted Stripe subscription has no local subscription row', {
@@ -290,7 +278,8 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
     stripeSubscription
   )
 
-  const hydratedSubscription = await getSubscriptionForDeletedStripeSubscription(stripeSubscription)
+  const hydratedSubscription =
+    await getUniqueSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
   if (!hydratedSubscription) {
     throw new Error(
       `Local subscription disappeared while settling deleted Stripe subscription ${stripeSubscriptionId}`

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.ts
@@ -267,9 +267,11 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
     await getUniqueSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
 
   if (!resolvedSubscription) {
-    throw new Error(
-      `No local subscription found for deleted Stripe subscription ${stripeSubscriptionId}`
-    )
+    logger.info('Deleted Stripe subscription has no local subscription row; skipping settlement', {
+      eventId: event.id,
+      stripeSubscriptionId,
+    })
+    return
   }
 
   await syncSubscriptionBillingTierFromStripeSubscription(

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.ts
@@ -238,11 +238,7 @@ export async function handleSubscriptionDeleted(subscription: TieredSubscription
       })
     }
 
-    // Reset usage after billing
     await resetUsageForSubscription(subscription)
-
-    // Note: better-auth's Stripe plugin already updates status to 'canceled' before calling this handler
-    // We only need to handle overage billing and usage reset
 
     logger.info('Successfully processed subscription cancellation', {
       subscriptionId: subscription.id,
@@ -273,6 +269,16 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
     return
   }
 
+  await db
+    .update(subscription)
+    .set({
+      ...getStripeSubscriptionPeriod(stripeSubscription),
+      stripeSubscriptionId,
+      status: 'canceled',
+      cancelAtPeriodEnd: stripeSubscription.cancel_at_period_end,
+    })
+    .where(eq(subscription.stripeSubscriptionId, stripeSubscriptionId))
+
   await syncSubscriptionBillingTierFromStripeSubscription(
     resolvedSubscription.id,
     stripeSubscription
@@ -293,16 +299,6 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
   let subscriptionForUsageLimits: TieredSubscriptionLifecycleRecord = subscriptionToSettle
 
   await handleSubscriptionDeleted(subscriptionToSettle)
-
-  await db
-    .update(subscription)
-    .set({
-      ...getStripeSubscriptionPeriod(stripeSubscription),
-      stripeSubscriptionId,
-      status: 'canceled',
-      cancelAtPeriodEnd: stripeSubscription.cancel_at_period_end,
-    })
-    .where(eq(subscription.id, hydratedSubscription.id))
 
   if (subscriptionToSettle.referenceType === 'user') {
     const { billingEnabled } = await getResolvedBillingSettings()

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.ts
@@ -278,9 +278,11 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
   const resolvedSubscription = await getSubscriptionForDeletedStripeSubscription(stripeSubscription)
 
   if (!resolvedSubscription) {
-    throw new Error(
-      `No local subscription found for deleted Stripe subscription ${stripeSubscriptionId}`
-    )
+    logger.warn('Deleted Stripe subscription has no local subscription row', {
+      eventId: event.id,
+      stripeSubscriptionId,
+    })
+    return
   }
 
   await syncSubscriptionBillingTierFromStripeSubscription(
@@ -288,8 +290,12 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
     stripeSubscription
   )
 
-  const hydratedSubscription =
-    (await getSubscriptionForDeletedStripeSubscription(stripeSubscription)) ?? resolvedSubscription
+  const hydratedSubscription = await getSubscriptionForDeletedStripeSubscription(stripeSubscription)
+  if (!hydratedSubscription) {
+    throw new Error(
+      `Local subscription disappeared while settling deleted Stripe subscription ${stripeSubscriptionId}`
+    )
+  }
 
   const subscriptionToSettle = {
     ...hydratedSubscription,

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.ts
@@ -5,7 +5,7 @@ import type Stripe from 'stripe'
 import { calculateSubscriptionOverage } from '@/lib/billing/core/billing'
 import {
   ensureDefaultUserSubscription,
-  getUniqueSubscriptionByStripeSubscriptionId,
+  getSubscriptionByStripeSubscriptionId,
 } from '@/lib/billing/core/subscription'
 import {
   decrementGrantedOnboardingAllowanceByCurrentPeriodUsage,
@@ -263,8 +263,7 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
   const stripeSubscription = event.data.object as Stripe.Subscription
   const stripeSubscriptionId = stripeSubscription.id
 
-  const resolvedSubscription =
-    await getUniqueSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
+  const resolvedSubscription = await getSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
 
   if (!resolvedSubscription) {
     logger.info('Deleted Stripe subscription has no local subscription row; skipping settlement', {
@@ -279,8 +278,7 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
     stripeSubscription
   )
 
-  const hydratedSubscription =
-    await getUniqueSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
+  const hydratedSubscription = await getSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
   if (!hydratedSubscription) {
     throw new Error(
       `Local subscription disappeared while settling deleted Stripe subscription ${stripeSubscriptionId}`

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.ts
@@ -304,12 +304,11 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
     const { billingEnabled } = await getResolvedBillingSettings()
 
     if (billingEnabled) {
-      await db.transaction(async (tx) => {
+      subscriptionForUsageLimits = await db.transaction(async (tx) => {
         const nextSubscription = await ensureDefaultUserSubscription(
           subscriptionToSettle.referenceId,
           tx
         )
-        subscriptionForUsageLimits = nextSubscription
 
         if (nextSubscription.tier?.isDefault && !nextSubscription.stripeSubscriptionId) {
           await resetUserDefaultUsageToOnboardingAllowanceBalance(
@@ -317,6 +316,8 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
             tx
           )
         }
+
+        return nextSubscription
       })
     }
   }

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.ts
@@ -267,11 +267,9 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
     await getUniqueSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
 
   if (!resolvedSubscription) {
-    logger.warn('Deleted Stripe subscription has no local subscription row', {
-      eventId: event.id,
-      stripeSubscriptionId,
-    })
-    return
+    throw new Error(
+      `No local subscription found for deleted Stripe subscription ${stripeSubscriptionId}`
+    )
   }
 
   await syncSubscriptionBillingTierFromStripeSubscription(

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.ts
@@ -312,8 +312,16 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
   const { billingEnabled } = await getResolvedBillingSettings()
   if (billingEnabled && subscriptionToSettle.referenceType === 'user') {
     await db.transaction(async (tx) => {
-      await ensureDefaultUserSubscription(subscriptionToSettle.referenceId, tx)
-      await resetUserDefaultUsageToOnboardingAllowanceBalance(subscriptionToSettle.referenceId, tx)
+      const nextSubscription = await ensureDefaultUserSubscription(
+        subscriptionToSettle.referenceId,
+        tx
+      )
+      if (nextSubscription.tier?.isDefault && !nextSubscription.stripeSubscriptionId) {
+        await resetUserDefaultUsageToOnboardingAllowanceBalance(
+          subscriptionToSettle.referenceId,
+          tx
+        )
+      }
     })
   }
 

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.ts
@@ -11,6 +11,7 @@ import {
   decrementGrantedOnboardingAllowanceByCurrentPeriodUsage,
   resetUserDefaultUsageToOnboardingAllowanceBalance,
 } from '@/lib/billing/core/usage'
+import { syncSubscriptionUsageLimits } from '@/lib/billing/organization'
 import { getResolvedBillingSettings } from '@/lib/billing/settings'
 import { requireStripeClient } from '@/lib/billing/stripe-client'
 import { type BillingTierRecord, isPaidBillingTier } from '@/lib/billing/tiers'
@@ -291,6 +292,7 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
     stripeSubscriptionId,
     status: 'canceled',
   }
+  let subscriptionForUsageLimits: TieredSubscriptionLifecycleRecord = subscriptionToSettle
 
   await handleSubscriptionDeleted(subscriptionToSettle)
 
@@ -304,21 +306,28 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
     })
     .where(eq(subscription.id, hydratedSubscription.id))
 
-  const { billingEnabled } = await getResolvedBillingSettings()
-  if (billingEnabled && subscriptionToSettle.referenceType === 'user') {
-    await db.transaction(async (tx) => {
-      const nextSubscription = await ensureDefaultUserSubscription(
-        subscriptionToSettle.referenceId,
-        tx
-      )
-      if (nextSubscription.tier?.isDefault && !nextSubscription.stripeSubscriptionId) {
-        await resetUserDefaultUsageToOnboardingAllowanceBalance(
+  if (subscriptionToSettle.referenceType === 'user') {
+    const { billingEnabled } = await getResolvedBillingSettings()
+
+    if (billingEnabled) {
+      await db.transaction(async (tx) => {
+        const nextSubscription = await ensureDefaultUserSubscription(
           subscriptionToSettle.referenceId,
           tx
         )
-      }
-    })
+        subscriptionForUsageLimits = nextSubscription
+
+        if (nextSubscription.tier?.isDefault && !nextSubscription.stripeSubscriptionId) {
+          await resetUserDefaultUsageToOnboardingAllowanceBalance(
+            subscriptionToSettle.referenceId,
+            tx
+          )
+        }
+      })
+    }
   }
+
+  await syncSubscriptionUsageLimits(subscriptionForUsageLimits)
 
   logger.info('Settled deleted Stripe subscription', {
     eventId: event.id,

--- a/apps/tradinggoose/lib/subscription/upgrade.ts
+++ b/apps/tradinggoose/lib/subscription/upgrade.ts
@@ -40,7 +40,7 @@ export function useSubscriptionUpgrade() {
         throw new Error('User not authenticated')
       }
 
-      let currentPersonalSubscriptionId: string | undefined
+      let currentPersonalStripeSubscriptionId: string | undefined
       let allSubscriptions: any[] = []
       try {
         const listResult = await client.subscription.list()
@@ -51,9 +51,10 @@ export function useSubscriptionUpgrade() {
               sub.status as (typeof ENTITLED_SUBSCRIPTION_STATUSES)[number]
             ) && sub.referenceId === userId
         )
-        currentPersonalSubscriptionId = activePersonalSubscription?.id
+        currentPersonalStripeSubscriptionId =
+          activePersonalSubscription?.stripeSubscriptionId || undefined
       } catch (_e) {
-        currentPersonalSubscriptionId = undefined
+        currentPersonalStripeSubscriptionId = undefined
       }
 
       let referenceId = userId
@@ -127,18 +128,19 @@ export function useSubscriptionUpgrade() {
           ...(targetTier.ownerType === 'organization' && { seats: initialSeats }),
         } as const
 
-        const finalParams = currentPersonalSubscriptionId
-          ? { ...upgradeParams, subscriptionId: currentPersonalSubscriptionId }
-          : upgradeParams
+        const finalParams =
+          targetTier.ownerType === 'user' && currentPersonalStripeSubscriptionId
+            ? { ...upgradeParams, subscriptionId: currentPersonalStripeSubscriptionId }
+            : upgradeParams
 
         logger.info(
-          currentPersonalSubscriptionId
+          targetTier.ownerType === 'user' && currentPersonalStripeSubscriptionId
             ? 'Upgrading existing subscription'
             : 'Creating new subscription',
           {
             billingTierId: targetTier.billingTierId,
             billingTier: targetTier.displayName,
-            subscriptionId: currentPersonalSubscriptionId,
+            stripeSubscriptionId: currentPersonalStripeSubscriptionId,
             usageScope: targetTier.usageScope,
             seatMode: targetTier.seatMode,
             referenceId,

--- a/packages/db/migrations/0036_fast_skullbuster.sql
+++ b/packages/db/migrations/0036_fast_skullbuster.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX "subscription_stripe_subscription_id_unique" ON "subscription" USING btree ("stripe_subscription_id");--> statement-breakpoint
+ALTER TABLE "copilot_review_items" DROP COLUMN "tool_calls";

--- a/packages/db/migrations/0036_fast_skullbuster.sql
+++ b/packages/db/migrations/0036_fast_skullbuster.sql
@@ -1,2 +1,2 @@
-CREATE INDEX "subscription_stripe_subscription_id_idx" ON "subscription" USING btree ("stripe_subscription_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "subscription_stripe_subscription_id_unique" ON "subscription" USING btree ("stripe_subscription_id");--> statement-breakpoint
 ALTER TABLE "copilot_review_items" DROP COLUMN "tool_calls";

--- a/packages/db/migrations/0036_fast_skullbuster.sql
+++ b/packages/db/migrations/0036_fast_skullbuster.sql
@@ -1,2 +1,2 @@
-CREATE UNIQUE INDEX "subscription_stripe_subscription_id_unique" ON "subscription" USING btree ("stripe_subscription_id");--> statement-breakpoint
+CREATE INDEX "subscription_stripe_subscription_id_idx" ON "subscription" USING btree ("stripe_subscription_id");--> statement-breakpoint
 ALTER TABLE "copilot_review_items" DROP COLUMN "tool_calls";

--- a/packages/db/migrations/meta/0036_snapshot.json
+++ b/packages/db/migrations/meta/0036_snapshot.json
@@ -1814,8 +1814,8 @@
           "method": "btree",
           "with": {}
         },
-        "subscription_stripe_subscription_id_idx": {
-          "name": "subscription_stripe_subscription_id_idx",
+        "subscription_stripe_subscription_id_unique": {
+          "name": "subscription_stripe_subscription_id_unique",
           "columns": [
             {
               "expression": "stripe_subscription_id",
@@ -1824,7 +1824,7 @@
               "nulls": "last"
             }
           ],
-          "isUnique": false,
+          "isUnique": true,
           "concurrently": false,
           "method": "btree",
           "with": {}

--- a/packages/db/migrations/meta/0036_snapshot.json
+++ b/packages/db/migrations/meta/0036_snapshot.json
@@ -1814,8 +1814,8 @@
           "method": "btree",
           "with": {}
         },
-        "subscription_stripe_subscription_id_unique": {
-          "name": "subscription_stripe_subscription_id_unique",
+        "subscription_stripe_subscription_id_idx": {
+          "name": "subscription_stripe_subscription_id_idx",
           "columns": [
             {
               "expression": "stripe_subscription_id",
@@ -1824,7 +1824,7 @@
               "nulls": "last"
             }
           ],
-          "isUnique": true,
+          "isUnique": false,
           "concurrently": false,
           "method": "btree",
           "with": {}

--- a/packages/db/migrations/meta/0036_snapshot.json
+++ b/packages/db/migrations/meta/0036_snapshot.json
@@ -1,0 +1,11581 @@
+{
+  "id": "36d68c52-849f-4828-91e1-ac10af16f3b0",
+  "prevId": "c4a41554-6cca-481b-a0c5-77fd08538b08",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credential": {
+      "name": "credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "credential_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env_key": {
+          "name": "env_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env_owner_user_id": {
+          "name": "env_owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_service_account_key": {
+          "name": "encrypted_service_account_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "credential_workspace_id_idx": {
+          "name": "credential_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credential_type_idx": {
+          "name": "credential_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credential_provider_id_idx": {
+          "name": "credential_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credential_account_id_idx": {
+          "name": "credential_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credential_env_owner_user_id_idx": {
+          "name": "credential_env_owner_user_id_idx",
+          "columns": [
+            {
+              "expression": "env_owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credential_workspace_account_unique": {
+          "name": "credential_workspace_account_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "account_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credential_workspace_env_unique": {
+          "name": "credential_workspace_env_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "type = 'env_workspace'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credential_workspace_personal_env_unique": {
+          "name": "credential_workspace_personal_env_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env_owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "type = 'env_personal'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credential_workspace_id_workspace_id_fk": {
+          "name": "credential_workspace_id_workspace_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_account_id_account_id_fk": {
+          "name": "credential_account_id_account_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_env_owner_user_id_user_id_fk": {
+          "name": "credential_env_owner_user_id_user_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "user",
+          "columnsFrom": [
+            "env_owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_created_by_user_id_fk": {
+          "name": "credential_created_by_user_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "credential_oauth_source_check": {
+          "name": "credential_oauth_source_check",
+          "value": "(type <> 'oauth') OR (account_id IS NOT NULL AND provider_id IS NOT NULL)"
+        },
+        "credential_workspace_env_source_check": {
+          "name": "credential_workspace_env_source_check",
+          "value": "(type <> 'env_workspace') OR (env_key IS NOT NULL AND env_owner_user_id IS NULL)"
+        },
+        "credential_personal_env_source_check": {
+          "name": "credential_personal_env_source_check",
+          "value": "(type <> 'env_personal') OR (env_key IS NOT NULL AND env_owner_user_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credential_member": {
+      "name": "credential_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "credential_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "credential_member_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "credential_member_user_id_idx": {
+          "name": "credential_member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credential_member_role_idx": {
+          "name": "credential_member_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credential_member_status_idx": {
+          "name": "credential_member_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credential_member_unique": {
+          "name": "credential_member_unique",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credential_member_credential_id_credential_id_fk": {
+          "name": "credential_member_credential_id_credential_id_fk",
+          "tableFrom": "credential_member",
+          "tableTo": "credential",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_member_user_id_user_id_fk": {
+          "name": "credential_member_user_id_user_id_fk",
+          "tableFrom": "credential_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_member_invited_by_user_id_fk": {
+          "name": "credential_member_invited_by_user_id_fk",
+          "tableFrom": "credential_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_token_idx": {
+          "name": "session_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_active_organization_id_organization_id_fk": {
+          "name": "session_active_organization_id_organization_id_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "preferred_locale": {
+          "name": "preferred_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "telemetry_enabled": {
+          "name": "telemetry_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_preferences": {
+          "name": "email_preferences",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "billing_usage_notifications_enabled": {
+          "name": "billing_usage_notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_user_id_user_id_fk": {
+          "name": "settings_user_id_user_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_user_id_unique": {
+          "name": "settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organization_id_idx": {
+          "name": "member_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_billing_ledger": {
+      "name": "organization_billing_ledger",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "total_manual_executions": {
+          "name": "total_manual_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_api_calls": {
+          "name": "total_api_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_webhook_triggers": {
+          "name": "total_webhook_triggers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_scheduled_executions": {
+          "name": "total_scheduled_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_chat_executions": {
+          "name": "total_chat_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens_used": {
+          "name": "total_tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "current_period_cost": {
+          "name": "current_period_cost",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "last_period_cost": {
+          "name": "last_period_cost",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "billed_overage_this_period": {
+          "name": "billed_overage_this_period",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_copilot_cost": {
+          "name": "total_copilot_cost",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "current_period_copilot_cost": {
+          "name": "current_period_copilot_cost",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "last_period_copilot_cost": {
+          "name": "last_period_copilot_cost",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_copilot_tokens": {
+          "name": "total_copilot_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_copilot_calls": {
+          "name": "total_copilot_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "billing_blocked": {
+          "name": "billing_blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_active": {
+          "name": "last_active",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_billing_ledger_organization_id_idx": {
+          "name": "organization_billing_ledger_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_billing_ledger_organization_id_organization_id_fk": {
+          "name": "organization_billing_ledger_organization_id_organization_id_fk",
+          "tableFrom": "organization_billing_ledger",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_member_billing_ledger": {
+      "name": "organization_member_billing_ledger",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_manual_executions": {
+          "name": "total_manual_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_api_calls": {
+          "name": "total_api_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_webhook_triggers": {
+          "name": "total_webhook_triggers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_scheduled_executions": {
+          "name": "total_scheduled_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_chat_executions": {
+          "name": "total_chat_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens_used": {
+          "name": "total_tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "current_period_cost": {
+          "name": "current_period_cost",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "last_period_cost": {
+          "name": "last_period_cost",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_copilot_cost": {
+          "name": "total_copilot_cost",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "current_period_copilot_cost": {
+          "name": "current_period_copilot_cost",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "last_period_copilot_cost": {
+          "name": "last_period_copilot_cost",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_copilot_tokens": {
+          "name": "total_copilot_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_copilot_calls": {
+          "name": "total_copilot_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_active": {
+          "name": "last_active",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_member_billing_ledger_organization_id_idx": {
+          "name": "organization_member_billing_ledger_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_member_billing_ledger_user_id_idx": {
+          "name": "organization_member_billing_ledger_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_member_billing_ledger_organization_id_organization_id_fk": {
+          "name": "organization_member_billing_ledger_organization_id_organization_id_fk",
+          "tableFrom": "organization_member_billing_ledger",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_member_billing_ledger_user_id_user_id_fk": {
+          "name": "organization_member_billing_ledger_user_id_user_id_fk",
+          "tableFrom": "organization_member_billing_ledger",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_member_billing_ledger_pkey": {
+          "name": "organization_member_billing_ledger_pkey",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sso_provider_provider_id_idx": {
+          "name": "sso_provider_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_domain_idx": {
+          "name": "sso_provider_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_user_id_idx": {
+          "name": "sso_provider_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_organization_id_idx": {
+          "name": "sso_provider_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organization_id_fk": {
+          "name": "sso_provider_organization_id_organization_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_tier_id": {
+          "name": "billing_tier_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_type": {
+          "name": "reference_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_start": {
+          "name": "trial_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "subscription_billing_tier_id_idx": {
+          "name": "subscription_billing_tier_id_idx",
+          "columns": [
+            {
+              "expression": "billing_tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscription_reference_status_idx": {
+          "name": "subscription_reference_status_idx",
+          "columns": [
+            {
+              "expression": "reference_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscription_stripe_subscription_id_unique": {
+          "name": "subscription_stripe_subscription_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_billing_tier_id_system_billing_tier_id_fk": {
+          "name": "subscription_billing_tier_id_system_billing_tier_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "system_billing_tier",
+          "columnsFrom": [
+            "billing_tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_rate_limits": {
+      "name": "user_rate_limits",
+      "schema": "",
+      "columns": {
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sync_api_requests": {
+          "name": "sync_api_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "async_api_requests": {
+          "name": "async_api_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "api_endpoint_requests": {
+          "name": "api_endpoint_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_request_at": {
+          "name": "last_request_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_rate_limited": {
+          "name": "is_rate_limited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rate_limit_reset_at": {
+          "name": "rate_limit_reset_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_stats": {
+      "name": "user_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_manual_executions": {
+          "name": "total_manual_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_api_calls": {
+          "name": "total_api_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_webhook_triggers": {
+          "name": "total_webhook_triggers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_scheduled_executions": {
+          "name": "total_scheduled_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_chat_executions": {
+          "name": "total_chat_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens_used": {
+          "name": "total_tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "granted_onboarding_allowance_usd": {
+          "name": "granted_onboarding_allowance_usd",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "custom_usage_limit": {
+          "name": "custom_usage_limit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_usage_limit_updated_at": {
+          "name": "custom_usage_limit_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "current_period_cost": {
+          "name": "current_period_cost",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "last_period_cost": {
+          "name": "last_period_cost",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "billed_overage_this_period": {
+          "name": "billed_overage_this_period",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_copilot_cost": {
+          "name": "total_copilot_cost",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "current_period_copilot_cost": {
+          "name": "current_period_copilot_cost",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "last_period_copilot_cost": {
+          "name": "last_period_copilot_cost",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_copilot_tokens": {
+          "name": "total_copilot_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_copilot_calls": {
+          "name": "total_copilot_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "storage_used_bytes": {
+          "name": "storage_used_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_active": {
+          "name": "last_active",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "billing_blocked": {
+          "name": "billing_blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_stats_user_id_user_id_fk": {
+          "name": "user_stats_user_id_user_id_fk",
+          "tableFrom": "user_stats",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_stats_user_id_unique": {
+          "name": "user_stats_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.copilot_review_items": {
+      "name": "copilot_review_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'message'"
+        },
+        "message_role": {
+          "name": "message_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_blocks": {
+          "name": "content_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "contexts": {
+          "name": "contexts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "file_attachments": {
+          "name": "file_attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "citations": {
+          "name": "citations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "copilot_review_items_session_id_idx": {
+          "name": "copilot_review_items_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "copilot_review_items_turn_id_idx": {
+          "name": "copilot_review_items_turn_id_idx",
+          "columns": [
+            {
+              "expression": "turn_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "copilot_review_items_kind_idx": {
+          "name": "copilot_review_items_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "copilot_review_items_session_sequence_unique": {
+          "name": "copilot_review_items_session_sequence_unique",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "copilot_review_items_session_item_unique": {
+          "name": "copilot_review_items_session_item_unique",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "copilot_review_items_session_id_copilot_review_sessions_id_fk": {
+          "name": "copilot_review_items_session_id_copilot_review_sessions_id_fk",
+          "tableFrom": "copilot_review_items",
+          "tableTo": "copilot_review_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "copilot_review_items_turn_id_copilot_review_turns_id_fk": {
+          "name": "copilot_review_items_turn_id_copilot_review_turns_id_fk",
+          "tableFrom": "copilot_review_items",
+          "tableTo": "copilot_review_turns",
+          "columnsFrom": [
+            "turn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.copilot_review_sessions": {
+      "name": "copilot_review_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_kind": {
+          "name": "entity_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_session_id": {
+          "name": "draft_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_yaml": {
+          "name": "preview_yaml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "copilot_review_sessions_user_id_idx": {
+          "name": "copilot_review_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "copilot_review_sessions_user_entity_idx": {
+          "name": "copilot_review_sessions_user_entity_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "copilot_review_sessions_workspace_entity_idx": {
+          "name": "copilot_review_sessions_workspace_entity_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "copilot_review_sessions_workspace_draft_idx": {
+          "name": "copilot_review_sessions_workspace_draft_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "draft_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "copilot_review_sessions_user_workspace_channel_idx": {
+          "name": "copilot_review_sessions_user_workspace_channel_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"workspace_id\", 'global')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"copilot_review_sessions\".\"channel_id\" IS NOT NULL AND \"copilot_review_sessions\".\"entity_kind\" = 'copilot'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "copilot_review_sessions_saved_entity_unique": {
+          "name": "copilot_review_sessions_saved_entity_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"copilot_review_sessions\".\"channel_id\" IS NULL AND \"copilot_review_sessions\".\"entity_kind\" <> 'workflow' AND \"copilot_review_sessions\".\"entity_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "copilot_review_sessions_draft_entity_unique": {
+          "name": "copilot_review_sessions_draft_entity_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "draft_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"copilot_review_sessions\".\"channel_id\" IS NULL AND \"copilot_review_sessions\".\"entity_kind\" <> 'workflow' AND \"copilot_review_sessions\".\"entity_id\" IS NULL AND \"copilot_review_sessions\".\"draft_session_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "copilot_review_sessions_created_at_idx": {
+          "name": "copilot_review_sessions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "copilot_review_sessions_updated_at_idx": {
+          "name": "copilot_review_sessions_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "copilot_review_sessions_user_id_user_id_fk": {
+          "name": "copilot_review_sessions_user_id_user_id_fk",
+          "tableFrom": "copilot_review_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.copilot_review_turns": {
+      "name": "copilot_review_turns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "user_message_item_id": {
+          "name": "user_message_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "copilot_review_turns_session_id_idx": {
+          "name": "copilot_review_turns_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "copilot_review_turns_session_status_idx": {
+          "name": "copilot_review_turns_session_status_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "copilot_review_turns_session_sequence_unique": {
+          "name": "copilot_review_turns_session_sequence_unique",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "copilot_review_turns_session_id_copilot_review_sessions_id_fk": {
+          "name": "copilot_review_turns_session_id_copilot_review_sessions_id_fk",
+          "tableFrom": "copilot_review_turns",
+          "tableTo": "copilot_review_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_usage_limit": {
+          "name": "org_usage_limit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_used_bytes": {
+          "name": "storage_used_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_active": {
+          "name": "last_active",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace": {
+      "name": "workspace",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_owner_type": {
+          "name": "billing_owner_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "billing_owner_user_id": {
+          "name": "billing_owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_owner_organization_id": {
+          "name": "billing_owner_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_personal_api_keys": {
+          "name": "allow_personal_api_keys",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_owner_id_user_id_fk": {
+          "name": "workspace_owner_id_user_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_billing_owner_user_id_user_id_fk": {
+          "name": "workspace_billing_owner_user_id_user_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "user",
+          "columnsFrom": [
+            "billing_owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workspace_billing_owner_organization_id_organization_id_fk": {
+          "name": "workspace_billing_owner_organization_id_organization_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "billing_owner_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspace_billing_owner_check": {
+          "name": "workspace_billing_owner_check",
+          "value": "(\n        \"workspace\".\"billing_owner_type\" = 'user'\n        AND \"workspace\".\"billing_owner_user_id\" IS NOT NULL\n        AND \"workspace\".\"billing_owner_organization_id\" IS NULL\n      ) OR (\n        \"workspace\".\"billing_owner_type\" = 'organization'\n        AND \"workspace\".\"billing_owner_user_id\" IS NULL\n        AND \"workspace\".\"billing_owner_organization_id\" IS NOT NULL\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.docs_embeddings": {
+      "name": "docs_embeddings",
+      "schema": "",
+      "columns": {
+        "chunk_id": {
+          "name": "chunk_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chunk_text": {
+          "name": "chunk_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_document": {
+          "name": "source_document",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_link": {
+          "name": "source_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_text": {
+          "name": "header_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_level": {
+          "name": "header_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text-embedding-3-small'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "chunk_text_tsv": {
+          "name": "chunk_text_tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', \"docs_embeddings\".\"chunk_text\")",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "docs_emb_source_document_idx": {
+          "name": "docs_emb_source_document_idx",
+          "columns": [
+            {
+              "expression": "source_document",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "docs_emb_header_level_idx": {
+          "name": "docs_emb_header_level_idx",
+          "columns": [
+            {
+              "expression": "header_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "docs_emb_source_header_idx": {
+          "name": "docs_emb_source_header_idx",
+          "columns": [
+            {
+              "expression": "source_document",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "header_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "docs_emb_model_idx": {
+          "name": "docs_emb_model_idx",
+          "columns": [
+            {
+              "expression": "embedding_model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "docs_emb_created_at_idx": {
+          "name": "docs_emb_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "docs_embedding_vector_hnsw_idx": {
+          "name": "docs_embedding_vector_hnsw_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": 16,
+            "ef_construction": 64
+          }
+        },
+        "docs_emb_metadata_gin_idx": {
+          "name": "docs_emb_metadata_gin_idx",
+          "columns": [
+            {
+              "expression": "metadata",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "docs_emb_chunk_text_fts_idx": {
+          "name": "docs_emb_chunk_text_fts_idx",
+          "columns": [
+            {
+              "expression": "chunk_text_tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "docs_embedding_not_null_check": {
+          "name": "docs_embedding_not_null_check",
+          "value": "\"embedding\" IS NOT NULL"
+        },
+        "docs_header_level_check": {
+          "name": "docs_header_level_check",
+          "value": "\"header_level\" >= 1 AND \"header_level\" <= 6"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.document": {
+      "name": "document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "knowledge_base_id": {
+          "name": "knowledge_base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_count": {
+          "name": "chunk_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "character_count": {
+          "name": "character_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processing_status": {
+          "name": "processing_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_completed_at": {
+          "name": "processing_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_error": {
+          "name": "processing_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag1": {
+          "name": "tag1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag2": {
+          "name": "tag2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag3": {
+          "name": "tag3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag4": {
+          "name": "tag4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag5": {
+          "name": "tag5",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag6": {
+          "name": "tag6",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag7": {
+          "name": "tag7",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doc_kb_id_idx": {
+          "name": "doc_kb_id_idx",
+          "columns": [
+            {
+              "expression": "knowledge_base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_filename_idx": {
+          "name": "doc_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_kb_uploaded_at_idx": {
+          "name": "doc_kb_uploaded_at_idx",
+          "columns": [
+            {
+              "expression": "knowledge_base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "uploaded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_processing_status_idx": {
+          "name": "doc_processing_status_idx",
+          "columns": [
+            {
+              "expression": "knowledge_base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_tag1_idx": {
+          "name": "doc_tag1_idx",
+          "columns": [
+            {
+              "expression": "tag1",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_tag2_idx": {
+          "name": "doc_tag2_idx",
+          "columns": [
+            {
+              "expression": "tag2",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_tag3_idx": {
+          "name": "doc_tag3_idx",
+          "columns": [
+            {
+              "expression": "tag3",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_tag4_idx": {
+          "name": "doc_tag4_idx",
+          "columns": [
+            {
+              "expression": "tag4",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_tag5_idx": {
+          "name": "doc_tag5_idx",
+          "columns": [
+            {
+              "expression": "tag5",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_tag6_idx": {
+          "name": "doc_tag6_idx",
+          "columns": [
+            {
+              "expression": "tag6",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_tag7_idx": {
+          "name": "doc_tag7_idx",
+          "columns": [
+            {
+              "expression": "tag7",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_knowledge_base_id_knowledge_base_id_fk": {
+          "name": "document_knowledge_base_id_knowledge_base_id_fk",
+          "tableFrom": "document",
+          "tableTo": "knowledge_base",
+          "columnsFrom": [
+            "knowledge_base_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.embedding": {
+      "name": "embedding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "knowledge_base_id": {
+          "name": "knowledge_base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_hash": {
+          "name": "chunk_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_length": {
+          "name": "content_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text-embedding-3-small'"
+        },
+        "start_offset": {
+          "name": "start_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_offset": {
+          "name": "end_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag1": {
+          "name": "tag1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag2": {
+          "name": "tag2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag3": {
+          "name": "tag3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag4": {
+          "name": "tag4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag5": {
+          "name": "tag5",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag6": {
+          "name": "tag6",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag7": {
+          "name": "tag7",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "content_tsv": {
+          "name": "content_tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', \"embedding\".\"content\")",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "emb_kb_id_idx": {
+          "name": "emb_kb_id_idx",
+          "columns": [
+            {
+              "expression": "knowledge_base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emb_doc_id_idx": {
+          "name": "emb_doc_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emb_doc_chunk_idx": {
+          "name": "emb_doc_chunk_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chunk_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emb_kb_model_idx": {
+          "name": "emb_kb_model_idx",
+          "columns": [
+            {
+              "expression": "knowledge_base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "embedding_model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emb_kb_enabled_idx": {
+          "name": "emb_kb_enabled_idx",
+          "columns": [
+            {
+              "expression": "knowledge_base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emb_doc_enabled_idx": {
+          "name": "emb_doc_enabled_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embedding_vector_hnsw_idx": {
+          "name": "embedding_vector_hnsw_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": 16,
+            "ef_construction": 64
+          }
+        },
+        "emb_tag1_idx": {
+          "name": "emb_tag1_idx",
+          "columns": [
+            {
+              "expression": "tag1",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emb_tag2_idx": {
+          "name": "emb_tag2_idx",
+          "columns": [
+            {
+              "expression": "tag2",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emb_tag3_idx": {
+          "name": "emb_tag3_idx",
+          "columns": [
+            {
+              "expression": "tag3",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emb_tag4_idx": {
+          "name": "emb_tag4_idx",
+          "columns": [
+            {
+              "expression": "tag4",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emb_tag5_idx": {
+          "name": "emb_tag5_idx",
+          "columns": [
+            {
+              "expression": "tag5",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emb_tag6_idx": {
+          "name": "emb_tag6_idx",
+          "columns": [
+            {
+              "expression": "tag6",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emb_tag7_idx": {
+          "name": "emb_tag7_idx",
+          "columns": [
+            {
+              "expression": "tag7",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emb_content_fts_idx": {
+          "name": "emb_content_fts_idx",
+          "columns": [
+            {
+              "expression": "content_tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "embedding_knowledge_base_id_knowledge_base_id_fk": {
+          "name": "embedding_knowledge_base_id_knowledge_base_id_fk",
+          "tableFrom": "embedding",
+          "tableTo": "knowledge_base",
+          "columnsFrom": [
+            "knowledge_base_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "embedding_document_id_document_id_fk": {
+          "name": "embedding_document_id_document_id_fk",
+          "tableFrom": "embedding",
+          "tableTo": "document",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "embedding_not_null_check": {
+          "name": "embedding_not_null_check",
+          "value": "\"embedding\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.knowledge_base": {
+      "name": "knowledge_base",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text-embedding-3-small'"
+        },
+        "embedding_dimension": {
+          "name": "embedding_dimension",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1536
+        },
+        "chunking_config": {
+          "name": "chunking_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"maxSize\": 1024, \"minSize\": 1, \"overlap\": 200}'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kb_user_id_idx": {
+          "name": "kb_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kb_workspace_id_idx": {
+          "name": "kb_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kb_user_workspace_idx": {
+          "name": "kb_user_workspace_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kb_deleted_at_idx": {
+          "name": "kb_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "knowledge_base_user_id_user_id_fk": {
+          "name": "knowledge_base_user_id_user_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_base_workspace_id_workspace_id_fk": {
+          "name": "knowledge_base_workspace_id_workspace_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_base_tag_definitions": {
+      "name": "knowledge_base_tag_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "knowledge_base_id": {
+          "name": "knowledge_base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_slot": {
+          "name": "tag_slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kb_tag_definitions_kb_slot_idx": {
+          "name": "kb_tag_definitions_kb_slot_idx",
+          "columns": [
+            {
+              "expression": "knowledge_base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kb_tag_definitions_kb_display_name_idx": {
+          "name": "kb_tag_definitions_kb_display_name_idx",
+          "columns": [
+            {
+              "expression": "knowledge_base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kb_tag_definitions_kb_id_idx": {
+          "name": "kb_tag_definitions_kb_id_idx",
+          "columns": [
+            {
+              "expression": "knowledge_base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "knowledge_base_tag_definitions_knowledge_base_id_knowledge_base_id_fk": {
+          "name": "knowledge_base_tag_definitions_knowledge_base_id_knowledge_base_id_fk",
+          "tableFrom": "knowledge_base_tag_definitions",
+          "tableTo": "knowledge_base",
+          "columnsFrom": [
+            "knowledge_base_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_admin": {
+      "name": "system_admin",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "system_admin_user_id_unique": {
+          "name": "system_admin_user_id_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "system_admin_user_id_user_id_fk": {
+          "name": "system_admin_user_id_user_id_fk",
+          "tableFrom": "system_admin",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_billing_settings": {
+      "name": "system_billing_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "onboarding_allowance_usd": {
+          "name": "onboarding_allowance_usd",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "overage_threshold_dollars": {
+          "name": "overage_threshold_dollars",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'50'"
+        },
+        "workflow_execution_charge_usd": {
+          "name": "workflow_execution_charge_usd",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "function_execution_charge_usd": {
+          "name": "function_execution_charge_usd",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "usage_warning_threshold_percent": {
+          "name": "usage_warning_threshold_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 80
+        },
+        "free_tier_upgrade_threshold_percent": {
+          "name": "free_tier_upgrade_threshold_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 90
+        },
+        "enterprise_contact_url": {
+          "name": "enterprise_contact_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "system_billing_settings_updated_by_user_id_idx": {
+          "name": "system_billing_settings_updated_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "updated_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "system_billing_settings_updated_by_user_id_user_id_fk": {
+          "name": "system_billing_settings_updated_by_user_id_user_id_fk",
+          "tableFrom": "system_billing_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "system_billing_settings_usage_warning_threshold_check": {
+          "name": "system_billing_settings_usage_warning_threshold_check",
+          "value": "\"system_billing_settings\".\"usage_warning_threshold_percent\" between 1 and 100"
+        },
+        "system_billing_settings_onboarding_allowance_check": {
+          "name": "system_billing_settings_onboarding_allowance_check",
+          "value": "\"system_billing_settings\".\"onboarding_allowance_usd\" >= 0"
+        },
+        "system_billing_settings_workflow_execution_charge_check": {
+          "name": "system_billing_settings_workflow_execution_charge_check",
+          "value": "\"system_billing_settings\".\"workflow_execution_charge_usd\" >= 0"
+        },
+        "system_billing_settings_function_execution_charge_check": {
+          "name": "system_billing_settings_function_execution_charge_check",
+          "value": "\"system_billing_settings\".\"function_execution_charge_usd\" >= 0"
+        },
+        "system_billing_settings_free_tier_upgrade_threshold_check": {
+          "name": "system_billing_settings_free_tier_upgrade_threshold_check",
+          "value": "\"system_billing_settings\".\"free_tier_upgrade_threshold_percent\" between 1 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.system_billing_tier": {
+      "name": "system_billing_tier",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_scope": {
+          "name": "usage_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_mode": {
+          "name": "seat_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "monthly_price_usd": {
+          "name": "monthly_price_usd",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yearly_price_usd": {
+          "name": "yearly_price_usd",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "included_usage_limit_usd": {
+          "name": "included_usage_limit_usd",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_limit_gb": {
+          "name": "storage_limit_gb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "concurrency_limit": {
+          "name": "concurrency_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seat_count": {
+          "name": "seat_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seat_maximum": {
+          "name": "seat_maximum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_monthly_price_id": {
+          "name": "stripe_monthly_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_yearly_price_id": {
+          "name": "stripe_yearly_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_rate_limit_per_minute": {
+          "name": "sync_rate_limit_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "async_rate_limit_per_minute": {
+          "name": "async_rate_limit_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_endpoint_rate_limit_per_minute": {
+          "name": "api_endpoint_rate_limit_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_pending_age_seconds": {
+          "name": "max_pending_age_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_pending_count": {
+          "name": "max_pending_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_edit_usage_limit": {
+          "name": "can_edit_usage_limit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "can_configure_sso": {
+          "name": "can_configure_sso",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "log_retention_days": {
+          "name": "log_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_execution_multiplier": {
+          "name": "workflow_execution_multiplier",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "workflow_model_cost_multiplier": {
+          "name": "workflow_model_cost_multiplier",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "function_execution_multiplier": {
+          "name": "function_execution_multiplier",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "copilot_cost_multiplier": {
+          "name": "copilot_cost_multiplier",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "pricing_features": {
+          "name": "pricing_features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "system_billing_tier_status_idx": {
+          "name": "system_billing_tier_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "system_billing_tier_display_order_idx": {
+          "name": "system_billing_tier_display_order_idx",
+          "columns": [
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "system_billing_tier_updated_by_user_id_idx": {
+          "name": "system_billing_tier_updated_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "updated_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "system_billing_tier_updated_by_user_id_user_id_fk": {
+          "name": "system_billing_tier_updated_by_user_id_user_id_fk",
+          "tableFrom": "system_billing_tier",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "system_billing_tier_status_check": {
+          "name": "system_billing_tier_status_check",
+          "value": "\"system_billing_tier\".\"status\" in ('active', 'draft', 'archived')"
+        },
+        "system_billing_tier_owner_type_check": {
+          "name": "system_billing_tier_owner_type_check",
+          "value": "\"system_billing_tier\".\"owner_type\" in ('user', 'organization')"
+        },
+        "system_billing_tier_usage_scope_check": {
+          "name": "system_billing_tier_usage_scope_check",
+          "value": "\"system_billing_tier\".\"usage_scope\" in ('individual', 'pooled')"
+        },
+        "system_billing_tier_seat_mode_check": {
+          "name": "system_billing_tier_seat_mode_check",
+          "value": "\"system_billing_tier\".\"seat_mode\" in ('fixed', 'adjustable')"
+        },
+        "system_billing_tier_seat_count_check": {
+          "name": "system_billing_tier_seat_count_check",
+          "value": "\"system_billing_tier\".\"seat_count\" is null or \"system_billing_tier\".\"seat_count\" >= 1"
+        },
+        "system_billing_tier_sync_rate_limit_check": {
+          "name": "system_billing_tier_sync_rate_limit_check",
+          "value": "\"system_billing_tier\".\"sync_rate_limit_per_minute\" is null or \"system_billing_tier\".\"sync_rate_limit_per_minute\" >= 0"
+        },
+        "system_billing_tier_async_rate_limit_check": {
+          "name": "system_billing_tier_async_rate_limit_check",
+          "value": "\"system_billing_tier\".\"async_rate_limit_per_minute\" is null or \"system_billing_tier\".\"async_rate_limit_per_minute\" >= 0"
+        },
+        "system_billing_tier_api_endpoint_rate_limit_check": {
+          "name": "system_billing_tier_api_endpoint_rate_limit_check",
+          "value": "\"system_billing_tier\".\"api_endpoint_rate_limit_per_minute\" is null or \"system_billing_tier\".\"api_endpoint_rate_limit_per_minute\" >= 0"
+        },
+        "system_billing_tier_max_pending_age_check": {
+          "name": "system_billing_tier_max_pending_age_check",
+          "value": "\"system_billing_tier\".\"max_pending_age_seconds\" is null or \"system_billing_tier\".\"max_pending_age_seconds\" >= 0"
+        },
+        "system_billing_tier_max_pending_count_check": {
+          "name": "system_billing_tier_max_pending_count_check",
+          "value": "\"system_billing_tier\".\"max_pending_count\" is null or \"system_billing_tier\".\"max_pending_count\" >= 0"
+        },
+        "system_billing_tier_log_retention_days_check": {
+          "name": "system_billing_tier_log_retention_days_check",
+          "value": "\"system_billing_tier\".\"log_retention_days\" is null or \"system_billing_tier\".\"log_retention_days\" >= 0"
+        },
+        "system_billing_tier_workflow_execution_multiplier_check": {
+          "name": "system_billing_tier_workflow_execution_multiplier_check",
+          "value": "\"system_billing_tier\".\"workflow_execution_multiplier\" >= 0"
+        },
+        "system_billing_tier_workflow_model_cost_multiplier_check": {
+          "name": "system_billing_tier_workflow_model_cost_multiplier_check",
+          "value": "\"system_billing_tier\".\"workflow_model_cost_multiplier\" >= 0"
+        },
+        "system_billing_tier_function_execution_multiplier_check": {
+          "name": "system_billing_tier_function_execution_multiplier_check",
+          "value": "\"system_billing_tier\".\"function_execution_multiplier\" >= 0"
+        },
+        "system_billing_tier_copilot_cost_multiplier_check": {
+          "name": "system_billing_tier_copilot_cost_multiplier_check",
+          "value": "\"system_billing_tier\".\"copilot_cost_multiplier\" >= 0"
+        },
+        "system_billing_tier_seat_range_check": {
+          "name": "system_billing_tier_seat_range_check",
+          "value": "\"system_billing_tier\".\"seat_maximum\" is null or \"system_billing_tier\".\"seat_count\" is null or \"system_billing_tier\".\"seat_maximum\" >= \"system_billing_tier\".\"seat_count\""
+        },
+        "system_billing_tier_user_owner_shape_check": {
+          "name": "system_billing_tier_user_owner_shape_check",
+          "value": "\"system_billing_tier\".\"owner_type\" = 'organization' or (\"system_billing_tier\".\"usage_scope\" = 'individual' and \"system_billing_tier\".\"seat_mode\" = 'fixed' and \"system_billing_tier\".\"seat_count\" is null and \"system_billing_tier\".\"seat_maximum\" is null)"
+        },
+        "system_billing_tier_org_seat_count_check": {
+          "name": "system_billing_tier_org_seat_count_check",
+          "value": "\"system_billing_tier\".\"owner_type\" = 'user' or \"system_billing_tier\".\"seat_count\" is not null"
+        },
+        "system_billing_tier_fixed_seat_maximum_check": {
+          "name": "system_billing_tier_fixed_seat_maximum_check",
+          "value": "\"system_billing_tier\".\"seat_mode\" = 'adjustable' or \"system_billing_tier\".\"seat_maximum\" is null"
+        },
+        "system_billing_tier_sso_owner_type_check": {
+          "name": "system_billing_tier_sso_owner_type_check",
+          "value": "\"system_billing_tier\".\"owner_type\" = 'organization' or \"system_billing_tier\".\"can_configure_sso\" = false"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.system_integration_definition": {
+      "name": "system_integration_definition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "system_integration_definition_parent_id_idx": {
+          "name": "system_integration_definition_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "system_integration_definition_parent_id_system_integration_definition_id_fk": {
+          "name": "system_integration_definition_parent_id_system_integration_definition_id_fk",
+          "tableFrom": "system_integration_definition",
+          "tableTo": "system_integration_definition",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "system_integration_definition_parent_check": {
+          "name": "system_integration_definition_parent_check",
+          "value": "\"system_integration_definition\".\"parent_id\" is null or \"system_integration_definition\".\"parent_id\" <> \"system_integration_definition\".\"id\""
+        },
+        "system_integration_definition_availability_check": {
+          "name": "system_integration_definition_availability_check",
+          "value": "(\"system_integration_definition\".\"parent_id\" is null and \"system_integration_definition\".\"is_enabled\" is null) or (\"system_integration_definition\".\"parent_id\" is not null and \"system_integration_definition\".\"is_enabled\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.system_integration_secret": {
+      "name": "system_integration_secret",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "system_integration_secret_definition_id_idx": {
+          "name": "system_integration_secret_definition_id_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "system_integration_secret_definition_key_unique": {
+          "name": "system_integration_secret_definition_key_unique",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "system_integration_secret_definition_id_system_integration_definition_id_fk": {
+          "name": "system_integration_secret_definition_id_system_integration_definition_id_fk",
+          "tableFrom": "system_integration_secret",
+          "tableTo": "system_integration_definition",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_service_values": {
+      "name": "system_service_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "system_service_value_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "system_service_values_service_idx": {
+          "name": "system_service_values_service_idx",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "system_service_values_service_kind_idx": {
+          "name": "system_service_values_service_kind_idx",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "system_service_values_service_kind_key_unique": {
+          "name": "system_service_values_service_kind_key_unique",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "registration_mode": {
+          "name": "registration_mode",
+          "type": "registration_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "billing_enabled": {
+          "name": "billing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trigger_dev_enabled": {
+          "name": "trigger_dev_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allow_promotion_codes": {
+          "name": "allow_promotion_codes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_domain": {
+          "name": "email_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tradinggoose.ai'"
+        },
+        "from_email_address": {
+          "name": "from_email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waitlist": {
+      "name": "waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "waitlist_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_by_user_id": {
+          "name": "rejected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_up_at": {
+          "name": "signed_up_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_locale": {
+          "name": "preferred_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "waitlist_email_idx": {
+          "name": "waitlist_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_status_idx": {
+          "name": "waitlist_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_user_id_idx": {
+          "name": "waitlist_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "waitlist_approved_by_user_id_user_id_fk": {
+          "name": "waitlist_approved_by_user_id_user_id_fk",
+          "tableFrom": "waitlist",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "waitlist_rejected_by_user_id_user_id_fk": {
+          "name": "waitlist_rejected_by_user_id_user_id_fk",
+          "tableFrom": "waitlist",
+          "tableTo": "user",
+          "columnsFrom": [
+            "rejected_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "waitlist_user_id_user_id_fk": {
+          "name": "waitlist_user_id_user_id_fk",
+          "tableFrom": "waitlist",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "waitlist_email_unique": {
+          "name": "waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat": {
+      "name": "chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_block_id": {
+          "name": "trigger_block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_version_id": {
+          "name": "deployment_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "customizations": {
+          "name": "customizations",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_emails": {
+          "name": "allowed_emails",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'"
+        },
+        "output_configs": {
+          "name": "output_configs",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "identifier_idx": {
+          "name": "identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_workflow_trigger_unique": {
+          "name": "chat_workflow_trigger_unique",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_deployment_version_idx": {
+          "name": "chat_deployment_version_idx",
+          "columns": [
+            {
+              "expression": "deployment_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_workflow_id_workflow_id_fk": {
+          "name": "chat_workflow_id_workflow_id_fk",
+          "tableFrom": "chat",
+          "tableTo": "workflow",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_deployment_version_id_workflow_deployment_version_id_fk": {
+          "name": "chat_deployment_version_id_workflow_deployment_version_id_fk",
+          "tableFrom": "chat",
+          "tableTo": "workflow_deployment_version",
+          "columnsFrom": [
+            "deployment_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "chat_user_id_user_id_fk": {
+          "name": "chat_user_id_user_id_fk",
+          "tableFrom": "chat",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idempotency_key": {
+      "name": "idempotency_key",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "result": {
+          "name": "result",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idempotency_key_namespace_unique": {
+          "name": "idempotency_key_namespace_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idempotency_key_created_at_idx": {
+          "name": "idempotency_key_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idempotency_key_namespace_idx": {
+          "name": "idempotency_key_namespace_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.marketplace": {
+      "name": "marketplace",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "marketplace_workflow_id_workflow_id_fk": {
+          "name": "marketplace_workflow_id_workflow_id_fk",
+          "tableFrom": "marketplace",
+          "tableTo": "workflow",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "marketplace_author_id_user_id_fk": {
+          "name": "marketplace_author_id_user_id_fk",
+          "tableFrom": "marketplace",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory": {
+      "name": "memory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "memory_key_idx": {
+          "name": "memory_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_workflow_idx": {
+          "name": "memory_workflow_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_workflow_key_idx": {
+          "name": "memory_workflow_key_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_workflow_id_workflow_id_fk": {
+          "name": "memory_workflow_id_workflow_id_fk",
+          "tableFrom": "memory",
+          "tableTo": "workflow",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orderHistoryTable": {
+      "name": "orderHistoryTable",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "submission_source": {
+          "name": "submission_source",
+          "type": "order_submission_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_identity": {
+          "name": "listing_identity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_order": {
+          "name": "normalized_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_history_provider_idx": {
+          "name": "order_history_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_history_workspace_idx": {
+          "name": "order_history_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_history_log_idx": {
+          "name": "order_history_log_idx",
+          "columns": [
+            {
+              "expression": "log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_history_recorded_at_idx": {
+          "name": "order_history_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_history_workspace_recorded_idx": {
+          "name": "order_history_workspace_recorded_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "orderHistoryTable_workspace_id_workspace_id_fk": {
+          "name": "orderHistoryTable_workspace_id_workspace_id_fk",
+          "tableFrom": "orderHistoryTable",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "orderHistoryTable_log_id_workflow_execution_logs_id_fk": {
+          "name": "orderHistoryTable_log_id_workflow_execution_logs_id_fk",
+          "tableFrom": "orderHistoryTable",
+          "tableTo": "workflow_execution_logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_execution": {
+      "name": "pending_execution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "billing_scope_id": {
+          "name": "billing_scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_scope_type": {
+          "name": "billing_scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_type": {
+          "name": "execution_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pending_execution_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_execution_billing_scope_idx": {
+          "name": "pending_execution_billing_scope_idx",
+          "columns": [
+            {
+              "expression": "billing_scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_execution_workflow_idx": {
+          "name": "pending_execution_workflow_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_execution_ordering_key_idx": {
+          "name": "pending_execution_ordering_key_idx",
+          "columns": [
+            {
+              "expression": "billing_scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordering_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_execution_source_idx": {
+          "name": "pending_execution_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_execution_status_idx": {
+          "name": "pending_execution_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_execution_user_id_user_id_fk": {
+          "name": "pending_execution_user_id_user_id_fk",
+          "tableFrom": "pending_execution",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_execution_workflow_id_workflow_id_fk": {
+          "name": "pending_execution_workflow_id_workflow_id_fk",
+          "tableFrom": "pending_execution",
+          "tableTo": "workflow",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_execution_workspace_id_workspace_id_fk": {
+          "name": "pending_execution_workspace_id_workspace_id_fk",
+          "tableFrom": "pending_execution",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template_stars": {
+      "name": "template_stars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starred_at": {
+          "name": "starred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_stars_user_id_idx": {
+          "name": "template_stars_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "template_stars_template_id_idx": {
+          "name": "template_stars_template_id_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "template_stars_user_template_idx": {
+          "name": "template_stars_user_template_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "template_stars_template_user_idx": {
+          "name": "template_stars_template_user_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "template_stars_starred_at_idx": {
+          "name": "template_stars_starred_at_idx",
+          "columns": [
+            {
+              "expression": "starred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "template_stars_template_starred_at_idx": {
+          "name": "template_stars_template_starred_at_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "template_stars_user_template_unique": {
+          "name": "template_stars_user_template_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "template_stars_user_id_user_id_fk": {
+          "name": "template_stars_user_id_user_id_fk",
+          "tableFrom": "template_stars",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "template_stars_template_id_templates_id_fk": {
+          "name": "template_stars_template_id_templates_id_fk",
+          "tableFrom": "template_stars",
+          "tableTo": "templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stars": {
+          "name": "stars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3972F6'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'FileText'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "templates_workflow_id_idx": {
+          "name": "templates_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "templates_user_id_idx": {
+          "name": "templates_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "templates_category_idx": {
+          "name": "templates_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "templates_views_idx": {
+          "name": "templates_views_idx",
+          "columns": [
+            {
+              "expression": "views",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "templates_stars_idx": {
+          "name": "templates_stars_idx",
+          "columns": [
+            {
+              "expression": "stars",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "templates_category_views_idx": {
+          "name": "templates_category_views_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "views",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "templates_category_stars_idx": {
+          "name": "templates_category_stars_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stars",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "templates_user_category_idx": {
+          "name": "templates_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "templates_created_at_idx": {
+          "name": "templates_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "templates_updated_at_idx": {
+          "name": "templates_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templates_workflow_id_workflow_id_fk": {
+          "name": "templates_workflow_id_workflow_id_fk",
+          "tableFrom": "templates",
+          "tableTo": "workflow",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "templates_user_id_user_id_fk": {
+          "name": "templates_user_id_user_id_fk",
+          "tableFrom": "templates",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook": {
+      "name": "webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "path_idx": {
+          "name": "path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_workflow_id_workflow_id_fk": {
+          "name": "webhook_workflow_id_workflow_id_fk",
+          "tableFrom": "webhook",
+          "tableTo": "workflow",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_block_id_workflow_blocks_id_fk": {
+          "name": "webhook_block_id_workflow_blocks_id_fk",
+          "tableFrom": "webhook",
+          "tableTo": "workflow_blocks",
+          "columnsFrom": [
+            "block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow": {
+      "name": "workflow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3972F6'"
+        },
+        "last_synced": {
+          "name": "last_synced",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deployed": {
+          "name": "is_deployed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deployed_state": {
+          "name": "deployed_state",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployed_at": {
+          "name": "deployed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_api_key_id": {
+          "name": "pinned_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collaborators": {
+          "name": "collaborators",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "marketplace_data": {
+          "name": "marketplace_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_user_id_idx": {
+          "name": "workflow_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_workspace_id_idx": {
+          "name": "workflow_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_user_workspace_idx": {
+          "name": "workflow_user_workspace_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_user_id_user_id_fk": {
+          "name": "workflow_user_id_user_id_fk",
+          "tableFrom": "workflow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_workspace_id_workspace_id_fk": {
+          "name": "workflow_workspace_id_workspace_id_fk",
+          "tableFrom": "workflow",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_folder_id_workflow_folder_id_fk": {
+          "name": "workflow_folder_id_workflow_folder_id_fk",
+          "tableFrom": "workflow",
+          "tableTo": "workflow_folder",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workflow_pinned_api_key_id_api_key_id_fk": {
+          "name": "workflow_pinned_api_key_id_api_key_id_fk",
+          "tableFrom": "workflow",
+          "tableTo": "api_key",
+          "columnsFrom": [
+            "pinned_api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_blocks": {
+      "name": "workflow_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_x": {
+          "name": "position_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_y": {
+          "name": "position_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "horizontal_handles": {
+          "name": "horizontal_handles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_wide": {
+          "name": "is_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "advanced_mode": {
+          "name": "advanced_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trigger_mode": {
+          "name": "trigger_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "sub_blocks": {
+          "name": "sub_blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "outputs": {
+          "name": "outputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_blocks_workflow_id_idx": {
+          "name": "workflow_blocks_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_blocks_workflow_type_idx": {
+          "name": "workflow_blocks_workflow_type_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_blocks_workflow_id_workflow_id_fk": {
+          "name": "workflow_blocks_workflow_id_workflow_id_fk",
+          "tableFrom": "workflow_blocks",
+          "tableTo": "workflow",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_deployment_version": {
+      "name": "workflow_deployment_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_deployment_version_workflow_id_idx": {
+          "name": "workflow_deployment_version_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_deployment_version_workflow_version_unique": {
+          "name": "workflow_deployment_version_workflow_version_unique",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_deployment_version_workflow_active_idx": {
+          "name": "workflow_deployment_version_workflow_active_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_deployment_version_created_at_idx": {
+          "name": "workflow_deployment_version_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_deployment_version_workflow_id_workflow_id_fk": {
+          "name": "workflow_deployment_version_workflow_id_workflow_id_fk",
+          "tableFrom": "workflow_deployment_version",
+          "tableTo": "workflow",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_edges": {
+      "name": "workflow_edges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_block_id": {
+          "name": "source_block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_block_id": {
+          "name": "target_block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_handle": {
+          "name": "source_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_handle": {
+          "name": "target_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_edges_workflow_id_idx": {
+          "name": "workflow_edges_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_edges_workflow_source_idx": {
+          "name": "workflow_edges_workflow_source_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_edges_workflow_target_idx": {
+          "name": "workflow_edges_workflow_target_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_edges_workflow_id_workflow_id_fk": {
+          "name": "workflow_edges_workflow_id_workflow_id_fk",
+          "tableFrom": "workflow_edges",
+          "tableTo": "workflow",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_edges_source_block_id_workflow_blocks_id_fk": {
+          "name": "workflow_edges_source_block_id_workflow_blocks_id_fk",
+          "tableFrom": "workflow_edges",
+          "tableTo": "workflow_blocks",
+          "columnsFrom": [
+            "source_block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_edges_target_block_id_workflow_blocks_id_fk": {
+          "name": "workflow_edges_target_block_id_workflow_blocks_id_fk",
+          "tableFrom": "workflow_edges",
+          "tableTo": "workflow_blocks",
+          "columnsFrom": [
+            "target_block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_execution_logs": {
+      "name": "workflow_execution_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_snapshot_id": {
+          "name": "state_snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_summary": {
+          "name": "workflow_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_ms": {
+          "name": "total_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_data": {
+          "name": "execution_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "cost": {
+          "name": "cost",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_execution_logs_workflow_id_idx": {
+          "name": "workflow_execution_logs_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_execution_logs_workspace_id_idx": {
+          "name": "workflow_execution_logs_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_execution_logs_execution_id_idx": {
+          "name": "workflow_execution_logs_execution_id_idx",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_execution_logs_state_snapshot_id_idx": {
+          "name": "workflow_execution_logs_state_snapshot_id_idx",
+          "columns": [
+            {
+              "expression": "state_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_execution_logs_trigger_idx": {
+          "name": "workflow_execution_logs_trigger_idx",
+          "columns": [
+            {
+              "expression": "trigger",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_execution_logs_level_idx": {
+          "name": "workflow_execution_logs_level_idx",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_execution_logs_started_at_idx": {
+          "name": "workflow_execution_logs_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_execution_logs_execution_id_unique": {
+          "name": "workflow_execution_logs_execution_id_unique",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_execution_logs_workflow_started_at_idx": {
+          "name": "workflow_execution_logs_workflow_started_at_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_execution_logs_workspace_started_at_idx": {
+          "name": "workflow_execution_logs_workspace_started_at_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_execution_logs_workflow_id_workflow_id_fk": {
+          "name": "workflow_execution_logs_workflow_id_workflow_id_fk",
+          "tableFrom": "workflow_execution_logs",
+          "tableTo": "workflow",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workflow_execution_logs_workspace_id_workspace_id_fk": {
+          "name": "workflow_execution_logs_workspace_id_workspace_id_fk",
+          "tableFrom": "workflow_execution_logs",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_execution_logs_state_snapshot_id_workflow_execution_snapshots_id_fk": {
+          "name": "workflow_execution_logs_state_snapshot_id_workflow_execution_snapshots_id_fk",
+          "tableFrom": "workflow_execution_logs",
+          "tableTo": "workflow_execution_snapshots",
+          "columnsFrom": [
+            "state_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_execution_snapshots": {
+      "name": "workflow_execution_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_hash": {
+          "name": "state_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_data": {
+          "name": "state_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_snapshots_workflow_id_idx": {
+          "name": "workflow_snapshots_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_snapshots_hash_idx": {
+          "name": "workflow_snapshots_hash_idx",
+          "columns": [
+            {
+              "expression": "state_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_snapshots_workspace_id_idx": {
+          "name": "workflow_snapshots_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_snapshots_workflow_hash_idx": {
+          "name": "workflow_snapshots_workflow_hash_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_snapshots_created_at_idx": {
+          "name": "workflow_snapshots_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_execution_snapshots_workflow_id_workflow_id_fk": {
+          "name": "workflow_execution_snapshots_workflow_id_workflow_id_fk",
+          "tableFrom": "workflow_execution_snapshots",
+          "tableTo": "workflow",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workflow_execution_snapshots_workspace_id_workspace_id_fk": {
+          "name": "workflow_execution_snapshots_workspace_id_workspace_id_fk",
+          "tableFrom": "workflow_execution_snapshots",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_folder": {
+      "name": "workflow_folder",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#6B7280'"
+        },
+        "is_expanded": {
+          "name": "is_expanded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_folder_user_idx": {
+          "name": "workflow_folder_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_folder_workspace_parent_idx": {
+          "name": "workflow_folder_workspace_parent_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_folder_parent_sort_idx": {
+          "name": "workflow_folder_parent_sort_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_folder_user_id_user_id_fk": {
+          "name": "workflow_folder_user_id_user_id_fk",
+          "tableFrom": "workflow_folder",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_folder_workspace_id_workspace_id_fk": {
+          "name": "workflow_folder_workspace_id_workspace_id_fk",
+          "tableFrom": "workflow_folder",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_log_webhook": {
+      "name": "workflow_log_webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "include_final_output": {
+          "name": "include_final_output",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_trace_spans": {
+          "name": "include_trace_spans",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_rate_limits": {
+          "name": "include_rate_limits",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "include_usage_data": {
+          "name": "include_usage_data",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "level_filter": {
+          "name": "level_filter",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['info', 'error']::text[]"
+        },
+        "trigger_filter": {
+          "name": "trigger_filter",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY['api', 'webhook', 'schedule', 'manual', 'chat']::text[]"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_log_webhook_workflow_id_idx": {
+          "name": "workflow_log_webhook_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_log_webhook_active_idx": {
+          "name": "workflow_log_webhook_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_log_webhook_workflow_id_workflow_id_fk": {
+          "name": "workflow_log_webhook_workflow_id_workflow_id_fk",
+          "tableFrom": "workflow_log_webhook",
+          "tableTo": "workflow",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_log_webhook_delivery": {
+      "name": "workflow_log_webhook_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_summary": {
+          "name": "workflow_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_snapshot": {
+          "name": "subscription_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "webhook_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_log_webhook_delivery_subscription_id_idx": {
+          "name": "workflow_log_webhook_delivery_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_log_webhook_delivery_execution_id_idx": {
+          "name": "workflow_log_webhook_delivery_execution_id_idx",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_log_webhook_delivery_workspace_id_idx": {
+          "name": "workflow_log_webhook_delivery_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_log_webhook_delivery_status_idx": {
+          "name": "workflow_log_webhook_delivery_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_log_webhook_delivery_next_attempt_idx": {
+          "name": "workflow_log_webhook_delivery_next_attempt_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_log_webhook_delivery_subscription_id_workflow_log_webhook_id_fk": {
+          "name": "workflow_log_webhook_delivery_subscription_id_workflow_log_webhook_id_fk",
+          "tableFrom": "workflow_log_webhook_delivery",
+          "tableTo": "workflow_log_webhook",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workflow_log_webhook_delivery_workflow_id_workflow_id_fk": {
+          "name": "workflow_log_webhook_delivery_workflow_id_workflow_id_fk",
+          "tableFrom": "workflow_log_webhook_delivery",
+          "tableTo": "workflow",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workflow_log_webhook_delivery_workspace_id_workspace_id_fk": {
+          "name": "workflow_log_webhook_delivery_workspace_id_workspace_id_fk",
+          "tableFrom": "workflow_log_webhook_delivery",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_schedule": {
+      "name": "workflow_schedule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ran_at": {
+          "name": "last_ran_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_failed_at": {
+          "name": "last_failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_schedule_workflow_block_unique": {
+          "name": "workflow_schedule_workflow_block_unique",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_schedule_workflow_id_workflow_id_fk": {
+          "name": "workflow_schedule_workflow_id_workflow_id_fk",
+          "tableFrom": "workflow_schedule",
+          "tableTo": "workflow",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_schedule_block_id_workflow_blocks_id_fk": {
+          "name": "workflow_schedule_block_id_workflow_blocks_id_fk",
+          "tableFrom": "workflow_schedule",
+          "tableTo": "workflow_blocks",
+          "columnsFrom": [
+            "block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_subflows": {
+      "name": "workflow_subflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_subflows_workflow_id_idx": {
+          "name": "workflow_subflows_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_subflows_workflow_type_idx": {
+          "name": "workflow_subflows_workflow_type_idx",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_subflows_workflow_id_workflow_id_fk": {
+          "name": "workflow_subflows_workflow_id_workflow_id_fk",
+          "tableFrom": "workflow_subflows",
+          "tableTo": "workflow",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_key_user_id_user_id_fk": {
+          "name": "api_key_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_workspace_id_workspace_id_fk": {
+          "name": "api_key_workspace_id_workspace_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_created_by_user_id_fk": {
+          "name": "api_key_created_by_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_key_unique": {
+          "name": "api_key_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workspace_type_check": {
+          "name": "workspace_type_check",
+          "value": "(type = 'workspace' AND workspace_id IS NOT NULL) OR (type = 'personal' AND workspace_id IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_tools": {
+      "name": "custom_tools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "custom_tools_workspace_id_idx": {
+          "name": "custom_tools_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_tools_workspace_title_unique": {
+          "name": "custom_tools_workspace_title_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_tools_workspace_id_workspace_id_fk": {
+          "name": "custom_tools_workspace_id_workspace_id_fk",
+          "tableFrom": "custom_tools",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_tools_user_id_user_id_fk": {
+          "name": "custom_tools_user_id_user_id_fk",
+          "tableFrom": "custom_tools",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.environment": {
+      "name": "environment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variables": {
+          "name": "variables",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "environment_user_id_user_id_fk": {
+          "name": "environment_user_id_user_id_fk",
+          "tableFrom": "environment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "environment_user_id_unique": {
+          "name": "environment_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.environment_variables": {
+      "name": "environment_variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "environment_variables_user_id_idx": {
+          "name": "environment_variables_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "environment_variables_workspace_id_idx": {
+          "name": "environment_variables_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "environment_variables_user_key_unique": {
+          "name": "environment_variables_user_key_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "environment_variables_workspace_key_unique": {
+          "name": "environment_variables_workspace_key_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "environment_variables_user_id_user_id_fk": {
+          "name": "environment_variables_user_id_user_id_fk",
+          "tableFrom": "environment_variables",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environment_variables_workspace_id_workspace_id_fk": {
+          "name": "environment_variables_workspace_id_workspace_id_fk",
+          "tableFrom": "environment_variables",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "environment_variables_scope_check": {
+          "name": "environment_variables_scope_check",
+          "value": "(user_id IS NOT NULL AND workspace_id IS NULL) OR (user_id IS NULL AND workspace_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.layout_map": {
+      "name": "layout_map",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "color_pair": {
+          "name": "color_pair",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "layout_map_workspace_idx": {
+          "name": "layout_map_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "layout_map_user_idx": {
+          "name": "layout_map_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "layout_map_workspace_user_idx": {
+          "name": "layout_map_workspace_user_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "layout_map_workspace_user_active_idx": {
+          "name": "layout_map_workspace_user_active_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "layout_map_workspace_id_workspace_id_fk": {
+          "name": "layout_map_workspace_id_workspace_id_fk",
+          "tableFrom": "layout_map",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "layout_map_user_id_user_id_fk": {
+          "name": "layout_map_user_id_user_id_fk",
+          "tableFrom": "layout_map",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_servers": {
+      "name": "mcp_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args": {
+          "name": "args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'"
+        },
+        "env": {
+          "name": "env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30000
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_connected": {
+          "name": "last_connected",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_status": {
+          "name": "connection_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'disconnected'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_count": {
+          "name": "tool_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_tools_refresh": {
+          "name": "last_tools_refresh",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_requests": {
+          "name": "total_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_servers_workspace_enabled_idx": {
+          "name": "mcp_servers_workspace_enabled_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_servers_workspace_deleted_idx": {
+          "name": "mcp_servers_workspace_deleted_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_servers_workspace_id_workspace_id_fk": {
+          "name": "mcp_servers_workspace_id_workspace_id_fk",
+          "tableFrom": "mcp_servers",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_servers_created_by_user_id_fk": {
+          "name": "mcp_servers_created_by_user_id_fk",
+          "tableFrom": "mcp_servers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monitor_view": {
+      "name": "monitor_view",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "monitor_view_workspace_idx": {
+          "name": "monitor_view_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "monitor_view_user_idx": {
+          "name": "monitor_view_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "monitor_view_workspace_user_idx": {
+          "name": "monitor_view_workspace_user_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "monitor_view_workspace_user_active_idx": {
+          "name": "monitor_view_workspace_user_active_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "monitor_view_workspace_user_sort_idx": {
+          "name": "monitor_view_workspace_user_sort_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "monitor_view_workspace_id_workspace_id_fk": {
+          "name": "monitor_view_workspace_id_workspace_id_fk",
+          "tableFrom": "monitor_view",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "monitor_view_user_id_user_id_fk": {
+          "name": "monitor_view_user_id_user_id_fk",
+          "tableFrom": "monitor_view",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_type": {
+          "name": "permission_type",
+          "type": "permission_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "permissions_user_id_idx": {
+          "name": "permissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permissions_entity_idx": {
+          "name": "permissions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permissions_user_entity_type_idx": {
+          "name": "permissions_user_entity_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permissions_user_entity_permission_idx": {
+          "name": "permissions_user_entity_permission_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permissions_user_entity_idx": {
+          "name": "permissions_user_entity_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permissions_unique_constraint": {
+          "name": "permissions_unique_constraint",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permissions_user_id_user_id_fk": {
+          "name": "permissions_user_id_user_id_fk",
+          "tableFrom": "permissions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_indicators": {
+      "name": "custom_indicators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'New Indicator'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3972F6'"
+        },
+        "pine_code": {
+          "name": "pine_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "input_meta": {
+          "name": "input_meta",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "custom_indicators_workspace_id_idx": {
+          "name": "custom_indicators_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_indicators_workspace_id_workspace_id_fk": {
+          "name": "custom_indicators_workspace_id_workspace_id_fk",
+          "tableFrom": "custom_indicators",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_indicators_user_id_user_id_fk": {
+          "name": "custom_indicators_user_id_user_id_fk",
+          "tableFrom": "custom_indicators",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill": {
+      "name": "skill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "skill_workspace_id_idx": {
+          "name": "skill_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skill_workspace_name_unique": {
+          "name": "skill_workspace_name_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skill_workspace_id_workspace_id_fk": {
+          "name": "skill_workspace_id_workspace_id_fk",
+          "tableFrom": "skill",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skill_user_id_user_id_fk": {
+          "name": "skill_user_id_user_id_fk",
+          "tableFrom": "skill",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watchlist_item": {
+      "name": "watchlist_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "watchlist_id": {
+          "name": "watchlist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "container_id": {
+          "name": "container_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing": {
+          "name": "listing",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "watchlist_item_watchlist_idx": {
+          "name": "watchlist_item_watchlist_idx",
+          "columns": [
+            {
+              "expression": "watchlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "watchlist_item_watchlist_container_sort_idx": {
+          "name": "watchlist_item_watchlist_container_sort_idx",
+          "columns": [
+            {
+              "expression": "watchlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "container_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "watchlist_item_container_sort_idx": {
+          "name": "watchlist_item_container_sort_idx",
+          "columns": [
+            {
+              "expression": "container_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "watchlist_item_watchlist_listing_identity_unique": {
+          "name": "watchlist_item_watchlist_listing_identity_unique",
+          "columns": [
+            {
+              "expression": "watchlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"listing\"->>'listing_type', '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"listing\"->>'listing_id', '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"listing\"->>'base_id', '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"listing\"->>'quote_id', '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watchlist_item_watchlist_id_watchlist_table_id_fk": {
+          "name": "watchlist_item_watchlist_id_watchlist_table_id_fk",
+          "tableFrom": "watchlist_item",
+          "tableTo": "watchlist_table",
+          "columnsFrom": [
+            "watchlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "watchlist_item_container_id_watchlist_table_id_fk": {
+          "name": "watchlist_item_container_id_watchlist_table_id_fk",
+          "tableFrom": "watchlist_item",
+          "tableTo": "watchlist_table",
+          "columnsFrom": [
+            "container_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watchlist_table": {
+      "name": "watchlist_table",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "watchlist_table_workspace_user_idx": {
+          "name": "watchlist_table_workspace_user_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "watchlist_table_workspace_user_parent_idx": {
+          "name": "watchlist_table_workspace_user_parent_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "watchlist_table_parent_sort_idx": {
+          "name": "watchlist_table_parent_sort_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "watchlist_table_workspace_user_name_unique": {
+          "name": "watchlist_table_workspace_user_name_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"watchlist_table\".\"parent_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "watchlist_table_workspace_id_workspace_id_fk": {
+          "name": "watchlist_table_workspace_id_workspace_id_fk",
+          "tableFrom": "watchlist_table",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "watchlist_table_user_id_user_id_fk": {
+          "name": "watchlist_table_user_id_user_id_fk",
+          "tableFrom": "watchlist_table",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "watchlist_table_parent_id_watchlist_table_id_fk": {
+          "name": "watchlist_table_parent_id_watchlist_table_id_fk",
+          "tableFrom": "watchlist_table",
+          "tableTo": "watchlist_table",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_environment": {
+      "name": "workspace_environment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variables": {
+          "name": "variables",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_environment_workspace_unique": {
+          "name": "workspace_environment_workspace_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_environment_workspace_id_workspace_id_fk": {
+          "name": "workspace_environment_workspace_id_workspace_id_fk",
+          "tableFrom": "workspace_environment",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_file": {
+      "name": "workspace_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_file_workspace_id_idx": {
+          "name": "workspace_file_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_file_key_idx": {
+          "name": "workspace_file_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_file_workspace_id_workspace_id_fk": {
+          "name": "workspace_file_workspace_id_workspace_id_fk",
+          "tableFrom": "workspace_file",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_file_uploaded_by_user_id_fk": {
+          "name": "workspace_file_uploaded_by_user_id_fk",
+          "tableFrom": "workspace_file",
+          "tableTo": "user",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_file_key_unique": {
+          "name": "workspace_file_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_invitation": {
+      "name": "workspace_invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "workspace_invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "permission_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "org_invitation_id": {
+          "name": "org_invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_invitation_workspace_id_workspace_id_fk": {
+          "name": "workspace_invitation_workspace_id_workspace_id_fk",
+          "tableFrom": "workspace_invitation",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_invitation_inviter_id_user_id_fk": {
+          "name": "workspace_invitation_inviter_id_user_id_fk",
+          "tableFrom": "workspace_invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_invitation_token_unique": {
+          "name": "workspace_invitation_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.credential_member_role": {
+      "name": "credential_member_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member"
+      ]
+    },
+    "public.credential_member_status": {
+      "name": "credential_member_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "pending",
+        "revoked"
+      ]
+    },
+    "public.credential_type": {
+      "name": "credential_type",
+      "schema": "public",
+      "values": [
+        "oauth",
+        "env_workspace",
+        "env_personal",
+        "service_account"
+      ]
+    },
+    "public.registration_mode": {
+      "name": "registration_mode",
+      "schema": "public",
+      "values": [
+        "open",
+        "waitlist",
+        "disabled"
+      ]
+    },
+    "public.system_service_value_kind": {
+      "name": "system_service_value_kind",
+      "schema": "public",
+      "values": [
+        "credential",
+        "setting"
+      ]
+    },
+    "public.waitlist_status": {
+      "name": "waitlist_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "signed_up"
+      ]
+    },
+    "public.order_submission_source": {
+      "name": "order_submission_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "copilot",
+        "workflow"
+      ]
+    },
+    "public.pending_execution_status": {
+      "name": "pending_execution_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing"
+      ]
+    },
+    "public.webhook_delivery_status": {
+      "name": "webhook_delivery_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "success",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.permission_type": {
+      "name": "permission_type",
+      "schema": "public",
+      "values": [
+        "admin",
+        "write",
+        "read"
+      ]
+    },
+    "public.workspace_invitation_status": {
+      "name": "workspace_invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected",
+        "cancelled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1780432066925,
       "tag": "0035_marvelous_avengers",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1781647170895,
+      "tag": "0036_fast_skullbuster",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/schema/billing.ts
+++ b/packages/db/schema/billing.ts
@@ -9,7 +9,6 @@ import {
   primaryKey,
   text,
   timestamp,
-  uniqueIndex,
 } from 'drizzle-orm/pg-core'
 import { organization, user } from './core'
 import { systemBillingTier } from './system'
@@ -147,9 +146,6 @@ export const subscription = pgTable(
   },
   (table) => ({
     billingTierIdIdx: index('subscription_billing_tier_id_idx').on(table.billingTierId),
-    stripeSubscriptionIdUnique: uniqueIndex('subscription_stripe_subscription_id_unique').on(
-      table.stripeSubscriptionId
-    ),
     referenceStatusIdx: index('subscription_reference_status_idx').on(
       table.referenceType,
       table.referenceId,

--- a/packages/db/schema/billing.ts
+++ b/packages/db/schema/billing.ts
@@ -9,7 +9,6 @@ import {
   primaryKey,
   text,
   timestamp,
-  uniqueIndex,
 } from 'drizzle-orm/pg-core'
 import { organization, user } from './core'
 import { systemBillingTier } from './system'
@@ -152,7 +151,7 @@ export const subscription = pgTable(
       table.referenceId,
       table.status
     ),
-    stripeSubscriptionIdUnique: uniqueIndex('subscription_stripe_subscription_id_unique').on(
+    stripeSubscriptionIdIdx: index('subscription_stripe_subscription_id_idx').on(
       table.stripeSubscriptionId
     ),
   })

--- a/packages/db/schema/billing.ts
+++ b/packages/db/schema/billing.ts
@@ -5,10 +5,11 @@ import {
   index,
   integer,
   json,
-  primaryKey,
   pgTable,
+  primaryKey,
   text,
   timestamp,
+  uniqueIndex,
 } from 'drizzle-orm/pg-core'
 import { organization, user } from './core'
 import { systemBillingTier } from './system'
@@ -146,6 +147,9 @@ export const subscription = pgTable(
   },
   (table) => ({
     billingTierIdIdx: index('subscription_billing_tier_id_idx').on(table.billingTierId),
+    stripeSubscriptionIdUnique: uniqueIndex('subscription_stripe_subscription_id_unique').on(
+      table.stripeSubscriptionId
+    ),
     referenceStatusIdx: index('subscription_reference_status_idx').on(
       table.referenceType,
       table.referenceId,

--- a/packages/db/schema/billing.ts
+++ b/packages/db/schema/billing.ts
@@ -9,6 +9,7 @@ import {
   primaryKey,
   text,
   timestamp,
+  uniqueIndex,
 } from 'drizzle-orm/pg-core'
 import { organization, user } from './core'
 import { systemBillingTier } from './system'
@@ -151,7 +152,7 @@ export const subscription = pgTable(
       table.referenceId,
       table.status
     ),
-    stripeSubscriptionIdIdx: index('subscription_stripe_subscription_id_idx').on(
+    stripeSubscriptionIdUnique: uniqueIndex('subscription_stripe_subscription_id_unique').on(
       table.stripeSubscriptionId
     ),
   })

--- a/packages/db/schema/billing.ts
+++ b/packages/db/schema/billing.ts
@@ -9,6 +9,7 @@ import {
   primaryKey,
   text,
   timestamp,
+  uniqueIndex,
 } from 'drizzle-orm/pg-core'
 import { organization, user } from './core'
 import { systemBillingTier } from './system'
@@ -150,6 +151,9 @@ export const subscription = pgTable(
       table.referenceType,
       table.referenceId,
       table.status
+    ),
+    stripeSubscriptionIdUnique: uniqueIndex('subscription_stripe_subscription_id_unique').on(
+      table.stripeSubscriptionId
     ),
   })
 )


### PR DESCRIPTION
## Summary
- Adds a sidebar-aware user menu trigger that shows the signed-in user's avatar, name, and email in the global navbar sidebar footer.
- Keeps the existing compact avatar trigger behavior for non-sidebar placements.
- Moves Stripe `customer.subscription.deleted` handling into the webhook event path and settles deleted subscriptions by Stripe subscription ID.
- Skips orphaned deleted Stripe subscription events, supports duplicate local rows by selecting the effective subscription, and syncs usage limits after settlement.
- Adds a `subscription.stripe_subscription_id` index and shared lookup helper for subscription/invoice webhook flows.

## Why
The sidebar profile menu needed a full-width trigger that matches sidebar navigation patterns while preserving the existing dropdown behavior.

Stripe subscription deletion handling also needed to be more resilient. Deleted events can arrive without a local row, with unreliable metadata, or with duplicate local subscription rows. Resolving by Stripe subscription ID avoids settling the wrong record and prevents incorrect usage resets.

## Affected Areas
- [x] `apps/tradinggoose`
- [ ] `apps/docs`
- [x] `packages/*`
- [ ] Workflows / execution
- [ ] Realtime / sockets
- [ ] Market data / charting
- [ ] Dev tooling / CI / infra
- [ ] Documentation only
- [x] Other: Billing / Stripe webhooks, sidebar profile UI

## Issue Links( if any )
None.

## Validation
```bash
cd apps/tradinggoose && bun run test global-navbar/components/user-menu.test.tsx lib/billing/core/subscription.test.ts lib/billing/webhooks/subscription.test.ts
# PASS: 3 test files, 21 tests

cd apps/tradinggoose && bun run type-check
# PASS

git diff --check upstream/staging...HEAD
# PASS
```

## Risk / Rollout Notes
- Apply the generated DB migration before relying on the new `subscription_stripe_subscription_id_idx` index.
- The generated migration also drops `copilot_review_items.tool_calls`; verify that this data removal is intended before applying it in shared environments.
- Monitor Stripe `customer.subscription.deleted` webhook logs, overage invoice finalization, and usage limit sync after deploy.
- Backout: revert this PR. If the migration has been applied, restore schema state with a follow-up rollback migration.

## Config / Data Changes
- Env vars added or changed: None.
- Database schema or migration impact: Adds an index on `subscription.stripe_subscription_id`; generated migration also drops `copilot_review_items.tool_calls`.
- External services or provider behavior changed: Stripe deleted subscription events are now settled through the explicit webhook `onEvent` path by Stripe subscription ID.

## Screenshots / Video
Not captured. Visible UI change is the sidebar footer user profile trigger and dropdown width behavior.

## Checklist
- [x] I kept the change focused and reviewed my own diff
- [x] I validated the change locally and documented the results above
- [x] I updated docs, examples, or copy if behavior/user-facing flows changed
- [x] I called out any env, schema, provider, or rollout impact
- [x] I did not include secrets, tokens, or private credentials in this PR