### PR TITLE
fix(tradinggoose): harden proxy auth recovery and runtime base URLs

### DIFF
--- a/apps/tradinggoose/.env.example
+++ b/apps/tradinggoose/.env.example
@@ -12,8 +12,7 @@
 # - Configure system-managed integration OAuth apps in Admin Integrations instead:
 #   google-drive, google-email, github-repo, microsoft, slack, reddit, etc.
 # - Platform-managed vars like NODE_ENV, NEXT_RUNTIME, and VERCEL are omitted on purpose.
-# - Internal React Email preview vars like EMAILS_DIR_ABSOLUTE_PATH and
-#   PREVIEW_SERVER_LOCATION are also omitted on purpose.
+# - Internal React Email preview vars are omitted on purpose.
 #
 # Notes:
 # - Boolean-like flags should use true/false unless noted otherwise.
@@ -233,14 +232,6 @@ KB_CONFIG_DELAY_BETWEEN_DOCUMENTS="50"
 NEXT_PUBLIC_POSTHOG_DISABLED="1"
 
 ###############################################################################
-# Email preview / local tooling
-###############################################################################
-
-# Optional: only used by React Email preview and similar local tooling when
-# NEXT_PUBLIC_APP_URL is not available in that process.
-# EMAILS_PREVIEW_BASE_URL="http://localhost:3000"
-
-###############################################################################
 # Deployment and local infrastructure helpers
 ###############################################################################
 
@@ -255,6 +246,3 @@ NEXT_PUBLIC_POSTHOG_DISABLED="1"
 
 # Optional: tell the app it is running inside a Docker image build.
 DOCKER_BUILD="false"
-
-# Optional: landing-page preview/dev helper used by getBaseUrl().
-# NEXT_PUBLIC_IS_PREVIEW_DEVELOPMENT="false"

--- a/apps/tradinggoose/app/(auth)/auth-locale-redirects.test.tsx
+++ b/apps/tradinggoose/app/(auth)/auth-locale-redirects.test.tsx
@@ -227,6 +227,8 @@ describe('auth locale redirects', () => {
       await setInputValue('#password', 'Password1!')
       await submitRenderedForm()
 
+      expect(mockRefetchSession).not.toHaveBeenCalled()
+      expect(mockFetch).not.toHaveBeenCalled()
       expect(mockPush).toHaveBeenCalledWith('/verify?fromSignup=true')
     }
   )

--- a/apps/tradinggoose/app/(auth)/signup/signup-form.tsx
+++ b/apps/tradinggoose/app/(auth)/signup/signup-form.tsx
@@ -7,7 +7,7 @@ import { useLocale } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { client, useSession } from '@/lib/auth-client'
+import { client } from '@/lib/auth-client'
 import { quickValidateEmail } from '@/lib/email/validation'
 import { getEnv, isTruthy } from '@/lib/env'
 import { createLogger } from '@/lib/logs/console/logger'
@@ -90,7 +90,6 @@ function SignupFormContent({
   const signupCopy = copy.auth.signup
   const defaultCallbackPath = '/workspace'
   const searchParams = useSearchParams()
-  const { refetch: refetchSession } = useSession()
   const [isLoading, setIsLoading] = useState(false)
   const [, setMounted] = useState(false)
   const [showPassword, setShowPassword] = useState(false)
@@ -346,21 +345,6 @@ function SignupFormContent({
       if (!response || response.error) {
         setIsLoading(false)
         return
-      }
-
-      try {
-        await refetchSession()
-        const localeResponse = await fetch('/api/users/me/settings', {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ preferredLocale: locale }),
-        })
-        if (!localeResponse.ok) {
-          throw new Error('Failed to persist preferred locale after signup')
-        }
-        logger.info('Session refreshed after successful signup')
-      } catch (sessionError) {
-        logger.error('Failed to refresh session or persist locale after signup:', sessionError)
       }
 
       if (typeof window !== 'undefined') {

--- a/apps/tradinggoose/app/(auth)/verify/use-verification.test.tsx
+++ b/apps/tradinggoose/app/(auth)/verify/use-verification.test.tsx
@@ -13,6 +13,7 @@ const mockPush = vi.hoisted(() => vi.fn())
 const mockEmailOtpSignIn = vi.hoisted(() => vi.fn())
 const mockSendVerificationOtp = vi.hoisted(() => vi.fn())
 const mockRefetchSession = vi.hoisted(() => vi.fn())
+const mockFetch = vi.hoisted(() => vi.fn())
 const testState = vi.hoisted(() => ({
   searchParams: new URLSearchParams(),
 }))
@@ -122,8 +123,11 @@ describe('useVerification', () => {
     mockEmailOtpSignIn.mockReset()
     mockSendVerificationOtp.mockReset()
     mockRefetchSession.mockReset()
+    mockFetch.mockReset()
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }))
     testState.searchParams = new URLSearchParams()
     window.history.replaceState({}, '', '/')
+    global.fetch = mockFetch as typeof fetch
   })
 
   afterEach(() => {
@@ -172,6 +176,15 @@ describe('useVerification', () => {
       email: 'ada@example.com',
       otp: '123456',
     })
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/users/me/settings',
+      expect.objectContaining({
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ preferredLocale: 'zh' }),
+      })
+    )
     expect(mockPush).toHaveBeenCalledWith('/workspace')
   })
 
@@ -197,5 +210,35 @@ describe('useVerification', () => {
     })
 
     expect(mockPush).toHaveBeenCalledWith('/workspace/ws-1/dashboard')
+  })
+
+  it('persists locale before redirecting when verification is disabled', async () => {
+    mockRefetchSession.mockResolvedValue(undefined)
+
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale='es' messages={getPublicCopy('es')}>
+          <VerificationHarness
+            locale='es'
+            hasEmailService={false}
+            isEmailVerificationEnabled={false}
+            onReady={() => {}}
+          />
+        </NextIntlClientProvider>
+      )
+    })
+
+    await act(async () => {})
+
+    expect(mockRefetchSession).toHaveBeenCalled()
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/users/me/settings',
+      expect.objectContaining({
+        method: 'PATCH',
+        credentials: 'include',
+        body: JSON.stringify({ preferredLocale: 'es' }),
+      })
+    )
+    expect(mockPush).toHaveBeenCalledWith('/workspace')
   })
 })

