### PR TITLE
fix(auth): use deployment-aware Better Auth cookies

### DIFF
--- a/apps/tradinggoose/lib/auth/cookies.test.ts
+++ b/apps/tradinggoose/lib/auth/cookies.test.ts
@@ -1,20 +1,27 @@
-import { describe, expect, it } from 'vitest'
-import { AUTH_COOKIE_NAMES, getAuthCookieDeletionOptions } from './cookies'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+async function loadCookies(appUrl: string) {
+  vi.resetModules()
+  vi.stubEnv('NEXT_PUBLIC_APP_URL', appUrl)
+  return import('./cookies')
+}
 
 describe('auth cookie cleanup contract', () => {
-  it('declares the Better Auth cookies used by this app', () => {
-    expect(AUTH_COOKIE_NAMES).toEqual([
-      'better-auth.session_token',
-      '__Secure-better-auth.session_token',
-      'better-auth.session_data',
-      '__Secure-better-auth.session_data',
-      'better-auth.dont_remember',
-      '__Secure-better-auth.dont_remember',
-    ])
+  afterEach(() => {
+    vi.unstubAllEnvs()
   })
 
-  it('expires secure-prefixed cookies with the Secure attribute', () => {
-    expect(getAuthCookieDeletionOptions('__Secure-better-auth.session_token')).toMatchObject({
+  it('declares secure Better Auth cookies for HTTPS app origins', async () => {
+    const { AUTH_COOKIE_NAMES, AUTH_SESSION_COOKIE_NAME, getAuthCookieDeletionOptions } =
+      await loadCookies('https://www.tradinggoose.ai')
+
+    expect(AUTH_SESSION_COOKIE_NAME).toBe('__Secure-better-auth.session_token')
+    expect(AUTH_COOKIE_NAMES).toEqual([
+      '__Secure-better-auth.session_token',
+      '__Secure-better-auth.session_data',
+      '__Secure-better-auth.dont_remember',
+    ])
+    expect(getAuthCookieDeletionOptions()).toMatchObject({
       httpOnly: true,
       maxAge: 0,
       path: '/',
@@ -23,8 +30,17 @@ describe('auth cookie cleanup contract', () => {
     })
   })
 
-  it('does not mark plain localhost cookies as Secure', () => {
-    expect(getAuthCookieDeletionOptions('better-auth.session_token')).toEqual({
+  it('declares plain Better Auth cookies for HTTP app origins', async () => {
+    const { AUTH_COOKIE_NAMES, AUTH_SESSION_COOKIE_NAME, getAuthCookieDeletionOptions } =
+      await loadCookies('http://localhost:3000')
+
+    expect(AUTH_SESSION_COOKIE_NAME).toBe('better-auth.session_token')
+    expect(AUTH_COOKIE_NAMES).toEqual([
+      'better-auth.session_token',
+      'better-auth.session_data',
+      'better-auth.dont_remember',
+    ])
+    expect(getAuthCookieDeletionOptions()).toEqual({
       httpOnly: true,
       maxAge: 0,
       path: '/',

--- a/apps/tradinggoose/lib/auth/cookies.ts
+++ b/apps/tradinggoose/lib/auth/cookies.ts
@@ -1,3 +1,5 @@
+import { getBaseUrl } from '@/lib/urls/utils'
+
 const AUTH_COOKIE_BASE_NAMES = [
   'better-auth.session_token',
   'better-auth.session_data',
@@ -5,17 +7,14 @@ const AUTH_COOKIE_BASE_NAMES = [
 ] as const
 
 const SECURE_COOKIE_PREFIX = '__Secure-'
+const AUTH_COOKIE_PREFIX = getBaseUrl().startsWith('https://') ? SECURE_COOKIE_PREFIX : ''
+const AUTH_COOKIE_SECURE = AUTH_COOKIE_PREFIX === SECURE_COOKIE_PREFIX
 
-export const AUTH_COOKIE_NAMES = AUTH_COOKIE_BASE_NAMES.flatMap((name) => [
-  name,
-  `${SECURE_COOKIE_PREFIX}${name}`,
-])
+export const AUTH_SESSION_COOKIE_NAME = `${AUTH_COOKIE_PREFIX}better-auth.session_token`
 
-function isSecureAuthCookieName(name: string) {
-  return name.startsWith(SECURE_COOKIE_PREFIX)
-}
+export const AUTH_COOKIE_NAMES = AUTH_COOKIE_BASE_NAMES.map((name) => `${AUTH_COOKIE_PREFIX}${name}`)
 
-export function getAuthCookieDeletionOptions(name: string) {
+export function getAuthCookieDeletionOptions() {
   const options = {
     httpOnly: true,
     maxAge: 0,
@@ -23,5 +22,5 @@ export function getAuthCookieDeletionOptions(name: string) {
     sameSite: 'lax' as const,
   }
 
-  return isSecureAuthCookieName(name) ? { ...options, secure: true } : options
+  return AUTH_COOKIE_SECURE ? { ...options, secure: true } : options
 }

--- a/apps/tradinggoose/proxy.test.ts
+++ b/apps/tradinggoose/proxy.test.ts
@@ -1,11 +1,8 @@
 import { NextRequest } from 'next/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const mockGetSessionCookie = vi.fn()
-
-vi.mock('better-auth/cookies', () => ({
-  getSessionCookie: (...args: unknown[]) => mockGetSessionCookie(...args),
-}))
+const PLAIN_SESSION_COOKIE = 'better-auth.session_token=session-cookie'
+const SECURE_SESSION_COOKIE = '__Secure-better-auth.session_token=session-cookie'
 
 vi.mock('./lib/logs/console/logger', () => ({
   createLogger: () => ({
@@ -40,13 +37,10 @@ describe('proxy auth routing', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.resetModules()
-    mockGetSessionCookie.mockReturnValue(undefined)
     process.env.NEXT_PUBLIC_APP_URL = 'https://www.tradinggoose.ai'
   })
 
   it('uses the request host for localhost auth redirects instead of hosted-mode rewrites', async () => {
-    mockGetSessionCookie.mockReturnValue(undefined)
-
     const { proxy } = await import('./proxy')
     const response = await proxy(
       new NextRequest('http://localhost:3000/workspace/ws-1/dashboard?layoutId=layout-1')
@@ -67,8 +61,6 @@ describe('proxy auth routing', () => {
   ])(
     'redirects unprefixed %s routes to the default locale when no preference is present',
     async (_, url, location) => {
-      mockGetSessionCookie.mockReturnValue(undefined)
-
       const { proxy } = await import('./proxy')
       const response = await proxy(
         new NextRequest(url, {
@@ -91,8 +83,6 @@ describe('proxy auth routing', () => {
     ['privacy', 'http://localhost:3000/privacy', 'http://localhost:3000/zh/privacy'],
     ['login', 'http://localhost:3000/login', 'http://localhost:3000/zh/login'],
   ])('redirects anonymous unprefixed %s routes to the locale cookie', async (_, url, location) => {
-    mockGetSessionCookie.mockReturnValue(undefined)
-
     const { proxy } = await import('./proxy')
     const response = await proxy(
       new NextRequest(url, {
@@ -109,8 +99,6 @@ describe('proxy auth routing', () => {
   })
 
   it('redirects anonymous unprefixed protected routes using Accept-Language', async () => {
-    mockGetSessionCookie.mockReturnValue(undefined)
-
     const { proxy } = await import('./proxy')
     const response = await proxy(
       new NextRequest('http://localhost:3000/workspace/ws-1/dashboard', {
@@ -141,31 +129,59 @@ describe('proxy auth routing', () => {
     expect(response.headers.get('x-middleware-rewrite')).toBeNull()
   })
 
+  it('does not treat plain auth cookies as authenticated on HTTPS deployments', async () => {
+    const { proxy } = await import('./proxy')
+    const response = await proxy(
+      new NextRequest('https://www.tradinggoose.ai/workspace/ws-1/dashboard', {
+        headers: {
+          cookie: PLAIN_SESSION_COOKIE,
+        },
+      })
+    )
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe(
+      'https://www.tradinggoose.ai/en/login?callbackUrl=%2Fworkspace%2Fws-1%2Fdashboard'
+    )
+    expect(response.headers.get('x-middleware-rewrite')).toBeNull()
+  })
+
+  it('accepts the secure auth cookie on HTTPS protected routes', async () => {
+    const { proxy } = await import('./proxy')
+    const response = await proxy(
+      new NextRequest('https://www.tradinggoose.ai/en/workspace', {
+        headers: {
+          cookie: SECURE_SESSION_COOKIE,
+          'user-agent': 'vitest',
+        },
+      })
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('location')).toBeNull()
+    expect(response.cookies.get('NEXT_LOCALE')?.value).toBe('en')
+  })
+
   it('allows the default-locale reauth login route through while clearing cookies', async () => {
-    mockGetSessionCookie.mockReturnValue('stale-cookie')
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
 
     const { proxy } = await import('./proxy')
     const response = await proxy(
-      new NextRequest('http://localhost:3000/en/login?reauth=1&callbackUrl=%2Fworkspace%2Fws-1')
+      new NextRequest('http://localhost:3000/en/login?reauth=1&callbackUrl=%2Fworkspace%2Fws-1', {
+        headers: {
+          cookie: PLAIN_SESSION_COOKIE,
+        },
+      })
     )
 
     expect(response.status).toBe(200)
     expect(response.headers.get('location')).toBeNull()
     expect(response.cookies.get('NEXT_LOCALE')?.value).toBe('en')
     expect(response.cookies.get('better-auth.session_token')?.maxAge).toBe(0)
-    expect(response.cookies.get('__Secure-better-auth.session_token')).toMatchObject({
-      maxAge: 0,
-      secure: true,
-    })
-    expect(response.cookies.get('__Secure-better-auth.session_data')).toMatchObject({
-      maxAge: 0,
-      secure: true,
-    })
+    expect(response.cookies.get('__Secure-better-auth.session_token')).toBeUndefined()
   })
 
   it('preserves locale on the login route while keeping callback targets canonical', async () => {
-    mockGetSessionCookie.mockReturnValue(undefined)
-
     const { proxy } = await import('./proxy')
     const response = await proxy(
       new NextRequest('http://localhost:3000/es/workspace/ws-1/dashboard?layoutId=layout-1')
@@ -187,12 +203,13 @@ describe('proxy auth routing', () => {
     '/es/sso',
     '/es/error',
   ])('lets session-cookie auth route %s reach its page boundary', async (pathname) => {
-    mockGetSessionCookie.mockReturnValue('session-cookie')
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
 
     const { proxy } = await import('./proxy')
     const response = await proxy(
       new NextRequest(`http://localhost:3000${pathname}`, {
         headers: {
+          cookie: PLAIN_SESSION_COOKIE,
           'user-agent': 'vitest',
         },
       })
@@ -204,8 +221,6 @@ describe('proxy auth routing', () => {
   })
 
   it('keeps default-locale prefixed routes canonical', async () => {
-    mockGetSessionCookie.mockReturnValue(undefined)
-
     const { proxy } = await import('./proxy')
     const response = await proxy(
       new NextRequest('http://localhost:3000/en/login', {
@@ -222,8 +237,6 @@ describe('proxy auth routing', () => {
   })
 
   it('lets next-intl handle localized landing routes canonically', async () => {
-    mockGetSessionCookie.mockReturnValue(undefined)
-
     const { proxy } = await import('./proxy')
     const response = await proxy(
       new NextRequest('http://localhost:3000/es', {
@@ -243,13 +256,13 @@ describe('proxy auth routing', () => {
     ['root', 'http://localhost:3000/?source=nav', 'http://localhost:3000/es?source=nav'],
     ['workspace', 'http://localhost:3000/workspace', 'http://localhost:3000/es/workspace'],
   ])('redirects session-cookie %s requests to the request locale', async (_, url, location) => {
-    mockGetSessionCookie.mockReturnValue('session-cookie')
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
 
     const { proxy } = await import('./proxy')
     const response = await proxy(
       new NextRequest(url, {
         headers: {
-          cookie: 'NEXT_LOCALE=es',
+          cookie: `NEXT_LOCALE=es; ${PLAIN_SESSION_COOKIE}`,
           'user-agent': 'vitest',
         },
       })
@@ -261,13 +274,13 @@ describe('proxy auth routing', () => {
   })
 
   it('keeps session-cookie prefixed requests canonical to the URL locale', async () => {
-    mockGetSessionCookie.mockReturnValue('session-cookie')
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
 
     const { proxy } = await import('./proxy')
     const response = await proxy(
       new NextRequest('http://localhost:3000/en/workspace', {
         headers: {
-          cookie: 'NEXT_LOCALE=zh',
+          cookie: `NEXT_LOCALE=zh; ${PLAIN_SESSION_COOKIE}`,
           'user-agent': 'vitest',
         },
       })
@@ -279,14 +292,14 @@ describe('proxy auth routing', () => {
   })
 
   it('rewrites session-cookie POST protected requests with the canonical callback header', async () => {
-    mockGetSessionCookie.mockReturnValue('session-cookie')
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
 
     const { proxy } = await import('./proxy')
     const response = await proxy(
       new NextRequest('http://localhost:3000/workspace/ws-1/dashboard?layoutId=layout-1', {
         method: 'POST',
         headers: {
-          cookie: 'NEXT_LOCALE=es',
+          cookie: `NEXT_LOCALE=es; ${PLAIN_SESSION_COOKIE}`,
           'user-agent': 'vitest',
         },
       })
@@ -307,7 +320,7 @@ describe('proxy auth routing', () => {
   })
 
   it('does not rewrite localized API-shaped paths to canonical API routes', async () => {
-    mockGetSessionCookie.mockReturnValue('session-cookie')
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
 
     const { proxy } = await import('./proxy')
     const response = await proxy(
@@ -315,6 +328,7 @@ describe('proxy auth routing', () => {
         'http://localhost:3000/es/api/workspaces/invitations/invitation-1?token=abc',
         {
           headers: {
+            cookie: PLAIN_SESSION_COOKIE,
             'user-agent': 'vitest',
           },
         }
@@ -328,8 +342,6 @@ describe('proxy auth routing', () => {
   })
 
   it('exempts canonical webhook trigger API requests from suspicious user-agent filtering', async () => {
-    mockGetSessionCookie.mockReturnValue(undefined)
-
     const { proxy } = await import('./proxy')
     const response = await proxy(
       new NextRequest('http://localhost:3000/api/webhooks/trigger/webhook-1', {
@@ -345,8 +357,6 @@ describe('proxy auth routing', () => {
   })
 
   it('does not exempt localized API-shaped webhook paths from suspicious user-agent filtering', async () => {
-    mockGetSessionCookie.mockReturnValue(undefined)
-
     const { proxy } = await import('./proxy')
     const response = await proxy(
       new NextRequest('http://localhost:3000/es/api/webhooks/trigger/webhook-1', {
@@ -361,8 +371,6 @@ describe('proxy auth routing', () => {
   })
 
   it('rewrites default-locale markdown requests with the normalized content path', async () => {
-    mockGetSessionCookie.mockReturnValue(undefined)
-
     const { proxy } = await import('./proxy')
     const response = await proxy(
       new NextRequest('http://localhost:3000/en/terms', {

--- a/apps/tradinggoose/proxy.ts
+++ b/apps/tradinggoose/proxy.ts
@@ -1,4 +1,3 @@
-import { getSessionCookie } from 'better-auth/cookies'
 import { type NextRequest, NextResponse } from 'next/server'
 import createMiddleware from 'next-intl/middleware'
 import { appendHomepageDiscoveryLinks } from '@/lib/discovery/link-headers'
@@ -22,7 +21,11 @@ import {
 } from '@/i18n/utils'
 import { createLogger } from './lib/logs/console/logger'
 import { generateRuntimeCSP } from './lib/security/csp'
-import { AUTH_COOKIE_NAMES, getAuthCookieDeletionOptions } from './lib/auth/cookies'
+import {
+  AUTH_COOKIE_NAMES,
+  AUTH_SESSION_COOKIE_NAME,
+  getAuthCookieDeletionOptions,
+} from './lib/auth/cookies'
 
 const logger = createLogger('Proxy')
 const handleI18nRouting = createMiddleware(routing)
@@ -30,11 +33,12 @@ const handleI18nRouting = createMiddleware(routing)
 const REAUTH_CLEANUP_ROUTE = '/login'
 
 function clearAuthCookies(response: NextResponse) {
+  const deletionOptions = getAuthCookieDeletionOptions()
   AUTH_COOKIE_NAMES.forEach((name) => {
     response.cookies.set({
       name,
       value: '',
-      ...getAuthCookieDeletionOptions(name),
+      ...deletionOptions,
     })
   })
 }
@@ -294,7 +298,7 @@ function handleSecurityFiltering(request: NextRequest): NextResponse | null {
 export async function proxy(request: NextRequest) {
   const url = request.nextUrl
   const initialRoute = resolveLocaleRoute(url.pathname)
-  const hasSessionCookie = Boolean(getSessionCookie(request))
+  const hasSessionCookie = Boolean(request.cookies.get(AUTH_SESSION_COOKIE_NAME)?.value)
   const route = resolveCanonicalLocaleRoute(request, initialRoute)
   const { locale, pathname: normalizedPathname } = route
 


### PR DESCRIPTION
## Summary
- Select Better Auth cookie names from the configured app URL scheme.
- Use the computed session cookie name in `proxy.ts` instead of `getSessionCookie`.
- Clear only the active auth cookie namespace during reauth cleanup.
- Add coverage for HTTPS `__Secure-` cookies and HTTP localhost cookies.

## Why
HTTPS deployments should only treat `__Secure-better-auth.session_token` as the active session cookie, while local HTTP development should use the plain Better Auth cookie name. This prevents proxy auth routing from accepting the wrong cookie variant for the deployment mode.

## Affected Areas
- [x] `apps/tradinggoose`
- [ ] `apps/docs`
- [ ] `packages/*`
- [ ] Workflows / execution
- [ ] Realtime / sockets
- [ ] Market data / charting
- [ ] Dev tooling / CI / infra
- [ ] Documentation only
- [x] Other: Auth proxy / cookie cleanup

## Issue Links( if any )
None.

## Validation
```bash
cd apps/tradinggoose
bun run test lib/auth/cookies.test.ts proxy.test.ts
# 3 test files passed, 37 tests passed
```

## Risk / Rollout Notes
Auth routing is the main risk area. The behavior depends on `NEXT_PUBLIC_APP_URL` matching the deployed public scheme. Backout is to revert this PR.

## Config / Data Changes
- Env vars added or changed: None.
- Database schema or migration impact: None.
- External services or provider behavior changed: None; this aligns proxy behavior with Better Auth cookie naming.

## Screenshots / Video
Not applicable; no visible UI changes.

## Checklist
- [x] I kept the change focused and reviewed my own diff
- [x] I validated the change locally and documented the results above
- [x] I updated docs, examples, or copy if behavior/user-facing flows changed
- [x] I called out any env, schema, provider, or rollout impact
- [x] I did not include secrets, tokens, or private credentials in this PR