### PR TITLE
fix(auth): use browser origin for client auth requests

### DIFF
--- a/apps/tradinggoose/app/[locale]/[...notFound]/page.tsx
+++ b/apps/tradinggoose/app/[locale]/[...notFound]/page.tsx
@@ -1,0 +1,5 @@
+import { notFound } from 'next/navigation'
+
+export default function LocalizedNotFoundRoute() {
+  notFound()
+}

--- a/apps/tradinggoose/lib/auth-client.test.ts
+++ b/apps/tradinggoose/lib/auth-client.test.ts
@@ -1,0 +1,53 @@
+/** @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  createAuthClient: vi.fn((config: unknown) => ({ config })),
+}))
+
+vi.mock('better-auth/react', () => ({
+  createAuthClient: mocks.createAuthClient,
+}))
+
+vi.mock('@better-auth/sso/client', () => ({
+  ssoClient: vi.fn(() => 'sso-client'),
+}))
+
+vi.mock('@better-auth/stripe/client', () => ({
+  stripeClient: vi.fn(() => 'stripe-client'),
+}))
+
+vi.mock('better-auth/client/plugins', () => ({
+  customSessionClient: vi.fn(() => 'custom-session-client'),
+  emailOTPClient: vi.fn(() => 'email-otp-client'),
+  genericOAuthClient: vi.fn(() => 'generic-oauth-client'),
+  organizationClient: vi.fn(() => 'organization-client'),
+}))
+
+vi.mock('@/lib/env', () => ({
+  env: {
+    NEXT_PUBLIC_SSO_ENABLED: false,
+  },
+}))
+
+vi.mock('@/lib/session/session-context', () => ({
+  SessionContext: null,
+}))
+
+describe('auth client', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mocks.createAuthClient.mockClear()
+  })
+
+  it('uses the browser origin for same-origin auth requests', async () => {
+    await import('./auth-client')
+
+    expect(mocks.createAuthClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: window.location.origin,
+      })
+    )
+  })
+})

--- a/apps/tradinggoose/lib/auth-client.ts
+++ b/apps/tradinggoose/lib/auth-client.ts
@@ -11,10 +11,9 @@ import { createAuthClient } from 'better-auth/react'
 import type { auth } from '@/lib/auth'
 import { env } from '@/lib/env'
 import { SessionContext, type SessionHookResult } from '@/lib/session/session-context'
-import { getBaseUrl } from '@/lib/urls/utils'
 
 export const client = createAuthClient({
-  baseURL: getBaseUrl(),
+  ...(typeof window === 'undefined' ? {} : { baseURL: window.location.origin }),
   plugins: [
     emailOTPClient(),
     genericOAuthClient(),


### PR DESCRIPTION
## Summary
- Use `window.location.origin` for browser-side Better Auth client requests instead of the configured app base URL.
- Avoid setting a client auth `baseURL` during server-side imports.
- Add a localized catch-all not-found route so locale-prefixed unknown routes resolve through Next.js `notFound()`.
- Add a jsdom unit test covering the browser-origin auth client behavior.

## Why
The auth client should send browser-side auth requests to the active origin so auth callbacks work correctly when the runtime origin differs from the configured public app URL. Locale-prefixed unknown routes also need an explicit catch-all route to preserve localized 404 behavior.

## Affected Areas
- [x] `apps/tradinggoose`
- [ ] `apps/docs`
- [ ] `packages/*`
- [ ] Workflows / execution
- [ ] Realtime / sockets
- [ ] Market data / charting
- [ ] Dev tooling / CI / infra
- [ ] Documentation only
- [ ] Other:

## Issue Links( if any )
None

## Validation
```bash
# repo root
git diff --check upstream/staging...HEAD
# PASS: no whitespace errors

# apps/tradinggoose
bun run test -- lib/auth-client.test.ts
# PASS: 1 test file, 1 test
```

## Risk / Rollout Notes
Low risk. The change is limited to browser-side auth client base URL selection and localized 404 routing.

Backout plan: revert the auth client `baseURL` change and remove the localized catch-all not-found route if auth callback or localized routing behavior regresses.

## Config / Data Changes
- Env vars added or changed: None
- Database schema or migration impact: None
- External services or provider behavior changed: Browser-side auth requests now use the current browser origin instead of the `NEXT_PUBLIC_APP_URL`-derived base URL.

## Screenshots / Video
N/A - no visible UI changes.

## Checklist
- [x] I kept the change focused and reviewed my own diff
- [x] I validated the change locally and documented the results above
- [x] I updated docs, examples, or copy if behavior/user-facing flows changed (N/A)
- [x] I called out any env, schema, provider, or rollout impact
- [x] I did not include secrets, tokens, or private credentials in this PR
