### PR TITLE
fix(auth): remove forced uncached session reads

### DIFF
--- a/apps/tradinggoose/app/[locale]/(auth)/auth-entry-pages.test.tsx
+++ b/apps/tradinggoose/app/[locale]/(auth)/auth-entry-pages.test.tsx
@@ -79,7 +79,7 @@ describe('localized auth entry pages', () => {
     mockGetRegistrationModeForRender.mockResolvedValue('open')
   })
 
-  it('redirects login to the localized workspace only after a real session check', async () => {
+  it('redirects login to the localized workspace when a session is present', async () => {
     mockGetSession.mockResolvedValue({
       user: {
         id: 'user-1',
@@ -89,12 +89,12 @@ describe('localized auth entry pages', () => {
     const LoginPage = (await import('./login/page')).default
 
     await expect(LoginPage()).rejects.toThrow('redirect:/es/workspace')
-    expect(mockGetSession).toHaveBeenCalledWith(undefined, { disableCookieCache: true })
+    expect(mockGetSession).toHaveBeenCalledWith()
     expect(mockGetOAuthProviderStatus).not.toHaveBeenCalled()
     expect(mockGetRegistrationModeForRender).not.toHaveBeenCalled()
   })
 
-  it('renders login when the real session check is empty', async () => {
+  it('renders login when the session check is empty', async () => {
     const LoginPage = (await import('./login/page')).default
 
     const result = await LoginPage()
@@ -105,7 +105,7 @@ describe('localized auth entry pages', () => {
     expect(mockRedirect).not.toHaveBeenCalled()
   })
 
-  it('redirects signup to the localized workspace only after a real session check', async () => {
+  it('redirects signup to the localized workspace when a session is present', async () => {
     mockGetSession.mockResolvedValue({
       user: {
         id: 'user-1',
@@ -117,12 +117,12 @@ describe('localized auth entry pages', () => {
     await expect(SignupPage({ searchParams: Promise.resolve({}) })).rejects.toThrow(
       'redirect:/es/workspace'
     )
-    expect(mockGetSession).toHaveBeenCalledWith(undefined, { disableCookieCache: true })
+    expect(mockGetSession).toHaveBeenCalledWith()
     expect(mockGetOAuthProviderStatus).not.toHaveBeenCalled()
     expect(mockGetRegistrationModeForRender).not.toHaveBeenCalled()
   })
 
-  it('renders signup when the real session check is empty', async () => {
+  it('renders signup when the session check is empty', async () => {
     const SignupPage = (await import('./signup/page')).default
 
     const result = await SignupPage({ searchParams: Promise.resolve({}) })

--- a/apps/tradinggoose/app/[locale]/(auth)/login/page.tsx
+++ b/apps/tradinggoose/app/[locale]/(auth)/login/page.tsx
@@ -11,7 +11,7 @@ export const dynamic = 'force-dynamic'
 export default async function LoginPage() {
   const [locale, session] = await Promise.all([
     getLocale(),
-    getSession(undefined, { disableCookieCache: true }),
+    getSession(),
   ])
 
   if (session?.user?.id) {

--- a/apps/tradinggoose/app/[locale]/(auth)/signup/page.tsx
+++ b/apps/tradinggoose/app/[locale]/(auth)/signup/page.tsx
@@ -17,7 +17,7 @@ export default async function SignupPage({
 }) {
   const [locale, session] = await Promise.all([
     getLocale(),
-    getSession(undefined, { disableCookieCache: true }),
+    getSession(),
   ])
 
   if (session?.user?.id) {

--- a/apps/tradinggoose/app/[locale]/workspace/[workspaceId]/layout.test.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/[workspaceId]/layout.test.tsx
@@ -78,7 +78,7 @@ describe('Workspace layout access guard', () => {
     expect(mockRedirect).toHaveBeenCalledWith(
       '/es/login?reauth=1&callbackUrl=%2Fworkspace%2Fws-1%2Ffiles%3FlayoutId%3Dlayout-1'
     )
-    expect(mockGetSession).toHaveBeenCalledWith(expect.any(Headers), { disableCookieCache: true })
+    expect(mockGetSession).toHaveBeenCalledWith(expect.any(Headers))
     expect(mockCheckWorkspaceAccess).not.toHaveBeenCalled()
   })
 

--- a/apps/tradinggoose/app/[locale]/workspace/[workspaceId]/layout.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/[workspaceId]/layout.tsx
@@ -15,7 +15,7 @@ export default async function WorkspaceLayout({
   const { locale: routeLocale, workspaceId } = await params
   const locale = routeLocale as LocaleCode
   const requestHeaders = await headers()
-  const session = await getSession(requestHeaders, { disableCookieCache: true })
+  const session = await getSession(requestHeaders)
   const userId = session?.user?.id
 
   if (!userId) {


### PR DESCRIPTION
## Summary
Removes forced uncached session reads from localized auth entry pages and workspace access guards.

The login, signup, and workspace layout server components now call `getSession()` / `getSession(requestHeaders)` without `disableCookieCache: true`, and the affected tests were updated to match the intended call shape.

## Why
Forced uncached session reads create unnecessary session lookups during auth redirects and workspace guard checks. Using the default session behavior keeps these routes aligned with the normal auth/session path while preserving redirect behavior for authenticated and unauthenticated users.

## Affected Areas
- [x] `apps/tradinggoose`
- [ ] `apps/docs`
- [ ] `packages/*`
- [ ] Workflows / execution
- [ ] Realtime / sockets
- [ ] Market data / charting
- [ ] Dev tooling / CI / infra
- [ ] Documentation only
- [ ] Other:

## Issue Links( if any )
None.

## Validation
```bash
cd apps/tradinggoose
bun run test -- "app/[locale]/(auth)/auth-entry-pages.test.tsx" "app/[locale]/workspace/[workspaceId]/layout.test.tsx"
# Result: 2 test files passed, 7 tests passed
```

## Risk / Rollout Notes
Low risk. This only removes the forced uncached session option from existing server-side auth checks. Backout is to restore `disableCookieCache: true` on the affected `getSession` calls if session freshness issues reappear.

## Config / Data Changes
- Env vars added or changed: None.
- Database schema or migration impact: None.
- External services or provider behavior changed: None.

## Screenshots / Video
Not applicable. No visible UI changes.

## Checklist
- [x] I kept the change focused and reviewed my own diff
- [x] I validated the change locally and documented the results above
- [x] I updated docs, examples, or copy if behavior/user-facing flows changed
- [x] I called out any env, schema, provider, or rollout impact
- [x] I did not include secrets, tokens, or private credentials in this PR