--- a/apps/tradinggoose/app/(auth)/verify/use-verification.ts
+++ b/apps/tradinggoose/app/(auth)/verify/use-verification.ts
@@ -2,11 +2,12 @@
 
 import { useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
+import { useLocale } from 'next-intl'
 import { useRouter } from '@/i18n/navigation'
 import { normalizeAuthErrorCode } from '@/lib/auth/auth-error-copy'
 import { client, useSession } from '@/lib/auth-client'
 import { createLogger } from '@/lib/logs/console/logger'
-import { normalizeCallbackUrl } from '@/i18n/utils'
+import { normalizeCallbackUrl, type LocaleCode } from '@/i18n/utils'
 import type { Messages } from 'next-intl'
 
 const logger = createLogger('useVerification')
@@ -95,6 +96,7 @@ export function useVerification({
   copy,
 }: UseVerificationParams): UseVerificationReturn {
   const router = useRouter()
+  const locale = useLocale() as LocaleCode
   const searchParams = useSearchParams()
   const { refetch: refetchSession } = useSession()
   const [otp, setOtp] = useState('')
@@ -162,6 +164,23 @@ export function useVerification({
 
   const isOtpComplete = otp.length === 6
 
+  async function persistPreferredLocale() {
+    try {
+      const response = await fetch('/api/users/me/settings', {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ preferredLocale: locale }),
+      })
+
+      if (!response.ok) {
+        throw new Error('Failed to persist preferred locale after verification')
+      }
+    } catch (error) {
+      logger.warn('Failed to persist preferred locale after verification', { error, locale })
+    }
+  }
+
   async function verifyCode() {
     if (!isOtpComplete || !email) return
 
@@ -184,6 +203,8 @@ export function useVerification({
         } catch (e) {
           logger.warn('Failed to refetch session after verification', e)
         }
+
+        await persistPreferredLocale()
 
         if (typeof window !== 'undefined') {
           sessionStorage.removeItem('verificationEmail')
@@ -277,6 +298,8 @@ export function useVerification({
           } catch (error) {
             logger.warn('Failed to refetch session during verification skip:', error)
           }
+
+          await persistPreferredLocale()
 
           if (isInviteFlow && redirectUrl) {
             router.push(redirectUrl)

--- a/apps/tradinggoose/app/(landing)/components/feature/components/workflow-preview/workflow-preview.test.tsx
+++ b/apps/tradinggoose/app/(landing)/components/feature/components/workflow-preview/workflow-preview.test.tsx
@@ -6,6 +6,7 @@ import { act } from 'react'
 import { NextIntlClientProvider } from 'next-intl'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { getPublicCopy } from '@/i18n/public-copy'
 
 vi.mock('@xyflow/react', () => ({
@@ -73,9 +74,11 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
 vi.mock('@/components/listing-selector/listing/row', () => ({
   getListingDisplaySymbol: (listing: { base?: string | null; name?: string | null }) =>
     listing?.base || listing?.name || 'Listing',
-  ListingDisplayRow: ({ listing }: { listing?: { base?: string | null; name?: string | null } }) => (
-    <span>{listing?.base || listing?.name || 'Listing'}</span>
-  ),
+  ListingDisplayRow: ({
+    listing,
+  }: {
+    listing?: { base?: string | null; name?: string | null }
+  }) => <span>{listing?.base || listing?.name || 'Listing'}</span>,
 }))
 vi.mock('@/components/listing-selector/selector/resolve-request', () => ({
   requestListingResolution: vi.fn().mockResolvedValue(null),
@@ -107,11 +110,8 @@ vi.mock('@/widgets/widgets/components/widget-header-control', () => ({
   widgetHeaderMenuTextClassName: '',
 }))
 
-import {
-  buildTradingAgentWorkflowDemos,
-  type WorkflowPreviewDemo,
-} from './workflow-preview-demos'
 import { WorkflowPreview } from './workflow-preview'
+import { buildTradingAgentWorkflowDemos, type WorkflowPreviewDemo } from './workflow-preview-demos'
 
 describe('WorkflowPreview', () => {
   let container: HTMLDivElement
@@ -145,12 +145,11 @@ describe('WorkflowPreview', () => {
 
     await act(async () => {
       root.render(
-        <NextIntlClientProvider
-          locale='en'
-          messages={getPublicCopy('en')}
-        >
-          <WorkflowPreview demos={[investmentDebateDemo!]} />
-        </NextIntlClientProvider>
+        <TooltipProvider>
+          <NextIntlClientProvider locale='en' messages={getPublicCopy('en')}>
+            <WorkflowPreview demos={[investmentDebateDemo!]} />
+          </NextIntlClientProvider>
+        </TooltipProvider>
       )
     })
 
@@ -247,15 +246,16 @@ describe('WorkflowPreview', () => {
 
     await act(async () => {
       root.render(
-        <NextIntlClientProvider
-          locale='es'
-          messages={getPublicCopy('es')}
-        >
-          <WorkflowPreview demos={[demo]} />
-        </NextIntlClientProvider>
+        <TooltipProvider>
+          <NextIntlClientProvider locale='es' messages={getPublicCopy('es')}>
+            <WorkflowPreview demos={[demo]} />
+          </NextIntlClientProvider>
+        </TooltipProvider>
       )
     })
 
-    expect(container.textContent).toContain(copy.workspace.widgets.workflowEditor.summary.objectItem)
+    expect(container.textContent).toContain(
+      copy.workspace.widgets.workflowEditor.summary.objectItem
+    )
   })
 })

--- a/apps/tradinggoose/app/(landing)/components/structured-data.tsx
+++ b/apps/tradinggoose/app/(landing)/components/structured-data.tsx
@@ -2,13 +2,15 @@ import { getLocale } from 'next-intl/server'
 import { getPublicBillingCatalog } from '@/lib/billing/catalog'
 import { buildHostedPricingNarrative } from '@/lib/billing/public-catalog'
 import { getPublicCopy } from '@/i18n/public-copy'
-import { type LocaleCode, localizeSiteUrl, SITE_BASE_URL } from '@/i18n/utils'
+import { type LocaleCode, localizeSiteUrl } from '@/i18n/utils'
+import { getBaseUrl } from '@/lib/urls/utils'
 
 const STRUCTURED_DATA_MODIFIED_AT = '2026-04-04T00:00:00+00:00'
-const siteEntityUrl = (id: string) => `${SITE_BASE_URL}/#${id}`
-const siteAssetUrl = (pathname: string) => `${SITE_BASE_URL}${pathname}`
 
-function buildStructuredOffers(catalog: Awaited<ReturnType<typeof getPublicBillingCatalog>>) {
+function buildStructuredOffers(
+  catalog: Awaited<ReturnType<typeof getPublicBillingCatalog>>,
+  siteEntityUrl: (id: string) => string
+) {
   if (!catalog.billingEnabled) {
     return []
   }
@@ -86,6 +88,9 @@ export default async function StructuredData() {
   const billingCatalog = await getPublicBillingCatalog()
   const locale = (await getLocale()) as LocaleCode
   const copy = getPublicCopy(locale)
+  const siteBaseUrl = getBaseUrl()
+  const siteEntityUrl = (id: string) => `${siteBaseUrl}/#${id}`
+  const siteAssetUrl = (pathname: string) => `${siteBaseUrl}${pathname}`
   const siteHomeUrl = localizeSiteUrl(locale, '/')
   const pricingNarrative = billingCatalog.billingEnabled
     ? buildHostedPricingNarrative(billingCatalog)
@@ -211,7 +216,7 @@ export default async function StructuredData() {
         applicationSubCategory: 'Trading Platform',
         operatingSystem: 'Web, Windows, macOS, Linux',
         softwareVersion: '2026.04.04',
-        offers: buildStructuredOffers(billingCatalog),
+        offers: buildStructuredOffers(billingCatalog, siteEntityUrl),
         featureList: [
           'Visual workflow canvas for trading strategies',
           'Custom indicator editor (PineTS)',

--- a/apps/tradinggoose/app/[locale]/(auth)/auth-entry-pages.test.tsx
+++ b/apps/tradinggoose/app/[locale]/(auth)/auth-entry-pages.test.tsx
@@ -1,0 +1,135 @@
+import type React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGetLocale = vi.fn()
+const mockGetSession = vi.fn()
+const mockRedirect = vi.fn((url: string) => {
+  throw new Error(`redirect:${url}`)
+})
+const mockGetOAuthProviderStatus = vi.fn()
+const mockGetRegistrationModeForRender = vi.fn()
+
+vi.mock('next-intl/server', () => ({
+  getLocale: () => mockGetLocale(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+}))
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children?: React.ReactNode
+    href: string
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+  redirect: ({ href, locale }: { href: string; locale?: string }) => {
+    const localizedPath = locale && href.startsWith('/') ? `/${locale}${href}` : href
+    return mockRedirect(localizedPath)
+  },
+}))
+
+vi.mock('@/app/(auth)/components/oauth-provider-checker', () => ({
+  getOAuthProviderStatus: () => mockGetOAuthProviderStatus(),
+}))
+
+vi.mock('@/lib/registration/service', () => ({
+  getRegistrationModeForRender: () => mockGetRegistrationModeForRender(),
+}))
+
+vi.mock('@/app/(auth)/components/auth-page-header', () => ({
+  AuthPageHeader: () => null,
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children }: { children?: React.ReactNode }) => <button>{children}</button>,
+}))
+
+vi.mock('@/app/(auth)/login/login-form', () => ({
+  default: ({ registrationMode }: { registrationMode: string }) => (
+    <div data-testid='login-form' data-registration-mode={registrationMode} />
+  ),
+}))
+
+vi.mock('@/app/(auth)/signup/signup-form', () => ({
+  default: ({ registrationMode }: { registrationMode: string }) => (
+    <div data-testid='signup-form' data-registration-mode={registrationMode} />
+  ),
+}))
+
+describe('localized auth entry pages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    mockGetLocale.mockResolvedValue('es')
+    mockGetSession.mockResolvedValue(null)
+    mockGetOAuthProviderStatus.mockResolvedValue({
+      githubAvailable: false,
+      googleAvailable: false,
+      isProduction: false,
+    })
+    mockGetRegistrationModeForRender.mockResolvedValue('open')
+  })
+
+  it('redirects login to the localized workspace only after a real session check', async () => {
+    mockGetSession.mockResolvedValue({
+      user: {
+        id: 'user-1',
+      },
+    })
+
+    const LoginPage = (await import('./login/page')).default
+
+    await expect(LoginPage()).rejects.toThrow('redirect:/es/workspace')
+    expect(mockGetSession).toHaveBeenCalledWith(undefined, { disableCookieCache: true })
+    expect(mockGetOAuthProviderStatus).not.toHaveBeenCalled()
+    expect(mockGetRegistrationModeForRender).not.toHaveBeenCalled()
+  })
+
+  it('renders login when the real session check is empty', async () => {
+    const LoginPage = (await import('./login/page')).default
+
+    const result = await LoginPage()
+    const markup = renderToStaticMarkup(result)
+
+    expect(markup).toContain('data-testid="login-form"')
+    expect(markup).toContain('data-registration-mode="open"')
+    expect(mockRedirect).not.toHaveBeenCalled()
+  })
+
+  it('redirects signup to the localized workspace only after a real session check', async () => {
+    mockGetSession.mockResolvedValue({
+      user: {
+        id: 'user-1',
+      },
+    })
+
+    const SignupPage = (await import('./signup/page')).default
+
+    await expect(SignupPage({ searchParams: Promise.resolve({}) })).rejects.toThrow(
+      'redirect:/es/workspace'
+    )
+    expect(mockGetSession).toHaveBeenCalledWith(undefined, { disableCookieCache: true })
+    expect(mockGetOAuthProviderStatus).not.toHaveBeenCalled()
+    expect(mockGetRegistrationModeForRender).not.toHaveBeenCalled()
+  })
+
+  it('renders signup when the real session check is empty', async () => {
+    const SignupPage = (await import('./signup/page')).default
+
+    const result = await SignupPage({ searchParams: Promise.resolve({}) })
+    const markup = renderToStaticMarkup(result)
+
+    expect(markup).toContain('data-testid="signup-form"')
+    expect(markup).toContain('data-registration-mode="open"')
+    expect(mockRedirect).not.toHaveBeenCalled()
+  })
+})

--- a/apps/tradinggoose/app/[locale]/(auth)/login/page.tsx
+++ b/apps/tradinggoose/app/[locale]/(auth)/login/page.tsx
@@ -1,11 +1,23 @@
+import { getLocale } from 'next-intl/server'
 import { getOAuthProviderStatus } from '@/app/(auth)/components/oauth-provider-checker'
 import LoginForm from '@/app/(auth)/login/login-form'
+import { getSession } from '@/lib/auth'
 import { getRegistrationModeForRender } from '@/lib/registration/service'
+import { redirect } from '@/i18n/navigation'
 
 // Force dynamic rendering to avoid prerender errors with search params
 export const dynamic = 'force-dynamic'
 
 export default async function LoginPage() {
+  const [locale, session] = await Promise.all([
+    getLocale(),
+    getSession(undefined, { disableCookieCache: true }),
+  ])
+
+  if (session?.user?.id) {
+    redirect({ href: '/workspace', locale })
+  }
+
   const [{ githubAvailable, googleAvailable, isProduction }, registrationMode] = await Promise.all([
     getOAuthProviderStatus(),
     getRegistrationModeForRender(),

--- a/apps/tradinggoose/app/[locale]/(auth)/signup/page.tsx
+++ b/apps/tradinggoose/app/[locale]/(auth)/signup/page.tsx
@@ -1,11 +1,11 @@
 import { getLocale } from 'next-intl/server'
-import { Link } from '@/i18n/navigation'
+import { Link, redirect } from '@/i18n/navigation'
 import { getPublicCopy } from '@/i18n/public-copy'
-import { type LocaleCode } from '@/i18n/utils'
 import { AuthPageHeader } from '@/app/(auth)/components/auth-page-header'
 import { getOAuthProviderStatus } from '@/app/(auth)/components/oauth-provider-checker'
 import SignupForm from '@/app/(auth)/signup/signup-form'
 import { Button } from '@/components/ui/button'
+import { getSession } from '@/lib/auth'
 import { getRegistrationModeForRender } from '@/lib/registration/service'
 
 export const dynamic = 'force-dynamic'
@@ -15,12 +15,18 @@ export default async function SignupPage({
 }: {
   searchParams?: Promise<{ invite_flow?: string }>
 }) {
-  const [providers, locale] = await Promise.all([
-    Promise.all([getOAuthProviderStatus(), getRegistrationModeForRender()]),
+  const [locale, session] = await Promise.all([
     getLocale(),
+    getSession(undefined, { disableCookieCache: true }),
   ])
+
+  if (session?.user?.id) {
+    redirect({ href: '/workspace', locale })
+  }
+
+  const providers = await Promise.all([getOAuthProviderStatus(), getRegistrationModeForRender()])
   const [{ githubAvailable, googleAvailable, isProduction }, registrationMode] = providers
-  const copy = getPublicCopy(locale as LocaleCode)
+  const copy = getPublicCopy(locale)
   const commonCopy = copy.auth.common
   const disabledCopy = copy.auth.disabled
   const resolvedSearchParams = (await searchParams) ?? {}

--- a/apps/tradinggoose/app/[locale]/(landing)/blog/[slug]/page.tsx
+++ b/apps/tradinggoose/app/[locale]/(landing)/blog/[slug]/page.tsx
@@ -12,9 +12,9 @@ import {
   buildLocalizedAlternates,
   getOpenGraphLocale,
   localizeSiteUrl,
-  SITE_BASE_URL,
   type LocaleCode,
 } from '@/i18n/utils'
+import { getBaseUrl } from '@/lib/urls/utils'
 import { getPostBySlug } from '@/app/(landing)/blog/lib/posts'
 import { formatBlogDate } from '@/app/(landing)/blog/lib/heading-slugs'
 import BreadcrumbNav from '@/app/(landing)/blog/components/breadcrumb-nav'
@@ -74,6 +74,7 @@ export default async function PostPage({ params }: PostPageProps) {
   if (!post) notFound()
   const locale = (await getLocale()) as LocaleCode
   const copy = getPublicCopy(locale)
+  const siteBaseUrl = getBaseUrl()
 
   const { title, date, image, authors, tags, toc, content, readingTime } = post
   const postPath = `/blog/${slug}`
@@ -102,7 +103,7 @@ export default async function PostPage({ params }: PostPageProps) {
         ],
       })),
     }),
-    publisher: { '@id': `${SITE_BASE_URL}/#organization` },
+    publisher: { '@id': `${siteBaseUrl}/#organization` },
     mainEntityOfPage: { '@type': 'WebPage', '@id': localizeSiteUrl(locale, postPath) },
     ...(tags?.length && { keywords: tags.join(', '), articleSection: tags[0] }),
     inLanguage: locale,

--- a/apps/tradinggoose/app/[locale]/(landing)/layout.tsx
+++ b/apps/tradinggoose/app/[locale]/(landing)/layout.tsx
@@ -1,18 +1,20 @@
 import type { Metadata } from 'next'
 import Background from '@/app/(landing)/components/background/background'
-import { SITE_BASE_URL } from '@/i18n/utils'
+import { getBaseUrl } from '@/lib/urls/utils'
 
-export const metadata: Metadata = {
-  metadataBase: new URL(SITE_BASE_URL),
-  manifest: '/manifest.webmanifest',
-  icons: {
-    icon: '/favicon.ico',
-    apple: '/apple-icon.png',
-  },
-  other: {
-    'msapplication-TileColor': '#000000',
-    'theme-color': '#000000',
-  },
+export function generateMetadata(): Metadata {
+  return {
+    metadataBase: new URL(getBaseUrl()),
+    manifest: '/manifest.webmanifest',
+    icons: {
+      icon: '/favicon.ico',
+      apple: '/apple-icon.png',
+    },
+    other: {
+      'msapplication-TileColor': '#000000',
+      'theme-color': '#000000',
+    },
+  }
 }
 
 export default function LandingLayout({ children }: { children: React.ReactNode }) {

--- a/apps/tradinggoose/app/[locale]/changelog/page.tsx
+++ b/apps/tradinggoose/app/[locale]/changelog/page.tsx
@@ -7,8 +7,8 @@ import {
   getOpenGraphLocale,
   type LocaleCode,
   localizeSiteUrl,
-  SITE_BASE_URL,
 } from '@/i18n/utils'
+import { getBaseUrl } from '@/lib/urls/utils'
 
 export async function generateMetadata(): Promise<Metadata> {
   const locale = (await getLocale()) as LocaleCode
@@ -36,6 +36,7 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function ChangelogPage() {
   const locale = (await getLocale()) as LocaleCode
   const copy = getPublicCopy(locale)
+  const siteBaseUrl = getBaseUrl()
   const changelogStructuredData = {
     '@context': 'https://schema.org',
     '@graph': [
@@ -46,10 +47,10 @@ export default async function ChangelogPage() {
         url: localizeSiteUrl(locale, '/changelog'),
         mainEntityOfPage: localizeSiteUrl(locale, '/changelog'),
         inLanguage: locale,
-        author: { '@id': `${SITE_BASE_URL}/#organization` },
-        publisher: { '@id': `${SITE_BASE_URL}/#organization` },
-        about: { '@id': `${SITE_BASE_URL}/#software` },
-        isPartOf: { '@id': `${SITE_BASE_URL}/#website` },
+        author: { '@id': `${siteBaseUrl}/#organization` },
+        publisher: { '@id': `${siteBaseUrl}/#organization` },
+        about: { '@id': `${siteBaseUrl}/#software` },
+        isPartOf: { '@id': `${siteBaseUrl}/#website` },
       },
       {
         '@type': 'BreadcrumbList',

--- a/apps/tradinggoose/app/[locale]/layout.tsx
+++ b/apps/tradinggoose/app/[locale]/layout.tsx
@@ -26,6 +26,8 @@ export const viewport: Viewport = {
   ],
 }
 
+export const dynamic = 'force-dynamic'
+
 export async function generateMetadata({
   params,
 }: {
@@ -35,10 +37,6 @@ export async function generateMetadata({
   return generateBrandedMetadata(
     hasLocale(routing.locales, locale) ? (locale as AppLocale) : routing.defaultLocale
   )
-}
-
-export function generateStaticParams() {
-  return routing.locales.map((locale) => ({ locale }))
 }
 
 export default async function RootLayout({

--- a/apps/tradinggoose/app/api/auth/sso/register/route.test.ts
+++ b/apps/tradinggoose/app/api/auth/sso/register/route.test.ts
@@ -47,7 +47,9 @@ vi.mock('@/lib/env', () => ({
   env: {
     SSO_ENABLED: true,
   },
-  getEnv: vi.fn(() => undefined),
+  getEnv: vi.fn((key: string) =>
+    key === 'NEXT_PUBLIC_APP_URL' ? 'http://localhost:3000' : undefined
+  ),
   isTruthy: (value: string | boolean | number | undefined) =>
     typeof value === 'string' ? value.toLowerCase() === 'true' || value === '1' : Boolean(value),
 }))

--- a/apps/tradinggoose/app/api/files/serve/[...path]/route.test.ts
+++ b/apps/tradinggoose/app/api/files/serve/[...path]/route.test.ts
@@ -60,7 +60,6 @@ describe('File Serve API Route', () => {
       },
       getEnv: vi.fn((key: string) => {
         if (key === 'NEXT_PUBLIC_APP_URL') return 'https://app.tradinggoose.ai'
-        if (key === 'NEXT_PUBLIC_IS_PREVIEW_DEVELOPMENT') return 'false'
         return undefined
       }),
     }))

--- a/apps/tradinggoose/app/api/webhooks/trigger/[path]/route.test.ts
+++ b/apps/tradinggoose/app/api/webhooks/trigger/[path]/route.test.ts
@@ -248,6 +248,7 @@ describe('Webhook Trigger API Route', () => {
         isActive: true,
         providerConfig: { requireAuth: false },
         workflowId: 'test-workflow-id',
+        blockId: 'generic-trigger-id',
         rateLimitCount: 100,
         rateLimitPeriod: 60,
       })
@@ -282,6 +283,7 @@ describe('Webhook Trigger API Route', () => {
         isActive: true,
         providerConfig: { requireAuth: true, token: 'test-token-123' },
         workflowId: 'test-workflow-id',
+        blockId: 'generic-trigger-id',
       })
       globalMockData.workflows.push({
         id: 'test-workflow-id',
@@ -317,6 +319,7 @@ describe('Webhook Trigger API Route', () => {
           secretHeaderName: 'X-Custom-Auth',
         },
         workflowId: 'test-workflow-id',
+        blockId: 'generic-trigger-id',
       })
       globalMockData.workflows.push({
         id: 'test-workflow-id',
@@ -348,6 +351,7 @@ describe('Webhook Trigger API Route', () => {
         isActive: true,
         providerConfig: { requireAuth: true, token: 'case-test-token' },
         workflowId: 'test-workflow-id',
+        blockId: 'generic-trigger-id',
       })
       globalMockData.workflows.push({
         id: 'test-workflow-id',
@@ -392,6 +396,7 @@ describe('Webhook Trigger API Route', () => {
           secretHeaderName: 'X-Secret-Key',
         },
         workflowId: 'test-workflow-id',
+        blockId: 'generic-trigger-id',
       })
       globalMockData.workflows.push({
         id: 'test-workflow-id',

--- a/apps/tradinggoose/app/changelog.xml/route.ts
+++ b/apps/tradinggoose/app/changelog.xml/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getBaseUrl } from '@/lib/urls/utils'
 
-export const dynamic = 'force-static'
+export const dynamic = 'force-dynamic'
 export const revalidate = 3600
 
 interface Release {

--- a/apps/tradinggoose/app/changelog.xml/route.ts
+++ b/apps/tradinggoose/app/changelog.xml/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { SITE_BASE_URL } from '@/i18n/utils'
+import { getBaseUrl } from '@/lib/urls/utils'
 
 export const dynamic = 'force-static'
 export const revalidate = 3600
@@ -25,6 +25,7 @@ function escapeXml(str: string) {
 
 export async function GET() {
   try {
+    const siteBaseUrl = getBaseUrl()
     const res = await fetch(
       'https://api.github.com/repos/TradingGoose/TradingGoose-Studio/releases',
       {
@@ -52,7 +53,7 @@ export async function GET() {
       <rss version="2.0">
         <channel>
           <title>TradingGoose Changelog</title>
-          <link>${SITE_BASE_URL}/changelog</link>
+          <link>${siteBaseUrl}/changelog</link>
           <description>Latest changes, fixes and updates in TradingGoose.</description>
           <language>en-us</language>
           ${items}

--- a/apps/tradinggoose/app/llms-full.txt/route.ts
+++ b/apps/tradinggoose/app/llms-full.txt/route.ts
@@ -4,9 +4,10 @@ import {
   buildHostedPricingNarrative,
   buildHostedPricingSentence,
 } from '@/lib/billing/public-catalog'
-import { SITE_BASE_URL } from '@/i18n/utils'
+import { getBaseUrl } from '@/lib/urls/utils'
 
 export async function GET() {
+  const siteBaseUrl = getBaseUrl()
   const billingCatalog = await getPublicBillingCatalog()
   const hostedPricingSentence = billingCatalog.billingEnabled
     ? buildHostedPricingSentence(billingCatalog)
@@ -31,7 +32,7 @@ export async function GET() {
 > information to cite TradingGoose accurately without hallucinating features,
 > pricing, or positioning.
 
-Canonical URL:  ${SITE_BASE_URL}
+Canonical URL:  ${siteBaseUrl}
 Source code:    https://github.com/tradinggoose/tradinggoose-studio   (open source, self-hostable)
 Documentation:  https://docs.tradinggoose.ai
 Last updated:   2026-04-04
@@ -92,7 +93,7 @@ TradingGoose ships in two forms:
 - Self-hosting supported
 - Community-maintained
 
-**TradingGoose Hosted (${SITE_BASE_URL})** — current managed cloud tiers:
+**TradingGoose Hosted (${siteBaseUrl})** — current managed cloud tiers:
 
 ${hostedPricingTable}
 
@@ -179,7 +180,7 @@ Calendly, Webflow, WordPress, Firecrawl, BrowserUse.
 
 **Is TradingGoose free?**
 Yes. TradingGoose Studio is open source under the license at
-${SITE_BASE_URL}/licenses and can be self-hosted at no cost. The hosted
+${siteBaseUrl}/licenses and can be self-hosted at no cost. The hosted
 edition at tradinggoose.ai ${hostedPricingSentence ? `currently offers ${hostedPricingSentence}.` : 'does not currently expose public billing tiers.'}
 Paid tiers start above the default free tier.
 
@@ -242,11 +243,11 @@ any market data provider and stream live prices into the workspace.
 
 ## 12. Getting started
 
-- Homepage: ${SITE_BASE_URL}
+- Homepage: ${siteBaseUrl}
 - Documentation: https://docs.tradinggoose.ai
 - GitHub (open source): https://github.com/TradingGoose/TradingGoose-Studio
-- Sign up (hosted, free tier): ${SITE_BASE_URL}/signup
-- Changelog: ${SITE_BASE_URL}/changelog
+- Sign up (hosted, free tier): ${siteBaseUrl}/signup
+- Changelog: ${siteBaseUrl}/changelog
 ${enterpriseContactLine}
 
 ## 13. Community
@@ -257,9 +258,9 @@ ${enterpriseContactLine}
 
 ## 14. Legal, licensing, and disclaimers
 
-- Terms: ${SITE_BASE_URL}/terms
-- Privacy: ${SITE_BASE_URL}/privacy
-- License and third-party notices: ${SITE_BASE_URL}/licenses
+- Terms: ${siteBaseUrl}/terms
+- Privacy: ${siteBaseUrl}/privacy
+- License and third-party notices: ${siteBaseUrl}/licenses
 - Support: support@tradinggoose.ai
 
 **Trading risk disclaimer:** TradingGoose is software. Trading in financial
@@ -281,9 +282,9 @@ When citing TradingGoose, prefer this canonical phrasing:
 > can be self-hosted.
 
 Canonical sources to cite:
-- Website: ${SITE_BASE_URL}
+- Website: ${siteBaseUrl}
 - GitHub: https://github.com/tradinggoose/tradinggoose-studio
-- This file: ${SITE_BASE_URL}/llms-full.txt
+- This file: ${siteBaseUrl}/llms-full.txt
 `
 
   return new Response(llmsFullContent, {

--- a/apps/tradinggoose/app/llms-full.txt/route.ts
+++ b/apps/tradinggoose/app/llms-full.txt/route.ts
@@ -6,6 +6,8 @@ import {
 } from '@/lib/billing/public-catalog'
 import { getBaseUrl } from '@/lib/urls/utils'
 
+export const dynamic = 'force-dynamic'
+
 export async function GET() {
   const siteBaseUrl = getBaseUrl()
   const billingCatalog = await getPublicBillingCatalog()

--- a/apps/tradinggoose/app/llms.txt/route.ts
+++ b/apps/tradinggoose/app/llms.txt/route.ts
@@ -1,8 +1,9 @@
 import { getPublicBillingCatalog } from '@/lib/billing/catalog'
 import { buildHostedPricingSentence } from '@/lib/billing/public-catalog'
-import { SITE_BASE_URL } from '@/i18n/utils'
+import { getBaseUrl } from '@/lib/urls/utils'
 
 export async function GET() {
+  const siteBaseUrl = getBaseUrl()
   const billingCatalog = await getPublicBillingCatalog()
   const hostedPricingSentence = billingCatalog.billingEnabled
     ? buildHostedPricingSentence(billingCatalog)
@@ -53,11 +54,11 @@ ${
 - Widget: a composable workspace panel (chart, indicator view, workflow status, etc.)
 
 ## Getting started
-- Homepage: ${SITE_BASE_URL}
+- Homepage: ${siteBaseUrl}
 - Documentation: https://docs.tradinggoose.ai
 - GitHub (open source): https://github.com/TradingGoose/TradingGoose-Studio
-- Sign up (hosted): ${SITE_BASE_URL}/signup
-- Changelog: ${SITE_BASE_URL}/changelog
+- Sign up (hosted): ${siteBaseUrl}/signup
+- Changelog: ${siteBaseUrl}/changelog
 
 ## Community
 - GitHub: https://github.com/TradingGoose/TradingGoose-Studio
@@ -65,11 +66,11 @@ ${
 - X / Twitter: https://x.com/tradinggoose
 
 ## License
-See ${SITE_BASE_URL}/licenses for license and third-party notices.
+See ${siteBaseUrl}/licenses for license and third-party notices.
 
 ## Full reference
 For a deeper, AI-readable reference (features, pricing tiers, FAQ, example
-workflow, integrations, glossary), see ${SITE_BASE_URL}/llms-full.txt
+workflow, integrations, glossary), see ${siteBaseUrl}/llms-full.txt
 `
 
   return new Response(llmsContent, {

--- a/apps/tradinggoose/app/llms.txt/route.ts
+++ b/apps/tradinggoose/app/llms.txt/route.ts
@@ -2,6 +2,8 @@ import { getPublicBillingCatalog } from '@/lib/billing/catalog'
 import { buildHostedPricingSentence } from '@/lib/billing/public-catalog'
 import { getBaseUrl } from '@/lib/urls/utils'
 
+export const dynamic = 'force-dynamic'
+
 export async function GET() {
   const siteBaseUrl = getBaseUrl()
   const billingCatalog = await getPublicBillingCatalog()

--- a/apps/tradinggoose/app/sitemap.ts
+++ b/apps/tradinggoose/app/sitemap.ts
@@ -3,6 +3,8 @@ import { getAllPosts } from '@/app/(landing)/blog/lib/posts'
 import { locales } from '@/i18n/routing'
 import { localizeSiteUrl } from '@/i18n/utils'
 
+export const dynamic = 'force-dynamic'
+
 type SitemapEntry = Omit<MetadataRoute.Sitemap[number], 'url'>
 
 function localizedEntries(pathname: string, entry: SitemapEntry): MetadataRoute.Sitemap {

--- a/apps/tradinggoose/components/emails/header.tsx
+++ b/apps/tradinggoose/components/emails/header.tsx
@@ -6,13 +6,13 @@ import { getBaseUrl } from '@/lib/urls/utils'
 import { type EmailLocale, getEmailCopy } from '@/components/emails/email-copy'
 
 interface EmailHeaderProps {
+  baseUrl?: string
   tagline?: string
   locale?: EmailLocale
 }
 
-export const EmailHeader = ({ tagline, locale }: EmailHeaderProps) => {
+export const EmailHeader = ({ baseUrl = getBaseUrl(), tagline, locale }: EmailHeaderProps) => {
   const brand = getBrandConfig()
-  const baseUrl = getBaseUrl()
   const logoSrc = `${baseUrl}/favicon/goose.png`
   const copy = getEmailCopy(locale)
   const resolvedTagline = tagline ?? copy.shared.tagline

--- a/apps/tradinggoose/components/emails/localized-email.tsx
+++ b/apps/tradinggoose/components/emails/localized-email.tsx
@@ -49,7 +49,7 @@ export function LocalizedEmail({
       <Body style={baseStyles.main}>
         <Preview>{preview}</Preview>
         <Container style={baseStyles.container}>
-          <EmailHeader locale={resolvedLocale} tagline={copy.shared.tagline} />
+          <EmailHeader baseUrl={baseUrl} locale={resolvedLocale} tagline={copy.shared.tagline} />
 
           <Section style={baseStyles.content}>
             <Text style={baseStyles.title}>{title}</Text>

--- a/apps/tradinggoose/hooks/workflow/use-workflow-execution.test.tsx
+++ b/apps/tradinggoose/hooks/workflow/use-workflow-execution.test.tsx
@@ -67,6 +67,8 @@ vi.mock('@/widgets/widgets/editor_workflow/context/workflow-route-context', () =
   })),
 }))
 
+import { useWorkflowExecution } from './use-workflow-execution'
+
 describe('useWorkflowExecution', () => {
   let container: HTMLDivElement | null = null
   let root: Root | null = null
@@ -96,7 +98,6 @@ describe('useWorkflowExecution', () => {
   }
 
   async function renderExecutionHook() {
-    const { useWorkflowExecution } = await import('./use-workflow-execution')
     const state: { execution: ReturnType<typeof useWorkflowExecution> | null } = {
       execution: null,
     }

--- a/apps/tradinggoose/i18n/utils.ts
+++ b/apps/tradinggoose/i18n/utils.ts
@@ -7,7 +7,6 @@ export type LocaleInput = LocaleCode | string | null | undefined
 
 export { defaultLocale, isLocaleCode, locales }
 
-export const SITE_BASE_URL = getBaseUrl()
 export const CANONICAL_CALLBACK_PATH_HEADER = 'x-tradinggoose-callback-path'
 export const LOCALE_COOKIE = 'NEXT_LOCALE'
 export const LOCALE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365

--- a/apps/tradinggoose/lib/auth.ts
+++ b/apps/tradinggoose/lib/auth.ts
@@ -425,6 +425,9 @@ export const auth = betterAuth({
     getBaseUrl(),
     ...(env.NEXT_PUBLIC_SOCKET_URL ? [env.NEXT_PUBLIC_SOCKET_URL] : []),
   ],
+  advanced: {
+    crossSubDomainCookies: { enabled: false },
+  },
   database: drizzleAdapter(db, {
     provider: 'pg',
     schema,

--- a/apps/tradinggoose/lib/auth.ts
+++ b/apps/tradinggoose/lib/auth.ts
@@ -686,18 +686,9 @@ export const auth = betterAuth({
             to: data.email,
             subject: getEmailSubject(data.type, locale),
             html,
+            text: `${getEmailSubject(data.type, locale)}\n\n${data.otp}`,
             emailType: 'transactional',
           })
-
-          if (result.message.toLowerCase().includes('no email service configured')) {
-            logger.info('🔑 VERIFICATION CODE FOR LOGIN/SIGNUP', {
-              email: data.email,
-              otp: data.otp,
-              type: data.type,
-              validation: validation.checks,
-            })
-            return
-          }
 
           if (!result.success) {
             throw new Error(`Failed to send verification code: ${result.message}`)

--- a/apps/tradinggoose/lib/auth.ts
+++ b/apps/tradinggoose/lib/auth.ts
@@ -689,7 +689,7 @@ export const auth = betterAuth({
             emailType: 'transactional',
           })
 
-          if (!result.success && result.message.includes('no email service configured')) {
+          if (result.message.toLowerCase().includes('no email service configured')) {
             logger.info('🔑 VERIFICATION CODE FOR LOGIN/SIGNUP', {
               email: data.email,
               otp: data.otp,

--- a/apps/tradinggoose/lib/auth/auth-error-handler.test.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-handler.test.ts
@@ -25,11 +25,11 @@ describe('handleAuthError', () => {
     vi.unstubAllGlobals()
   })
 
-  it('routes login-page sign-out failures through proxy reauth cleanup', async () => {
+  it('routes login-page auth recovery through proxy reauth cleanup', async () => {
     vi.resetModules()
     vi.clearAllMocks()
     stubWindow('https://app.tradinggoose.ai/login?callbackUrl=%2Fworkspace#credentials')
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')))
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })))
 
     const { handleAuthError } = await import('./auth-error-handler')
 

--- a/apps/tradinggoose/lib/auth/auth-error-handler.test.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-handler.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const replaceMock = vi.fn()
+
+function stubWindow(url: string) {
+  const parsedUrl = new URL(url)
+
+  vi.stubGlobal('window', {
+    location: {
+      href: parsedUrl.href,
+      pathname: parsedUrl.pathname,
+      search: parsedUrl.search,
+      hash: parsedUrl.hash,
+      replace: replaceMock,
+    },
+    sessionStorage: {
+      getItem: vi.fn(() => '0'),
+      setItem: vi.fn(),
+    },
+  })
+}
+
+describe('handleAuthError', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('routes login-page sign-out failures through proxy reauth cleanup', async () => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    stubWindow('https://app.tradinggoose.ai/login?callbackUrl=%2Fworkspace#credentials')
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')))
+
+    const { handleAuthError } = await import('./auth-error-handler')
+
+    await handleAuthError('login-unauthorized', '/login')
+
+    expect(replaceMock).toHaveBeenCalledWith(
+      '/login?callbackUrl=%2Fworkspace&reauth=1#credentials'
+    )
+  })
+})

--- a/apps/tradinggoose/lib/auth/auth-error-handler.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-handler.ts
@@ -32,13 +32,15 @@ function isLoginPathname(pathname: string) {
 
 async function safeServerSignOut() {
   try {
-    await fetch('/api/auth/sign-out', {
-      method: 'POST',
-      credentials: 'include',
-      headers: { 'cache-control': 'no-store' },
-    })
-  } catch (error) {
-    logger.warn('Fallback sign-out failed', { error })
+    return (
+      await fetch('/api/auth/sign-out', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'cache-control': 'no-store' },
+      })
+    ).ok
+  } catch {
+    return false
   }
 }
 
@@ -58,9 +60,17 @@ export async function handleAuthError(reason: string, callbackPathname: string) 
   }
 
   isHandlingAuthError = true
-  await safeServerSignOut()
+  const signOutSucceeded = await safeServerSignOut()
 
   if (isLoginPathname(window.location.pathname)) {
+    if (!signOutSucceeded) {
+      const loginUrl = new URL(window.location.href)
+      loginUrl.searchParams.set('reauth', '1')
+      logger.warn('Routing login page through reauth cleanup after sign-out failure', { reason })
+      window.location.replace(`${loginUrl.pathname}${loginUrl.search}${loginUrl.hash}`)
+      return
+    }
+
     logger.warn('Cleared stale auth state on login page', { reason })
     isHandlingAuthError = false
     return

--- a/apps/tradinggoose/lib/auth/auth-error-handler.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-handler.ts
@@ -6,29 +6,6 @@ import { isLocaleCode, normalizeCallbackUrl } from '@/i18n/utils'
 const logger = createLogger('AuthErrorHandler')
 let isHandlingAuthError = false
 const LAST_RECOVERY_KEY = 'tradinggoose-auth-recovery-ts'
-const AUTH_COOKIE_NAMES = [
-  'better-auth.session_token',
-  'better-auth.session_data',
-  'better-auth.dont_remember',
-  '__Secure-better-auth.session_token',
-  '__Secure-better-auth.session_data',
-  '__Secure-better-auth.dont_remember',
-]
-
-function deleteBrowserAuthCookies() {
-  if (typeof document === 'undefined' || typeof window === 'undefined') return
-
-  const baseDomain = window.location.hostname
-  const domains = [undefined, baseDomain, `.${baseDomain}`].filter(Boolean)
-
-  AUTH_COOKIE_NAMES.forEach((name) => {
-    domains.forEach((domain) => {
-      document.cookie = `${name}=; Max-Age=0; Path=/; SameSite=Lax${
-        domain ? `; Domain=${domain}` : ''
-      }`
-    })
-  })
-}
 
 function shouldRateLimitRecovery(reason?: string) {
   if (typeof window === 'undefined') return false
@@ -81,7 +58,6 @@ export async function handleAuthError(reason: string, callbackPathname: string) 
   }
 
   isHandlingAuthError = true
-  deleteBrowserAuthCookies()
   await safeServerSignOut()
 
   if (isLoginPathname(window.location.pathname)) {

--- a/apps/tradinggoose/lib/auth/auth-error-handler.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-handler.ts
@@ -37,7 +37,8 @@ async function safeServerSignOut() {
       credentials: 'include',
       headers: { 'cache-control': 'no-store' },
     })
-  } catch {
+  } catch (error) {
+    logger.warn('Fallback sign-out failed', { error })
   }
 }
 

--- a/apps/tradinggoose/lib/auth/auth-error-handler.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-handler.ts
@@ -32,15 +32,12 @@ function isLoginPathname(pathname: string) {
 
 async function safeServerSignOut() {
   try {
-    return (
-      await fetch('/api/auth/sign-out', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'cache-control': 'no-store' },
-      })
-    ).ok
+    await fetch('/api/auth/sign-out', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'cache-control': 'no-store' },
+    })
   } catch {
-    return false
   }
 }
 
@@ -60,19 +57,13 @@ export async function handleAuthError(reason: string, callbackPathname: string) 
   }
 
   isHandlingAuthError = true
-  const signOutSucceeded = await safeServerSignOut()
+  await safeServerSignOut()
 
   if (isLoginPathname(window.location.pathname)) {
-    if (!signOutSucceeded) {
-      const loginUrl = new URL(window.location.href)
-      loginUrl.searchParams.set('reauth', '1')
-      logger.warn('Routing login page through reauth cleanup after sign-out failure', { reason })
-      window.location.replace(`${loginUrl.pathname}${loginUrl.search}${loginUrl.hash}`)
-      return
-    }
-
-    logger.warn('Cleared stale auth state on login page', { reason })
-    isHandlingAuthError = false
+    const loginUrl = new URL(window.location.href)
+    loginUrl.searchParams.set('reauth', '1')
+    logger.warn('Routing login page through reauth cleanup', { reason })
+    window.location.replace(`${loginUrl.pathname}${loginUrl.search}${loginUrl.hash}`)
     return
   }
 

--- a/apps/tradinggoose/lib/auth/cookies.test.ts
+++ b/apps/tradinggoose/lib/auth/cookies.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { AUTH_COOKIE_NAMES, getAuthCookieDeletionOptions } from './cookies'
+
+describe('auth cookie cleanup contract', () => {
+  it('declares the Better Auth cookies used by this app', () => {
+    expect(AUTH_COOKIE_NAMES).toEqual([
+      'better-auth.session_token',
+      '__Secure-better-auth.session_token',
+      'better-auth.session_data',
+      '__Secure-better-auth.session_data',
+      'better-auth.dont_remember',
+      '__Secure-better-auth.dont_remember',
+    ])
+  })
+
+  it('expires secure-prefixed cookies with the Secure attribute', () => {
+    expect(getAuthCookieDeletionOptions('__Secure-better-auth.session_token')).toMatchObject({
+      httpOnly: true,
+      maxAge: 0,
+      path: '/',
+      sameSite: 'lax',
+      secure: true,
+    })
+  })
+
+  it('does not mark plain localhost cookies as Secure', () => {
+    expect(getAuthCookieDeletionOptions('better-auth.session_token')).toEqual({
+      httpOnly: true,
+      maxAge: 0,
+      path: '/',
+      sameSite: 'lax',
+    })
+  })
+})

--- a/apps/tradinggoose/lib/auth/cookies.ts
+++ b/apps/tradinggoose/lib/auth/cookies.ts
@@ -1,0 +1,27 @@
+const AUTH_COOKIE_BASE_NAMES = [
+  'better-auth.session_token',
+  'better-auth.session_data',
+  'better-auth.dont_remember',
+] as const
+
+const SECURE_COOKIE_PREFIX = '__Secure-'
+
+export const AUTH_COOKIE_NAMES = AUTH_COOKIE_BASE_NAMES.flatMap((name) => [
+  name,
+  `${SECURE_COOKIE_PREFIX}${name}`,
+])
+
+function isSecureAuthCookieName(name: string) {
+  return name.startsWith(SECURE_COOKIE_PREFIX)
+}
+
+export function getAuthCookieDeletionOptions(name: string) {
+  const options = {
+    httpOnly: true,
+    maxAge: 0,
+    path: '/',
+    sameSite: 'lax' as const,
+  }
+
+  return isSecureAuthCookieName(name) ? { ...options, secure: true } : options
+}

--- a/apps/tradinggoose/lib/branding/metadata.ts
+++ b/apps/tradinggoose/lib/branding/metadata.ts
@@ -1,7 +1,8 @@
 import type { Metadata } from 'next'
 import { getBrandConfig } from '@/lib/branding/branding'
 import { getPublicCopy } from '@/i18n/public-copy'
-import { defaultLocale, getOpenGraphLocale, type LocaleCode, SITE_BASE_URL } from '@/i18n/utils'
+import { defaultLocale, getOpenGraphLocale, type LocaleCode } from '@/i18n/utils'
+import { getBaseUrl } from '@/lib/urls/utils'
 
 export const DEFAULT_META_DESCRIPTION =
   'Open-source LLM trading platform. Connect data providers, write custom indicators in PineTS, and trigger AI agent workflows on live signals.'
@@ -16,6 +17,7 @@ export function generateBrandedMetadata(
   const brand = getBrandConfig()
   const copy = getPublicCopy(locale)
   const landingMeta = copy.meta.landing
+  const siteBaseUrl = getBaseUrl()
 
   const defaultTitle = brand.name
 
@@ -32,7 +34,7 @@ export function generateBrandedMetadata(
     referrer: 'origin-when-cross-origin',
     creator: brand.name,
     publisher: brand.name,
-    metadataBase: new URL(SITE_BASE_URL),
+    metadataBase: new URL(siteBaseUrl),
     robots: {
       index: true,
       follow: true,
@@ -110,6 +112,8 @@ export function generateBrandedMetadata(
  * Generate static structured data for SEO
  */
 export function generateStructuredData() {
+  const siteBaseUrl = getBaseUrl()
+
   return {
     '@context': 'https://schema.org',
     '@type': 'SoftwareApplication',
@@ -117,7 +121,7 @@ export function generateStructuredData() {
     alternateName: ['TradingGoose Studio', 'TradingGoose.ai'],
     description:
       'TradingGoose (also known as TradingGoose Studio) is an open-source visual workflow platform for technical LLM-driven trading, maintained at github.com/TradingGoose/TradingGoose-Studio. Connect your own market data providers, write custom indicators in PineTS, monitor live prices, and route signals into AI agent workflows that trigger trades, alerts, portfolio rebalancing, or any action you define. Not affiliated with the older TradingGoose multi-agent LLM research framework.',
-    url: SITE_BASE_URL,
+    url: siteBaseUrl,
     sameAs: [
       'https://github.com/TradingGoose/TradingGoose-Studio',
       'https://docs.tradinggoose.ai',
@@ -136,7 +140,7 @@ export function generateStructuredData() {
       '@type': 'Organization',
       name: 'TradingGoose Studio',
       alternateName: 'TradingGoose',
-      url: SITE_BASE_URL,
+      url: siteBaseUrl,
       sameAs: [
         'https://github.com/TradingGoose/TradingGoose-Studio',
         'https://discord.gg/wavf5JWhuT',

--- a/apps/tradinggoose/lib/email/mailer.test.ts
+++ b/apps/tradinggoose/lib/email/mailer.test.ts
@@ -5,8 +5,17 @@ const mockBatchSend = vi.fn()
 const mockContactsCreate = vi.fn()
 const mockAzureBeginSend = vi.fn()
 const mockAzurePollUntilDone = vi.fn()
-const { mockResolveResendServiceConfig, mockResolveAzureCommunicationEmailServiceConfig } =
+const {
+  mockLoggerInfo,
+  mockLoggerWarn,
+  mockLoggerError,
+  mockResolveResendServiceConfig,
+  mockResolveAzureCommunicationEmailServiceConfig,
+} =
   vi.hoisted(() => ({
+    mockLoggerInfo: vi.fn(),
+    mockLoggerWarn: vi.fn(),
+    mockLoggerError: vi.fn(),
     mockResolveResendServiceConfig: vi.fn(),
     mockResolveAzureCommunicationEmailServiceConfig: vi.fn(),
   }))
@@ -57,6 +66,14 @@ vi.mock('@/lib/system-services/runtime', () => ({
 
 vi.mock('@/lib/urls/utils', () => ({
   getBaseUrl: vi.fn().mockReturnValue('https://test.tradinggoose.ai'),
+}))
+
+vi.mock('@/lib/logs/console/logger', () => ({
+  createLogger: () => ({
+    info: mockLoggerInfo,
+    warn: mockLoggerWarn,
+    error: mockLoggerError,
+  }),
 }))
 
 import {
@@ -163,7 +180,7 @@ describe('mailer', () => {
         html: '<p>Test content</p><a href="mock-token-123">Unsubscribe</a>',
         headers: {
           'List-Unsubscribe':
-            '<https://test.tradinggoose.ai/unsubscribe?token=mock-token-123&email=test%40example.com>',
+            '<https://test.tradinggoose.ai/en/unsubscribe?token=mock-token-123&email=test%40example.com>',
           'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
         },
       })
@@ -183,6 +200,39 @@ describe('mailer', () => {
 
       // Should not call Resend
       expect(mockSend).not.toHaveBeenCalled()
+    })
+
+    it('should log unsent email text when no email service is configured', async () => {
+      mockResolveResendServiceConfig.mockResolvedValue({
+        apiKey: null,
+        audienceId: null,
+      })
+      mockResolveAzureCommunicationEmailServiceConfig.mockResolvedValue({
+        connectionString: null,
+      })
+
+      const result = await sendEmail({
+        ...testEmailOptions,
+        text: 'Verification code: 123456',
+        emailType: 'transactional',
+      })
+
+      expect(result).toEqual({
+        success: true,
+        message: 'Email logging successful (no email service configured)',
+        data: { id: 'mock-email-id' },
+      })
+      expect(mockSend).not.toHaveBeenCalled()
+      expect(mockAzureBeginSend).not.toHaveBeenCalled()
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        'Email not sent (no email service configured):',
+        expect.objectContaining({
+          to: testEmailOptions.to,
+          subject: testEmailOptions.subject,
+          from: 'TradingGoose <noreply@tradinggoose.ai>',
+          text: 'Verification code: 123456',
+        })
+      )
     })
 
     it.concurrent('should handle Resend API errors and fallback to Azure', async () => {

--- a/apps/tradinggoose/lib/email/mailer.ts
+++ b/apps/tradinggoose/lib/email/mailer.ts
@@ -184,6 +184,7 @@ export async function sendEmail(options: EmailOptions): Promise<SendEmailResult>
       to: options.to,
       subject: options.subject,
       from: processedData.senderEmail,
+      text: processedData.text,
     })
     return {
       success: true,

--- a/apps/tradinggoose/lib/urls/utils.test.ts
+++ b/apps/tradinggoose/lib/urls/utils.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockEnv } = vi.hoisted(() => ({
+  mockEnv: {} as Record<string, string | undefined>,
+}))
+
+vi.mock('@/lib/env', () => ({
+  getEnv: (key: string) => mockEnv[key],
+}))
+
+import { getBaseDomain, getBaseUrl, getEmailDomain } from './utils'
+
+describe('url helpers', () => {
+  beforeEach(() => {
+    for (const key of Object.keys(mockEnv)) {
+      delete mockEnv[key]
+    }
+    mockEnv.NEXT_PUBLIC_APP_URL = 'https://www.tradinggoose.ai'
+  })
+
+  it('uses NEXT_PUBLIC_APP_URL as the base URL', () => {
+    expect(getBaseUrl()).toBe('https://www.tradinggoose.ai')
+  })
+
+  it('treats preview and production as configured app URLs', () => {
+    mockEnv.NEXT_PUBLIC_APP_URL = 'https://preview.tradinggoose.ai'
+
+    expect(getBaseUrl()).toBe('https://preview.tradinggoose.ai')
+  })
+
+  it('derives the base domain only from NEXT_PUBLIC_APP_URL', () => {
+    mockEnv.NEXT_PUBLIC_APP_URL = 'https://www.tradinggoose.ai'
+
+    expect(getBaseDomain()).toBe('www.tradinggoose.ai')
+    expect(getEmailDomain()).toBe('tradinggoose.ai')
+  })
+
+  it('rejects missing and invalid configured app URLs', () => {
+    mockEnv.NEXT_PUBLIC_APP_URL = undefined
+    expect(() => getBaseDomain()).toThrow('NEXT_PUBLIC_APP_URL is required')
+
+    mockEnv.NEXT_PUBLIC_APP_URL = 'app.tradinggoose.ai'
+    expect(() => getBaseDomain()).toThrow('NEXT_PUBLIC_APP_URL must be a valid URL')
+  })
+})

--- a/apps/tradinggoose/lib/urls/utils.test.ts
+++ b/apps/tradinggoose/lib/urls/utils.test.ts
@@ -16,6 +16,8 @@ describe('url helpers', () => {
       delete mockEnv[key]
     }
     mockEnv.NEXT_PUBLIC_APP_URL = 'https://www.tradinggoose.ai'
+    delete process.env.EMAILS_DIR_ABSOLUTE_PATH
+    delete process.env.PREVIEW_SERVER_LOCATION
   })
 
   it('uses NEXT_PUBLIC_APP_URL as the base URL', () => {
@@ -35,11 +37,34 @@ describe('url helpers', () => {
     expect(getEmailDomain()).toBe('tradinggoose.ai')
   })
 
-  it('rejects missing and invalid configured app URLs', () => {
+  it('uses the documented email preview fallback when app url is unavailable there', () => {
+    mockEnv.NEXT_PUBLIC_APP_URL = undefined
+    mockEnv.EMAILS_PREVIEW_BASE_URL = 'http://127.0.0.1:3000'
+    process.env.EMAILS_DIR_ABSOLUTE_PATH = '/tmp/emails'
+
+    expect(getBaseUrl()).toBe('http://127.0.0.1:3000')
+  })
+
+  it('defaults email preview to localhost when no preview base url is provided', () => {
+    mockEnv.NEXT_PUBLIC_APP_URL = undefined
+    process.env.PREVIEW_SERVER_LOCATION = '/tmp/preview-server'
+
+    expect(getBaseUrl()).toBe('http://localhost:3000')
+  })
+
+  it('rejects missing and invalid configured app urls outside email preview', () => {
     mockEnv.NEXT_PUBLIC_APP_URL = undefined
     expect(() => getBaseDomain()).toThrow('NEXT_PUBLIC_APP_URL is required')
 
     mockEnv.NEXT_PUBLIC_APP_URL = 'app.tradinggoose.ai'
-    expect(() => getBaseDomain()).toThrow('NEXT_PUBLIC_APP_URL must be a valid URL')
+    expect(() => getBaseDomain()).toThrow('Configured base URL must be a valid URL')
+  })
+
+  it('rejects invalid email preview base urls', () => {
+    mockEnv.NEXT_PUBLIC_APP_URL = undefined
+    mockEnv.EMAILS_PREVIEW_BASE_URL = 'preview.tradinggoose.ai'
+    process.env.EMAILS_DIR_ABSOLUTE_PATH = '/tmp/emails'
+
+    expect(() => getBaseUrl()).toThrow('Configured base URL must be a valid URL')
   })
 })

--- a/apps/tradinggoose/lib/urls/utils.test.ts
+++ b/apps/tradinggoose/lib/urls/utils.test.ts
@@ -16,8 +16,6 @@ describe('url helpers', () => {
       delete mockEnv[key]
     }
     mockEnv.NEXT_PUBLIC_APP_URL = 'https://www.tradinggoose.ai'
-    delete process.env.EMAILS_DIR_ABSOLUTE_PATH
-    delete process.env.PREVIEW_SERVER_LOCATION
   })
 
   it('uses NEXT_PUBLIC_APP_URL as the base URL', () => {
@@ -37,34 +35,11 @@ describe('url helpers', () => {
     expect(getEmailDomain()).toBe('tradinggoose.ai')
   })
 
-  it('uses the documented email preview fallback when app url is unavailable there', () => {
-    mockEnv.NEXT_PUBLIC_APP_URL = undefined
-    mockEnv.EMAILS_PREVIEW_BASE_URL = 'http://127.0.0.1:3000'
-    process.env.EMAILS_DIR_ABSOLUTE_PATH = '/tmp/emails'
-
-    expect(getBaseUrl()).toBe('http://127.0.0.1:3000')
-  })
-
-  it('defaults email preview to localhost when no preview base url is provided', () => {
-    mockEnv.NEXT_PUBLIC_APP_URL = undefined
-    process.env.PREVIEW_SERVER_LOCATION = '/tmp/preview-server'
-
-    expect(getBaseUrl()).toBe('http://localhost:3000')
-  })
-
   it('rejects missing and invalid configured app urls outside email preview', () => {
     mockEnv.NEXT_PUBLIC_APP_URL = undefined
     expect(() => getBaseDomain()).toThrow('NEXT_PUBLIC_APP_URL is required')
 
     mockEnv.NEXT_PUBLIC_APP_URL = 'app.tradinggoose.ai'
     expect(() => getBaseDomain()).toThrow('Configured base URL must be a valid URL')
-  })
-
-  it('rejects invalid email preview base urls', () => {
-    mockEnv.NEXT_PUBLIC_APP_URL = undefined
-    mockEnv.EMAILS_PREVIEW_BASE_URL = 'preview.tradinggoose.ai'
-    process.env.EMAILS_DIR_ABSOLUTE_PATH = '/tmp/emails'
-
-    expect(() => getBaseUrl()).toThrow('Configured base URL must be a valid URL')
   })
 })

--- a/apps/tradinggoose/lib/urls/utils.ts
+++ b/apps/tradinggoose/lib/urls/utils.ts
@@ -1,54 +1,17 @@
 import { getEnv } from '@/lib/env'
-import { isProd } from '@/lib/environment'
 
 /**
- * Returns the base URL of the application from NEXT_PUBLIC_APP_URL
- * This ensures webhooks, callbacks, and other integrations always use the correct public URL
- * @returns The base URL string (e.g., 'http://localhost:3000' or 'https://example.com')
- * @throws Error if NEXT_PUBLIC_APP_URL is not configured
+ * Returns the configured application URL.
  */
 export function getBaseUrl(): string {
-  const baseUrl = getEnv('NEXT_PUBLIC_APP_URL')
-  const isPreviewDev =
-    getEnv('NEXT_PUBLIC_IS_PREVIEW_DEVELOPMENT') === 'true' ||
-    getEnv('NEXT_PUBLIC_IS_PREVIEW_DEVELOPMENT') === '1'
-  const isReactEmailPreview =
-    !!process.env.EMAILS_DIR_ABSOLUTE_PATH || !!process.env.PREVIEW_SERVER_LOCATION
-
-  if (!baseUrl || !baseUrl.trim()) {
-    const fallback = process.env.EMAILS_PREVIEW_BASE_URL || 'http://localhost:3000'
-    if (isProd && !isPreviewDev && !isReactEmailPreview) {
-      // Avoid hard crash in production builds but surface a warning for misconfiguration.
-      // eslint-disable-next-line no-console
-      console.warn('NEXT_PUBLIC_APP_URL missing – falling back to', fallback)
-    }
-    return fallback
-  }
-
-  if (baseUrl.startsWith('http://') || baseUrl.startsWith('https://')) {
-    return baseUrl
-  }
-
-  const protocol = isProd ? 'https://' : 'http://'
-  return `${protocol}${baseUrl}`
+  return getConfiguredAppUrl()
 }
 
 /**
- * Returns just the domain and port part of the application URL
- * @returns The domain with port if applicable (e.g., 'localhost:3000' or 'tradinggoose.ai')
+ * Returns just the domain and port from NEXT_PUBLIC_APP_URL.
  */
 export function getBaseDomain(): string {
-  try {
-    const url = new URL(getBaseUrl())
-    return url.host // host includes port if specified
-  } catch (_e) {
-    const fallbackUrl = getEnv('NEXT_PUBLIC_APP_URL') || 'http://localhost:3000'
-    try {
-      return new URL(fallbackUrl).host
-    } catch {
-      return isProd ? 'tradinggoose.ai' : 'localhost:3000'
-    }
-  }
+  return new URL(getConfiguredAppUrl()).host
 }
 
 /**
@@ -56,10 +19,31 @@ export function getBaseDomain(): string {
  * @returns The email domain (e.g., 'tradinggoose.ai' instead of 'www.tradinggoose.ai')
  */
 export function getEmailDomain(): string {
-  try {
-    const baseDomain = getBaseDomain()
-    return baseDomain.startsWith('www.') ? baseDomain.substring(4) : baseDomain
-  } catch (_e) {
-    return isProd ? 'tradinggoose.ai' : 'localhost:3000'
+  const baseDomain = getBaseDomain()
+  return baseDomain.startsWith('www.') ? baseDomain.substring(4) : baseDomain
+}
+
+function getConfiguredAppUrl() {
+  return normalizeHttpOrigin(getEnv('NEXT_PUBLIC_APP_URL'), 'NEXT_PUBLIC_APP_URL')
+}
+
+function normalizeHttpOrigin(value: string | undefined, envName: string) {
+  const trimmed = value?.trim()
+  if (!trimmed) {
+    throw new Error(`${envName} is required`)
   }
+
+  let parsed: URL
+
+  try {
+    parsed = new URL(trimmed)
+  } catch {
+    throw new Error(`${envName} must be a valid URL`)
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`${envName} must use http or https`)
+  }
+
+  return parsed.origin
 }

--- a/apps/tradinggoose/lib/urls/utils.ts
+++ b/apps/tradinggoose/lib/urls/utils.ts
@@ -1,49 +1,29 @@
 import { getEnv } from '@/lib/env'
 
-/**
- * Returns the configured application URL.
- */
 export function getBaseUrl(): string {
-  return getConfiguredAppUrl()
-}
-
-/**
- * Returns just the domain and port from NEXT_PUBLIC_APP_URL.
- */
-export function getBaseDomain(): string {
-  return new URL(getConfiguredAppUrl()).host
-}
-
-/**
- * Returns the domain for email addresses, stripping www subdomain for Resend compatibility
- * @returns The email domain (e.g., 'tradinggoose.ai' instead of 'www.tradinggoose.ai')
- */
-export function getEmailDomain(): string {
-  const baseDomain = getBaseDomain()
-  return baseDomain.startsWith('www.') ? baseDomain.substring(4) : baseDomain
-}
-
-function getConfiguredAppUrl() {
-  return normalizeHttpOrigin(getEnv('NEXT_PUBLIC_APP_URL'), 'NEXT_PUBLIC_APP_URL')
-}
-
-function normalizeHttpOrigin(value: string | undefined, envName: string) {
-  const trimmed = value?.trim()
-  if (!trimmed) {
-    throw new Error(`${envName} is required`)
+  const value = getEnv('NEXT_PUBLIC_APP_URL')?.trim()
+  if (!value) {
+    throw new Error('NEXT_PUBLIC_APP_URL is required')
   }
 
-  let parsed: URL
-
+  let url: URL
   try {
-    parsed = new URL(trimmed)
+    url = new URL(value)
   } catch {
-    throw new Error(`${envName} must be a valid URL`)
+    throw new Error('NEXT_PUBLIC_APP_URL must be a valid URL')
   }
 
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    throw new Error(`${envName} must use http or https`)
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('NEXT_PUBLIC_APP_URL must use http or https')
   }
 
-  return parsed.origin
+  return url.origin
+}
+
+export function getBaseDomain(): string {
+  return new URL(getBaseUrl()).host
+}
+
+export function getEmailDomain(): string {
+  return getBaseDomain().replace(/^www\./, '')
 }

--- a/apps/tradinggoose/lib/urls/utils.ts
+++ b/apps/tradinggoose/lib/urls/utils.ts
@@ -1,12 +1,7 @@
 import { getEnv } from '@/lib/env'
 
 export function getBaseUrl(): string {
-  const configuredAppUrl = getEnv('NEXT_PUBLIC_APP_URL')?.trim()
-  const value =
-    configuredAppUrl ||
-    (process.env.EMAILS_DIR_ABSOLUTE_PATH || process.env.PREVIEW_SERVER_LOCATION
-      ? getEnv('EMAILS_PREVIEW_BASE_URL')?.trim() || 'http://localhost:3000'
-      : undefined)
+  const value = getEnv('NEXT_PUBLIC_APP_URL')?.trim()
 
   if (!value) {
     throw new Error('NEXT_PUBLIC_APP_URL is required')

--- a/apps/tradinggoose/lib/urls/utils.ts
+++ b/apps/tradinggoose/lib/urls/utils.ts
@@ -1,7 +1,13 @@
 import { getEnv } from '@/lib/env'
 
 export function getBaseUrl(): string {
-  const value = getEnv('NEXT_PUBLIC_APP_URL')?.trim()
+  const configuredAppUrl = getEnv('NEXT_PUBLIC_APP_URL')?.trim()
+  const value =
+    configuredAppUrl ||
+    (process.env.EMAILS_DIR_ABSOLUTE_PATH || process.env.PREVIEW_SERVER_LOCATION
+      ? getEnv('EMAILS_PREVIEW_BASE_URL')?.trim() || 'http://localhost:3000'
+      : undefined)
+
   if (!value) {
     throw new Error('NEXT_PUBLIC_APP_URL is required')
   }
@@ -10,11 +16,11 @@ export function getBaseUrl(): string {
   try {
     url = new URL(value)
   } catch {
-    throw new Error('NEXT_PUBLIC_APP_URL must be a valid URL')
+    throw new Error('Configured base URL must be a valid URL')
   }
 
   if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-    throw new Error('NEXT_PUBLIC_APP_URL must use http or https')
+    throw new Error('Configured base URL must use http or https')
   }
 
   return url.origin

--- a/apps/tradinggoose/lib/workflows/triggers.test.ts
+++ b/apps/tradinggoose/lib/workflows/triggers.test.ts
@@ -1,15 +1,8 @@
-import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 vi.unmock('@/blocks/registry')
 
-let listWorkflowRunTriggers: typeof import('./triggers').listWorkflowRunTriggers
-let resolveWorkflowRunTrigger: typeof import('./triggers').resolveWorkflowRunTrigger
-
-beforeAll(async () => {
-  const triggers = await import('./triggers')
-  listWorkflowRunTriggers = triggers.listWorkflowRunTriggers
-  resolveWorkflowRunTrigger = triggers.resolveWorkflowRunTrigger
-})
+import { listWorkflowRunTriggers, resolveWorkflowRunTrigger } from './triggers'
 
 const block = (type: string, extra: Record<string, unknown> = {}) => ({
   type,

--- a/apps/tradinggoose/proxy.test.ts
+++ b/apps/tradinggoose/proxy.test.ts
@@ -178,14 +178,29 @@ describe('proxy auth routing', () => {
     expect(response.cookies.get('NEXT_LOCALE')?.value).toBe('es')
   })
 
-  it('redirects authenticated localized auth routes to the localized workspace root', async () => {
+  it.each([
+    '/es/login',
+    '/es/signup',
+    '/es/waitlist',
+    '/es/reset-password',
+    '/es/verify',
+    '/es/sso',
+    '/es/error',
+  ])('lets session-cookie auth route %s reach its page boundary', async (pathname) => {
     mockGetSessionCookie.mockReturnValue('session-cookie')
 
     const { proxy } = await import('./proxy')
-    const response = await proxy(new NextRequest('http://localhost:3000/es/login'))
+    const response = await proxy(
+      new NextRequest(`http://localhost:3000${pathname}`, {
+        headers: {
+          'user-agent': 'vitest',
+        },
+      })
+    )
 
-    expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toBe('http://localhost:3000/es/workspace')
+    expect(response.status).toBe(200)
+    expect(response.headers.get('location')).toBeNull()
+    expect(response.cookies.get('NEXT_LOCALE')?.value).toBe('es')
   })
 
   it('keeps default-locale prefixed routes canonical', async () => {

--- a/apps/tradinggoose/proxy.test.ts
+++ b/apps/tradinggoose/proxy.test.ts
@@ -153,6 +153,14 @@ describe('proxy auth routing', () => {
     expect(response.headers.get('location')).toBeNull()
     expect(response.cookies.get('NEXT_LOCALE')?.value).toBe('en')
     expect(response.cookies.get('better-auth.session_token')?.maxAge).toBe(0)
+    expect(response.cookies.get('__Secure-better-auth.session_token')).toMatchObject({
+      maxAge: 0,
+      secure: true,
+    })
+    expect(response.cookies.get('__Secure-better-auth.session_data')).toMatchObject({
+      maxAge: 0,
+      secure: true,
+    })
   })
 
   it('preserves locale on the login route while keeping callback targets canonical', async () => {

--- a/apps/tradinggoose/proxy.ts
+++ b/apps/tradinggoose/proxy.ts
@@ -27,7 +27,7 @@ import { AUTH_COOKIE_NAMES, getAuthCookieDeletionOptions } from './lib/auth/cook
 const logger = createLogger('Proxy')
 const handleI18nRouting = createMiddleware(routing)
 
-const AUTH_ROUTES = new Set(['/login', '/signup'])
+const REAUTH_CLEANUP_ROUTE = '/login'
 
 function clearAuthCookies(response: NextResponse) {
   AUTH_COOKIE_NAMES.forEach((name) => {
@@ -158,9 +158,9 @@ function isProtectedAppPath(pathname: string): boolean {
   )
 }
 
-function isAuthRoute(pathname: string): boolean {
+function isReauthCleanupRoute(pathname: string): boolean {
   const { pathname: normalizedPathname } = resolveLocaleRoute(pathname)
-  return AUTH_ROUTES.has(normalizedPathname)
+  return normalizedPathname === REAUTH_CLEANUP_ROUTE
 }
 
 function buildProtectedRequestHeaders(request: NextRequest, route: LocaleRoute) {
@@ -294,14 +294,14 @@ function handleSecurityFiltering(request: NextRequest): NextResponse | null {
 export async function proxy(request: NextRequest) {
   const url = request.nextUrl
   const initialRoute = resolveLocaleRoute(url.pathname)
-  const hasActiveSession = Boolean(getSessionCookie(request))
+  const hasSessionCookie = Boolean(getSessionCookie(request))
   const route = resolveCanonicalLocaleRoute(request, initialRoute)
   const { locale, pathname: normalizedPathname } = route
 
   const isProtectedPath = isProtectedAppPath(url.pathname)
   const reauth = url.searchParams.get('reauth') === '1'
 
-  if (isProtectedPath && !hasActiveSession) {
+  if (isProtectedPath && !hasSessionCookie) {
     return buildLoginRedirect(request, route, `${route.pathname}${url.search}`)
   }
 
@@ -309,25 +309,16 @@ export async function proxy(request: NextRequest) {
     ? buildProtectedRequestHeaders(request, route)
     : undefined
 
-  if (isAuthRoute(url.pathname)) {
-    if (reauth) {
-      const localeResponse = routeToCanonicalLocale(request, route)
-      if (localeResponse) {
-        clearAuthCookies(localeResponse)
-        return localeResponse
-      }
-
-      const response = handleI18nRouting(request)
-      clearAuthCookies(response)
-      return withLocaleCookie(response, locale)
+  if (reauth && isReauthCleanupRoute(url.pathname)) {
+    const localeResponse = routeToCanonicalLocale(request, route)
+    if (localeResponse) {
+      clearAuthCookies(localeResponse)
+      return localeResponse
     }
 
-    if (hasActiveSession) {
-      return withLocaleCookie(
-        NextResponse.redirect(new URL(localizeUrl(url.origin, locale, '/workspace'))),
-        locale
-      )
-    }
+    const response = handleI18nRouting(request)
+    clearAuthCookies(response)
+    return withLocaleCookie(response, locale)
   }
 
   const securityBlock = handleSecurityFiltering(request)

--- a/apps/tradinggoose/proxy.ts
+++ b/apps/tradinggoose/proxy.ts
@@ -22,27 +22,19 @@ import {
 } from '@/i18n/utils'
 import { createLogger } from './lib/logs/console/logger'
 import { generateRuntimeCSP } from './lib/security/csp'
+import { AUTH_COOKIE_NAMES, getAuthCookieDeletionOptions } from './lib/auth/cookies'
 
 const logger = createLogger('Proxy')
 const handleI18nRouting = createMiddleware(routing)
 
 const AUTH_ROUTES = new Set(['/login', '/signup'])
-const AUTH_COOKIE_KEYS = [
-  'better-auth.session_token',
-  'better-auth.session_data',
-  'better-auth.dont_remember',
-  '__Secure-better-auth.session_token',
-  '__Secure-better-auth.session_data',
-  '__Secure-better-auth.dont_remember',
-]
 
 function clearAuthCookies(response: NextResponse) {
-  AUTH_COOKIE_KEYS.forEach((name) => {
+  AUTH_COOKIE_NAMES.forEach((name) => {
     response.cookies.set({
       name,
       value: '',
-      maxAge: 0,
-      path: '/',
+      ...getAuthCookieDeletionOptions(name),
     })
   })
 }

--- a/apps/tradinggoose/stores/index.ts
+++ b/apps/tradinggoose/stores/index.ts
@@ -1,8 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
 import { createLogger } from '@/lib/logs/console/logger'
-import { stripLocaleFromPathname } from '@/i18n/utils'
 import { useConsoleStore } from '@/stores/console/store'
 import { getCopilotStore, useCopilotStore } from '@/stores/copilot/store'
 import { useCustomToolsStore } from '@/stores/custom-tools/store'
@@ -14,113 +12,6 @@ import { useSubscriptionStore } from '@/stores/subscription/store'
 import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
 
 const logger = createLogger('Stores')
-const BEFORE_UNLOAD_AUTH_PATHS = new Set(['/login', '/signup', '/reset-password', '/verify'])
-
-// Track initialization state
-let isInitializing = false
-let appFullyInitialized = false
-let dataInitialized = false // Flag for actual data loading completion
-
-const AUTH_COOKIE_KEYS = [
-  'better-auth.session_token',
-  'better-auth.session_data',
-  'better-auth.dont_remember',
-  '__Secure-better-auth.session_token',
-  '__Secure-better-auth.session_data',
-  '__Secure-better-auth.dont_remember',
-]
-
-function hasAuthCookie(): boolean {
-  if (typeof document === 'undefined') return false
-  return AUTH_COOKIE_KEYS.some((key) => document.cookie.includes(`${key}=`))
-}
-
-/**
- * Initialize the application state and sync system
- * localStorage persistence has been removed - relies on DB and Zustand stores only
- */
-async function initializeApplication(): Promise<void> {
-  if (typeof window === 'undefined' || isInitializing) return
-
-  // Skip initialization entirely when no auth cookie is present to avoid
-  // unauthenticated 401 loops while the app is redirecting to /login.
-  if (!hasAuthCookie()) {
-    logger.info('Auth cookie missing, skipping app initialization')
-    appFullyInitialized = false
-    dataInitialized = false
-    return
-  }
-
-  isInitializing = true
-  appFullyInitialized = false
-
-  // Track initialization start time
-  const initStartTime = Date.now()
-
-  try {
-    // Load environment variables directly from DB
-    await useEnvironmentStore.getState().loadEnvironmentVariables()
-
-    // Mark data as initialized only after sync managers have loaded data from DB
-    dataInitialized = true
-
-    // Log initialization timing information
-    const initDuration = Date.now() - initStartTime
-    logger.info(`Application initialization completed in ${initDuration}ms`)
-
-    // Mark application as fully initialized
-    appFullyInitialized = true
-  } catch (error) {
-    logger.error('Error during application initialization:', { error })
-    // Still mark as initialized to prevent being stuck in initializing state
-    appFullyInitialized = true
-    // But don't mark data as initialized on error
-    dataInitialized = false
-  } finally {
-    isInitializing = false
-  }
-}
-
-/**
- * Checks if application is fully initialized
- */
-export function isAppInitialized(): boolean {
-  return appFullyInitialized
-}
-
-/**
- * Checks if data has been loaded from the database
- * This should be checked before any sync operations
- */
-export function isDataInitialized(): boolean {
-  return dataInitialized
-}
-
-/**
- * Handle application cleanup before unload
- */
-function handleBeforeUnload(event: BeforeUnloadEvent): void {
-  // Check if we're on an authentication page and skip confirmation if we are
-  if (typeof window !== 'undefined') {
-    const path = stripLocaleFromPathname(window.location.pathname).pathname
-    // Skip confirmation for auth-related pages
-    if (BEFORE_UNLOAD_AUTH_PATHS.has(path)) {
-      return
-    }
-  }
-
-  // Standard beforeunload pattern
-  event.preventDefault()
-  event.returnValue = ''
-}
-
-/**
- * Clean up sync system
- */
-function cleanupApplication(): void {
-  window.removeEventListener('beforeunload', handleBeforeUnload)
-  // Note: No sync managers to dispose - Socket.IO handles cleanup
-}
 
 /**
  * Clear all user data when signing out
@@ -140,72 +31,10 @@ export async function clearUserData(): Promise<void> {
     const keysToRemove = Object.keys(localStorage).filter((key) => !keysToKeep.includes(key))
     keysToRemove.forEach((key) => localStorage.removeItem(key))
 
-    // Reset application initialization state
-    appFullyInitialized = false
-    dataInitialized = false
-
     logger.info('User data cleared successfully')
   } catch (error) {
     logger.error('Error clearing user data:', { error })
   }
-}
-
-/**
- * Hook to manage application lifecycle
- */
-export function useAppInitialization() {
-  useEffect(() => {
-    // Use Promise to handle async initialization
-    initializeApplication()
-
-    return () => {
-      cleanupApplication()
-    }
-  }, [])
-}
-
-/**
- * Hook to reinitialize the application after successful login
- * Use this in the login success handler or post-login page
- */
-export function useLoginInitialization() {
-  useEffect(() => {
-    reinitializeAfterLogin()
-  }, [])
-}
-
-/**
- * Reinitialize the application after login
- * This ensures we load fresh data from the database for the new user
- */
-export async function reinitializeAfterLogin(): Promise<void> {
-  if (typeof window === 'undefined') return
-
-  try {
-    // Reset application initialization state
-    appFullyInitialized = false
-    dataInitialized = false
-
-    // Note: No sync managers to dispose - Socket.IO handles cleanup
-
-    // Clean existing state to avoid stale data
-    resetAllStores()
-
-    // Reset initialization flags to force a fresh load
-    isInitializing = false
-
-    // Reinitialize the application
-    await initializeApplication()
-
-    logger.info('Application reinitialized after login')
-  } catch (error) {
-    logger.error('Error reinitializing application:', { error })
-  }
-}
-
-// Initialize immediately when imported on client
-if (typeof window !== 'undefined') {
-  initializeApplication()
 }
 
 // Export all stores

--- a/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-editor/preview/preview-node.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-editor/preview/preview-node.test.tsx
@@ -1,6 +1,7 @@
-import { createElement } from 'react'
+import { createElement, type ReactElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
 
 vi.mock('@xyflow/react', () => ({
   Handle: ({ id, type, position }: { id: string; type: string; position: string }) =>
@@ -60,9 +61,12 @@ vi.mock('@/widgets/widgets/editor_workflow/copy', () => ({
 
 import { PreviewNode } from './preview-node'
 
+const renderPreviewMarkup = (node: ReactElement) =>
+  renderToStaticMarkup(createElement(TooltipProvider, null, node))
+
 describe('PreviewNode', () => {
   it('renders canonical read-only node chrome and handles for regular blocks', () => {
-    const markup = renderToStaticMarkup(
+    const markup = renderPreviewMarkup(
       createElement(PreviewNode as any, {
         id: 'agent-1',
         data: {
@@ -91,7 +95,7 @@ describe('PreviewNode', () => {
   })
 
   it('omits input/error handles for trigger blocks', () => {
-    const markup = renderToStaticMarkup(
+    const markup = renderPreviewMarkup(
       createElement(PreviewNode as any, {
         id: 'trigger-1',
         data: {
@@ -114,7 +118,7 @@ describe('PreviewNode', () => {
   })
 
   it('omits output handles for condition/response blocks', () => {
-    const markup = renderToStaticMarkup(
+    const markup = renderPreviewMarkup(
       createElement(PreviewNode as any, {
         id: 'condition-1',
         data: {
@@ -137,7 +141,7 @@ describe('PreviewNode', () => {
   })
 
   it('uses horizontal handle ports when block requests horizontal handles', () => {
-    const markup = renderToStaticMarkup(
+    const markup = renderPreviewMarkup(
       createElement(PreviewNode as any, {
         id: 'agent-horizontal',
         data: {
@@ -165,7 +169,7 @@ describe('PreviewNode', () => {
   })
 
   it('renders precomputed preview summaries when localized summary metadata is provided', () => {
-    const markup = renderToStaticMarkup(
+    const markup = renderPreviewMarkup(
       createElement(PreviewNode as any, {
         id: 'agent-precomputed',
         data: {
@@ -201,7 +205,7 @@ describe('PreviewNode', () => {
 
   it('throws when precomputed preview summaries are missing localized object item metadata', () => {
     expect(() =>
-      renderToStaticMarkup(
+      renderPreviewMarkup(
         createElement(PreviewNode as any, {
           id: 'agent-precomputed-error',
           data: {
@@ -230,7 +234,7 @@ describe('PreviewNode', () => {
   })
 
   it('filters conditional preview rows before rendering duplicate subblock ids', () => {
-    const markup = renderToStaticMarkup(
+    const markup = renderPreviewMarkup(
       createElement(PreviewNode as any, {
         id: 'custom-conditional',
         data: {
@@ -284,7 +288,7 @@ describe('PreviewNode', () => {
   })
 
   it('renders both deploy-managed and editor-managed trigger fields in preview mode', () => {
-    const markup = renderToStaticMarkup(
+    const markup = renderPreviewMarkup(
       createElement(PreviewNode as any, {
         id: 'trigger-preview-1',
         data: {
@@ -345,7 +349,7 @@ describe('PreviewNode', () => {
   })
 
   it('renders centralized trigger metadata labels instead of inline trigger option labels', () => {
-    const markup = renderToStaticMarkup(
+    const markup = renderPreviewMarkup(
       createElement(PreviewNode as any, {
         id: 'trigger-preview-2',
         data: {

--- a/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-editor/preview/read-only-node-editor-panel.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-editor/preview/read-only-node-editor-panel.test.tsx
@@ -1,6 +1,7 @@
-import { createElement } from 'react'
+import { createElement, type ReactElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import type { WorkflowState } from '@/stores/workflows/workflow/types'
 import { ReadOnlyNodeEditorPanel } from './read-only-node-editor-panel'
 
@@ -108,9 +109,12 @@ function createWorkflowState(): WorkflowState {
   }
 }
 
+const renderPreviewMarkup = (node: ReactElement) =>
+  renderToStaticMarkup(createElement(TooltipProvider, null, node))
+
 describe('ReadOnlyNodeEditorPanel', () => {
   it('renders empty selection state when no node is selected', () => {
-    const markup = renderToStaticMarkup(
+    const markup = renderPreviewMarkup(
       createElement(ReadOnlyNodeEditorPanel, {
         selectedNodeId: null,
         workflowState: createWorkflowState(),
@@ -121,7 +125,7 @@ describe('ReadOnlyNodeEditorPanel', () => {
   })
 
   it('renders missing-node state when selected id is not present', () => {
-    const markup = renderToStaticMarkup(
+    const markup = renderPreviewMarkup(
       createElement(ReadOnlyNodeEditorPanel, {
         selectedNodeId: 'missing',
         workflowState: createWorkflowState(),
@@ -133,7 +137,7 @@ describe('ReadOnlyNodeEditorPanel', () => {
   })
 
   it('renders inspector header and canonical summary rows for selected node', () => {
-    const markup = renderToStaticMarkup(
+    const markup = renderPreviewMarkup(
       createElement(ReadOnlyNodeEditorPanel, {
         selectedNodeId: 'agent_1',
         workflowState: createWorkflowState(),
@@ -149,7 +153,7 @@ describe('ReadOnlyNodeEditorPanel', () => {
   })
 
   it('evaluates preview conditions for canonical loop nodes', () => {
-    const markup = renderToStaticMarkup(
+    const markup = renderPreviewMarkup(
       createElement(ReadOnlyNodeEditorPanel, {
         selectedNodeId: 'loop_1',
         workflowState: createWorkflowState(),


### PR DESCRIPTION
## Summary
- Let localized auth entry routes reach their page boundary instead of redirecting from proxy based only on session-cookie presence.
- Move authenticated login/signup redirects to page-level checks using uncached session lookup.
- Centralize Better Auth cookie cleanup, including `__Secure-*` cookie variants, and route stale login-page auth recovery through `?reauth=1`.
- Require and validate `NEXT_PUBLIC_APP_URL`, then resolve base URLs at runtime for metadata, structured data, sitemap, changelog RSS, `llms*.txt`, and email assets.
- Persist preferred locale after OTP verification instead of during initial signup.
- Preserve transactional email text in no-provider local logging and simplify stale client-side store initialization behavior.

## Why
Stale Better Auth cookies could cause auth entry pages to redirect away before users could reauthenticate. Static or fallback base URL handling could also generate incorrect canonical URLs in preview/hosted environments. This makes auth recovery, cookie cleanup, locale persistence, and canonical URL generation deterministic.

## Affected Areas
- [x] `apps/tradinggoose`
- [ ] `apps/docs`
- [ ] `packages/*`
- [ ] Workflows / execution
- [ ] Realtime / sockets
- [ ] Market data / charting
- [ ] Dev tooling / CI / infra
- [ ] Documentation only
- [x] Other: Auth/proxy routing, SEO metadata, runtime URL generation, email delivery/logging

## Issue Links( if any )
None.

## Validation
```bash
cd apps/tradinggoose
bunx vitest run proxy.test.ts 'app/(auth)/auth-locale-redirects.test.tsx' 'app/(auth)/verify/use-verification.test.tsx' 'app/[locale]/(auth)/auth-entry-pages.test.tsx' lib/auth/auth-error-handler.test.ts lib/auth/cookies.test.ts lib/email/mailer.test.ts lib/urls/utils.test.ts 'app/api/files/serve/[...path]/route.test.ts'
```

Result: Passed, 10 test files / 83 tests. Vitest emitted existing mock-hoisting warnings from `app/api/__test-utils__/utils.ts`.

```bash
cd apps/tradinggoose
bun run type-check
```

Result: Passed.

## Risk / Rollout Notes
- `NEXT_PUBLIC_APP_URL` is now required and must be a valid `http` or `https` URL. Local, preview, and hosted environments should confirm it is set correctly.
- Stale auth sessions may be forced through one login-page reauth cleanup flow, which is intentional.
- No database migration is included. Backout is a code revert if auth or URL behavior regresses.

## Config / Data Changes
- Env vars added or changed: no new env vars; `NEXT_PUBLIC_APP_URL` is now strictly required/validated, and preview-only base URL fallback references were removed from `.env.example`.
- Database schema or migration impact: none.
- External services or provider behavior changed: Better Auth cross-subdomain cookies are disabled; no-provider email logging now includes transactional text for local verification flows.

## Screenshots / Video
Not applicable. Routing/auth/metadata behavior only.

## Checklist
- [x] I kept the change focused and reviewed my own diff
- [x] I validated the change locally and documented the results above
- [x] I updated docs, examples, or copy if behavior/user-facing flows changed
- [x] I called out any env, schema, provider, or rollout impact
- [x] I did not include secrets, tokens, or private credentials in this PR