### PR TITLE
fix(auth): unify callback-safe session recovery

### DIFF
--- a/apps/tradinggoose/app/(auth)/auth-locale-redirects.test.tsx
+++ b/apps/tradinggoose/app/(auth)/auth-locale-redirects.test.tsx
@@ -259,9 +259,9 @@ describe('auth locale redirects', () => {
     }
   )
 
-  it('signs out through Better Auth when rendering a reauth login route', async () => {
+  it('blocks login controls while reauth cleanup is pending', async () => {
     testState.searchParams = new URLSearchParams('reauth=1&callbackUrl=%2Fworkspace')
-    mockSignOut.mockResolvedValue({ data: null })
+    mockSignOut.mockReturnValue(new Promise(() => {}))
 
     await renderWithLocale(
       'en',
@@ -274,6 +274,9 @@ describe('auth locale redirects', () => {
     )
 
     expect(mockSignOut).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('#email')).toBeNull()
+    expect(container.querySelector('#password')).toBeNull()
+    expect(container.querySelector('form')).toBeNull()
   })
 
   it('pushes the canonical signup path from the verify screen back action', async () => {

--- a/apps/tradinggoose/app/(auth)/auth-locale-redirects.test.tsx
+++ b/apps/tradinggoose/app/(auth)/auth-locale-redirects.test.tsx
@@ -110,7 +110,11 @@ vi.mock('@/components/ui/label', () => ({
     ...props
   }: React.LabelHTMLAttributes<HTMLLabelElement> & {
     children?: React.ReactNode
-  }) => <label {...props}>{children}</label>,
+  }) => (
+    <label {...props} htmlFor={props.htmlFor ?? 'test-field'}>
+      {children}
+    </label>
+  ),
 }))
 
 vi.mock('@/components/ui/dialog', () => ({
@@ -208,12 +212,6 @@ describe('auth locale redirects', () => {
     })
   }
 
-  async function flushEffects() {
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0))
-    })
-  }
-
   async function renderLogin(locale: 'en' | 'es' | 'zh' = 'en') {
     await renderWithLocale(
       locale,
@@ -269,39 +267,33 @@ describe('auth locale redirects', () => {
     }
   )
 
-  it('blocks login controls while reauth cleanup is pending', async () => {
+  it('keeps login controls available while reauth cleanup is pending', async () => {
     testState.searchParams = new URLSearchParams('reauth=1&callbackUrl=%2Fworkspace')
     mockSignOut.mockReturnValue(new Promise(() => {}))
 
     await renderLogin()
 
     expect(mockSignOut).toHaveBeenCalledTimes(1)
-    expect(container.querySelector('#email')).toBeNull()
-    expect(container.querySelector('#password')).toBeNull()
-    expect(container.querySelector('form')).toBeNull()
+    expect(container.querySelector('#email')).toBeInstanceOf(HTMLInputElement)
+    expect(container.querySelector('#password')).toBeInstanceOf(HTMLInputElement)
+    expect(container.querySelector('form')).toBeInstanceOf(HTMLFormElement)
   })
 
-  it('does not start duplicate sign-out requests when retrying reauth cleanup', async () => {
+  it('does not start duplicate sign-out requests while reauth cleanup is pending', async () => {
     testState.searchParams = new URLSearchParams('reauth=1&callbackUrl=%2Fworkspace')
-    mockSignOut.mockRejectedValueOnce(new Error('sign-out failed'))
+    mockSignInEmail.mockResolvedValue({ error: { code: 'FAILED_TO_CREATE_SESSION' } })
     mockSignOut.mockReturnValue(new Promise(() => {}))
 
     await renderLogin()
-    await flushEffects()
 
     expect(mockSignOut).toHaveBeenCalledTimes(1)
 
-    const retryButton = container.querySelector('button')
-    if (!(retryButton instanceof HTMLButtonElement)) {
-      throw new Error('Expected reauth retry button to render')
-    }
+    await setInputValue('#email', 'ada@example.com')
+    await setInputValue('#password', 'Password1!')
+    await submitRenderedForm()
 
-    await act(async () => {
-      retryButton.click()
-      await new Promise((resolve) => setTimeout(resolve, 0))
-    })
-
-    expect(mockSignOut).toHaveBeenCalledTimes(2)
+    expect(mockSignInEmail).toHaveBeenCalledTimes(1)
+    expect(mockSignOut).toHaveBeenCalledTimes(1)
   })
 
   it('runs reauth cleanup when direct login cannot create a session', async () => {
@@ -316,9 +308,10 @@ describe('auth locale redirects', () => {
 
     expect(mockSignInEmail).toHaveBeenCalledTimes(1)
     expect(mockSignOut).toHaveBeenCalledTimes(1)
-    expect(container.querySelector('#email')).toBeNull()
-    expect(container.querySelector('#password')).toBeNull()
-    expect(container.querySelector('form')).toBeNull()
+    expect(container.querySelector('#email')).toBeInstanceOf(HTMLInputElement)
+    expect(container.querySelector('#password')).toBeInstanceOf(HTMLInputElement)
+    expect(container.querySelector('form')).toBeInstanceOf(HTMLFormElement)
+    expect(container.textContent).toContain(getPublicCopy('en').auth.login.errors.unableToSignInNow)
   })
 
   it('keeps invalid credential failures on the login form', async () => {
@@ -334,7 +327,9 @@ describe('auth locale redirects', () => {
 
     expect(mockSignOut).not.toHaveBeenCalled()
     expect(container.querySelector('form')).toBeInstanceOf(HTMLFormElement)
-    expect(container.textContent).toContain(getPublicCopy('en').auth.login.errors.invalidCredentials)
+    expect(container.textContent).toContain(
+      getPublicCopy('en').auth.login.errors.invalidCredentials
+    )
   })
 
   it('pushes the canonical signup path from the verify screen back action', async () => {
@@ -356,11 +351,7 @@ describe('auth locale redirects', () => {
 
     await renderWithLocale(
       'en',
-      <VerifyContent
-        hasEmailService
-        isProduction={false}
-        isEmailVerificationEnabled
-      />
+      <VerifyContent hasEmailService isProduction={false} isEmailVerificationEnabled />
     )
 
     const backButton = Array.from(container.querySelectorAll('button')).find(

--- a/apps/tradinggoose/app/(auth)/auth-locale-redirects.test.tsx
+++ b/apps/tradinggoose/app/(auth)/auth-locale-redirects.test.tsx
@@ -268,7 +268,7 @@ describe('auth locale redirects', () => {
     }
   )
 
-  it('aborts a hanging reauth cleanup before direct login starts', async () => {
+  it('runs reauth cleanup on arrival and waits before direct login starts', async () => {
     vi.useFakeTimers()
     testState.searchParams = new URLSearchParams('reauth=1&callbackUrl=%2Fworkspace')
     const cleanupSignalRef: { current: AbortSignal | null } = { current: null }
@@ -280,7 +280,7 @@ describe('auth locale redirects', () => {
 
     await renderLogin()
 
-    expect(mockSignOut).not.toHaveBeenCalled()
+    expect(mockSignOut).toHaveBeenCalledTimes(1)
     expect(container.querySelector('form')).toBeInstanceOf(HTMLFormElement)
 
     await setInputValue('#email', 'ada@example.com')
@@ -288,7 +288,6 @@ describe('auth locale redirects', () => {
 
     await submitRenderedForm()
 
-    expect(mockSignOut).toHaveBeenCalledTimes(1)
     expect(mockSignInEmail).not.toHaveBeenCalled()
 
     await act(async () => {

--- a/apps/tradinggoose/app/(auth)/auth-locale-redirects.test.tsx
+++ b/apps/tradinggoose/app/(auth)/auth-locale-redirects.test.tsx
@@ -299,8 +299,13 @@ describe('auth locale redirects', () => {
     expect(mockSignInEmail).toHaveBeenCalledTimes(1)
   })
 
-  it('runs reauth cleanup when direct login cannot create a session', async () => {
-    mockSignInEmail.mockResolvedValue({ error: { code: 'FAILED_TO_CREATE_SESSION' } })
+  it.each([
+    'FAILED_TO_CREATE_SESSION',
+    'UNABLE_TO_CREATE_SESSION',
+    'FAILED_TO_GET_SESSION',
+    'SESSION_EXPIRED',
+  ])('runs reauth cleanup when direct login returns %s', async (errorCode) => {
+    mockSignInEmail.mockResolvedValue({ error: { code: errorCode } })
     mockSignOut.mockReturnValue(new Promise(() => {}))
 
     await renderLogin()

--- a/apps/tradinggoose/app/(auth)/auth-locale-redirects.test.tsx
+++ b/apps/tradinggoose/app/(auth)/auth-locale-redirects.test.tsx
@@ -208,6 +208,12 @@ describe('auth locale redirects', () => {
     })
   }
 
+  async function flushEffects() {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+  }
+
   async function renderLogin(locale: 'en' | 'es' | 'zh' = 'en') {
     await renderWithLocale(
       locale,
@@ -273,6 +279,29 @@ describe('auth locale redirects', () => {
     expect(container.querySelector('#email')).toBeNull()
     expect(container.querySelector('#password')).toBeNull()
     expect(container.querySelector('form')).toBeNull()
+  })
+
+  it('does not start duplicate sign-out requests when retrying reauth cleanup', async () => {
+    testState.searchParams = new URLSearchParams('reauth=1&callbackUrl=%2Fworkspace')
+    mockSignOut.mockRejectedValueOnce(new Error('sign-out failed'))
+    mockSignOut.mockReturnValue(new Promise(() => {}))
+
+    await renderLogin()
+    await flushEffects()
+
+    expect(mockSignOut).toHaveBeenCalledTimes(1)
+
+    const retryButton = container.querySelector('button')
+    if (!(retryButton instanceof HTMLButtonElement)) {
+      throw new Error('Expected reauth retry button to render')
+    }
+
+    await act(async () => {
+      retryButton.click()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(mockSignOut).toHaveBeenCalledTimes(2)
   })
 
   it('runs reauth cleanup when direct login cannot create a session', async () => {

--- a/apps/tradinggoose/app/(auth)/auth-locale-redirects.test.tsx
+++ b/apps/tradinggoose/app/(auth)/auth-locale-redirects.test.tsx
@@ -208,6 +208,18 @@ describe('auth locale redirects', () => {
     })
   }
 
+  async function renderLogin(locale: 'en' | 'es' | 'zh' = 'en') {
+    await renderWithLocale(
+      locale,
+      <LoginPage
+        githubAvailable={false}
+        googleAvailable={false}
+        isProduction={false}
+        registrationMode='open'
+      />
+    )
+  }
+
   it.each(['es', 'zh'] as const)(
     'pushes the canonical verify path after signup for %s',
     async (locale) => {
@@ -241,15 +253,7 @@ describe('auth locale redirects', () => {
     async (locale) => {
       mockSignInEmail.mockRejectedValue({ code: 'EMAIL_NOT_VERIFIED' })
 
-      await renderWithLocale(
-        locale,
-        <LoginPage
-          githubAvailable={false}
-          googleAvailable={false}
-          isProduction={false}
-          registrationMode='open'
-        />
-      )
+      await renderLogin(locale)
 
       await setInputValue('#email', 'ada@example.com')
       await setInputValue('#password', 'Password1!')
@@ -263,20 +267,45 @@ describe('auth locale redirects', () => {
     testState.searchParams = new URLSearchParams('reauth=1&callbackUrl=%2Fworkspace')
     mockSignOut.mockReturnValue(new Promise(() => {}))
 
-    await renderWithLocale(
-      'en',
-      <LoginPage
-        githubAvailable={false}
-        googleAvailable={false}
-        isProduction={false}
-        registrationMode='open'
-      />
-    )
+    await renderLogin()
 
     expect(mockSignOut).toHaveBeenCalledTimes(1)
     expect(container.querySelector('#email')).toBeNull()
     expect(container.querySelector('#password')).toBeNull()
     expect(container.querySelector('form')).toBeNull()
+  })
+
+  it('runs reauth cleanup when direct login cannot create a session', async () => {
+    mockSignInEmail.mockResolvedValue({ error: { code: 'FAILED_TO_CREATE_SESSION' } })
+    mockSignOut.mockReturnValue(new Promise(() => {}))
+
+    await renderLogin()
+
+    await setInputValue('#email', 'ada@example.com')
+    await setInputValue('#password', 'Password1!')
+    await submitRenderedForm()
+
+    expect(mockSignInEmail).toHaveBeenCalledTimes(1)
+    expect(mockSignOut).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('#email')).toBeNull()
+    expect(container.querySelector('#password')).toBeNull()
+    expect(container.querySelector('form')).toBeNull()
+  })
+
+  it('keeps invalid credential failures on the login form', async () => {
+    mockSignInEmail.mockResolvedValue({
+      error: { code: 'INVALID_CREDENTIALS', status: 401 },
+    })
+
+    await renderLogin()
+
+    await setInputValue('#email', 'ada@example.com')
+    await setInputValue('#password', 'wrong-password')
+    await submitRenderedForm()
+
+    expect(mockSignOut).not.toHaveBeenCalled()
+    expect(container.querySelector('form')).toBeInstanceOf(HTMLFormElement)
+    expect(container.textContent).toContain(getPublicCopy('en').auth.login.errors.invalidCredentials)
   })
 
   it('pushes the canonical signup path from the verify screen back action', async () => {

--- a/apps/tradinggoose/app/(auth)/auth-locale-redirects.test.tsx
+++ b/apps/tradinggoose/app/(auth)/auth-locale-redirects.test.tsx
@@ -170,6 +170,7 @@ describe('auth locale redirects', () => {
       root.unmount()
     })
     container.remove()
+    vi.useRealTimers()
     vi.restoreAllMocks()
     reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = false
   })
@@ -267,33 +268,36 @@ describe('auth locale redirects', () => {
     }
   )
 
-  it('keeps login controls available while reauth cleanup is pending', async () => {
+  it('aborts a hanging reauth cleanup before direct login starts', async () => {
+    vi.useFakeTimers()
     testState.searchParams = new URLSearchParams('reauth=1&callbackUrl=%2Fworkspace')
-    mockSignOut.mockReturnValue(new Promise(() => {}))
+    const cleanupSignalRef: { current: AbortSignal | null } = { current: null }
+    mockSignOut.mockImplementation((options) => {
+      cleanupSignalRef.current = options?.fetchOptions?.signal ?? null
+      return new Promise(() => {})
+    })
+    mockSignInEmail.mockResolvedValue({})
 
     await renderLogin()
 
-    expect(mockSignOut).toHaveBeenCalledTimes(1)
-    expect(container.querySelector('#email')).toBeInstanceOf(HTMLInputElement)
-    expect(container.querySelector('#password')).toBeInstanceOf(HTMLInputElement)
+    expect(mockSignOut).not.toHaveBeenCalled()
     expect(container.querySelector('form')).toBeInstanceOf(HTMLFormElement)
-  })
-
-  it('does not start duplicate sign-out requests while reauth cleanup is pending', async () => {
-    testState.searchParams = new URLSearchParams('reauth=1&callbackUrl=%2Fworkspace')
-    mockSignInEmail.mockResolvedValue({ error: { code: 'FAILED_TO_CREATE_SESSION' } })
-    mockSignOut.mockReturnValue(new Promise(() => {}))
-
-    await renderLogin()
-
-    expect(mockSignOut).toHaveBeenCalledTimes(1)
 
     await setInputValue('#email', 'ada@example.com')
     await setInputValue('#password', 'Password1!')
+
     await submitRenderedForm()
 
-    expect(mockSignInEmail).toHaveBeenCalledTimes(1)
     expect(mockSignOut).toHaveBeenCalledTimes(1)
+    expect(mockSignInEmail).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync()
+      await Promise.resolve()
+    })
+
+    expect(cleanupSignalRef.current?.aborted).toBe(true)
+    expect(mockSignInEmail).toHaveBeenCalledTimes(1)
   })
 
   it('runs reauth cleanup when direct login cannot create a session', async () => {
@@ -308,9 +312,6 @@ describe('auth locale redirects', () => {
 
     expect(mockSignInEmail).toHaveBeenCalledTimes(1)
     expect(mockSignOut).toHaveBeenCalledTimes(1)
-    expect(container.querySelector('#email')).toBeInstanceOf(HTMLInputElement)
-    expect(container.querySelector('#password')).toBeInstanceOf(HTMLInputElement)
-    expect(container.querySelector('form')).toBeInstanceOf(HTMLFormElement)
     expect(container.textContent).toContain(getPublicCopy('en').auth.login.errors.unableToSignInNow)
   })
 

--- a/apps/tradinggoose/app/(auth)/auth-provider-callbacks.test.tsx
+++ b/apps/tradinggoose/app/(auth)/auth-provider-callbacks.test.tsx
@@ -7,7 +7,7 @@ import { act } from 'react'
 import { NextIntlClientProvider } from 'next-intl'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { AUTH_ERROR_CALLBACK_COOKIE } from '@/lib/auth/auth-error-copy'
+import { getAuthErrorCallbackPath } from '@/lib/auth/auth-error-copy'
 import { getPublicCopy } from '@/i18n/public-copy'
 import { SocialLoginButtons } from './components/social-login-buttons'
 import SSOForm from './sso/sso-form'
@@ -108,7 +108,6 @@ describe('auth provider callback routing', () => {
     testState.searchParams = new URLSearchParams()
     mockSocialSignIn.mockResolvedValue({})
     mockSsoSignIn.mockResolvedValue({})
-    document.cookie = `${AUTH_ERROR_CALLBACK_COOKIE}=; path=/; max-age=0`
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -154,9 +153,8 @@ describe('auth provider callback routing', () => {
     expect(mockSocialSignIn).toHaveBeenCalledWith({
       provider,
       callbackURL: '/workspace',
-      errorCallbackURL: '/error',
+      errorCallbackURL: getAuthErrorCallbackPath('/workspace'),
     })
-    expect(document.cookie).toContain(`${AUTH_ERROR_CALLBACK_COOKIE}=%2Fworkspace`)
   })
 
   it('routes SSO callback failures to the auth error page', async () => {
@@ -194,8 +192,7 @@ describe('auth provider callback routing', () => {
     expect(mockSsoSignIn).toHaveBeenCalledWith({
       email: 'user@example.com',
       callbackURL: '/workspace',
-      errorCallbackURL: '/error',
+      errorCallbackURL: getAuthErrorCallbackPath('/workspace'),
     })
-    expect(document.cookie).toContain(`${AUTH_ERROR_CALLBACK_COOKIE}=%2Fworkspace`)
   })
 })

--- a/apps/tradinggoose/app/(auth)/auth-provider-callbacks.test.tsx
+++ b/apps/tradinggoose/app/(auth)/auth-provider-callbacks.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import type React from 'react'
+import { act } from 'react'
+import { NextIntlClientProvider } from 'next-intl'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getPublicCopy } from '@/i18n/public-copy'
+import { SocialLoginButtons } from './components/social-login-buttons'
+import SSOForm from './sso/sso-form'
+
+const mockSocialSignIn = vi.hoisted(() => vi.fn())
+const mockSsoSignIn = vi.hoisted(() => vi.fn())
+const testState = vi.hoisted(() => ({
+  searchParams: new URLSearchParams(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => ({
+    get: (key: string) => testState.searchParams.get(key),
+  }),
+}))
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children?: React.ReactNode
+    href: string
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock('@/lib/auth-client', () => ({
+  client: {
+    signIn: {
+      social: mockSocialSignIn,
+      sso: mockSsoSignIn,
+    },
+  },
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    children?: React.ReactNode
+  }) => <button {...props}>{children}</button>,
+}))
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}))
+
+vi.mock('@/components/ui/label', () => ({
+  Label: ({
+    children,
+    ...props
+  }: React.LabelHTMLAttributes<HTMLLabelElement> & {
+    children?: React.ReactNode
+  }) => (
+    <label {...props} htmlFor={props.htmlFor ?? 'test-field'}>
+      {children}
+    </label>
+  ),
+}))
+
+vi.mock('@/components/ui/alert', () => ({
+  Alert: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  AlertDescription: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/icons/icons', () => ({
+  GithubIcon: () => <span />,
+  GoogleIcon: () => <span />,
+}))
+
+vi.mock('@/app/(auth)/components/auth-page-header', () => ({
+  AuthPageHeader: () => null,
+}))
+
+vi.mock('@/app/(auth)/components/auth-waitlist-note', () => ({
+  AuthWaitlistNote: () => null,
+}))
+
+vi.mock('@/app/fonts/inter', () => ({
+  inter: { className: '' },
+}))
+
+describe('auth provider callback routing', () => {
+  let container: HTMLDivElement
+  let root: Root
+  const reactActEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean
+  }
+
+  beforeEach(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+    testState.searchParams = new URLSearchParams()
+    mockSocialSignIn.mockResolvedValue({})
+    mockSsoSignIn.mockResolvedValue({})
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+    vi.clearAllMocks()
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = false
+  })
+
+  it.each([
+    ['Google', 'google'],
+    ['GitHub', 'github'],
+  ])('routes %s OAuth callback failures to the auth error page', async (buttonText, provider) => {
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale='en' messages={getPublicCopy('en')}>
+          <SocialLoginButtons
+            githubAvailable
+            googleAvailable
+            callbackURL='/workspace'
+            isProduction
+          />
+        </NextIntlClientProvider>
+      )
+    })
+
+    const button = Array.from(container.querySelectorAll('button')).find((candidate) =>
+      candidate.textContent?.includes(buttonText)
+    )
+    if (!(button instanceof HTMLButtonElement)) {
+      throw new Error(`Expected ${buttonText} button to render`)
+    }
+
+    await act(async () => {
+      button.click()
+    })
+
+    expect(mockSocialSignIn).toHaveBeenCalledWith({
+      provider,
+      callbackURL: '/workspace',
+      errorCallbackURL: '/error',
+    })
+  })
+
+  it('routes SSO callback failures to the auth error page', async () => {
+    testState.searchParams = new URLSearchParams({ callbackUrl: '/workspace' })
+
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale='en' messages={getPublicCopy('en')}>
+          <SSOForm registrationMode='open' />
+        </NextIntlClientProvider>
+      )
+    })
+
+    const input = container.querySelector('input[name="email"]')
+    if (!(input instanceof HTMLInputElement)) {
+      throw new Error('Expected SSO email input to render')
+    }
+
+    const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+    valueSetter?.call(input, 'user@example.com')
+
+    await act(async () => {
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    const form = container.querySelector('form')
+    if (!(form instanceof HTMLFormElement)) {
+      throw new Error('Expected SSO form to render')
+    }
+
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    })
+
+    expect(mockSsoSignIn).toHaveBeenCalledWith({
+      email: 'user@example.com',
+      callbackURL: '/workspace',
+      errorCallbackURL: '/error',
+    })
+  })
+})

--- a/apps/tradinggoose/app/(auth)/auth-provider-callbacks.test.tsx
+++ b/apps/tradinggoose/app/(auth)/auth-provider-callbacks.test.tsx
@@ -7,6 +7,7 @@ import { act } from 'react'
 import { NextIntlClientProvider } from 'next-intl'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AUTH_ERROR_CALLBACK_COOKIE } from '@/lib/auth/auth-error-copy'
 import { getPublicCopy } from '@/i18n/public-copy'
 import { SocialLoginButtons } from './components/social-login-buttons'
 import SSOForm from './sso/sso-form'
@@ -107,6 +108,7 @@ describe('auth provider callback routing', () => {
     testState.searchParams = new URLSearchParams()
     mockSocialSignIn.mockResolvedValue({})
     mockSsoSignIn.mockResolvedValue({})
+    document.cookie = `${AUTH_ERROR_CALLBACK_COOKIE}=; path=/; max-age=0`
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -154,6 +156,7 @@ describe('auth provider callback routing', () => {
       callbackURL: '/workspace',
       errorCallbackURL: '/error',
     })
+    expect(document.cookie).toContain(`${AUTH_ERROR_CALLBACK_COOKIE}=%2Fworkspace`)
   })
 
   it('routes SSO callback failures to the auth error page', async () => {
@@ -193,5 +196,6 @@ describe('auth provider callback routing', () => {
       callbackURL: '/workspace',
       errorCallbackURL: '/error',
     })
+    expect(document.cookie).toContain(`${AUTH_ERROR_CALLBACK_COOKIE}=%2Fworkspace`)
   })
 })

--- a/apps/tradinggoose/app/(auth)/components/social-login-buttons.tsx
+++ b/apps/tradinggoose/app/(auth)/components/social-login-buttons.tsx
@@ -5,6 +5,7 @@ import { useMessages } from 'next-intl'
 import { GithubIcon, GoogleIcon } from '@/components/icons/icons'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
+import { rememberAuthErrorCallback } from '@/lib/auth/auth-error-copy'
 import { useAuthRedirectUrls } from '@/lib/auth/redirect-urls'
 import { client } from '@/lib/auth-client'
 import { createLogger } from '@/lib/logs/console/logger'
@@ -18,6 +19,7 @@ interface SocialLoginButtonsProps {
   googleAvailable: boolean
   callbackURL?: string
   isProduction: boolean
+  beforeSignIn?: () => Promise<void>
   children?: ReactNode
 }
 
@@ -26,6 +28,7 @@ export function SocialLoginButtons({
   googleAvailable,
   callbackURL,
   isProduction: _isProduction,
+  beforeSignIn,
   children,
 }: SocialLoginButtonsProps) {
   const [isGithubLoading, setIsGithubLoading] = useState(false)
@@ -83,6 +86,8 @@ export function SocialLoginButtons({
     setIsGithubLoading(true)
     setErrorMessage('')
     try {
+      await beforeSignIn?.()
+      rememberAuthErrorCallback(resolvedCallbackURL)
       const result = await client.signIn.social({
         provider: 'github',
         callbackURL: resolvedCallbackURL,
@@ -107,6 +112,8 @@ export function SocialLoginButtons({
     setIsGoogleLoading(true)
     setErrorMessage('')
     try {
+      await beforeSignIn?.()
+      rememberAuthErrorCallback(resolvedCallbackURL)
       const result = await client.signIn.social({
         provider: 'google',
         callbackURL: resolvedCallbackURL,

--- a/apps/tradinggoose/app/(auth)/components/social-login-buttons.tsx
+++ b/apps/tradinggoose/app/(auth)/components/social-login-buttons.tsx
@@ -5,7 +5,6 @@ import { useMessages } from 'next-intl'
 import { GithubIcon, GoogleIcon } from '@/components/icons/icons'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
-import { rememberAuthErrorCallback } from '@/lib/auth/auth-error-copy'
 import { useAuthRedirectUrls } from '@/lib/auth/redirect-urls'
 import { client } from '@/lib/auth-client'
 import { createLogger } from '@/lib/logs/console/logger'
@@ -39,7 +38,7 @@ export function SocialLoginButtons({
   const copy = useMessages()
   const socialCopy = copy.auth.social
   const resolvedCallbackURL = authRedirectUrls.providerCallbackPath(callbackURL)
-  const errorCallbackURL = authRedirectUrls.providerErrorPath('/error')
+  const errorCallbackURL = authRedirectUrls.providerErrorPath(resolvedCallbackURL)
 
   useEffect(() => {
     setMounted(true)
@@ -87,7 +86,6 @@ export function SocialLoginButtons({
     setErrorMessage('')
     try {
       await beforeSignIn?.()
-      rememberAuthErrorCallback(resolvedCallbackURL)
       const result = await client.signIn.social({
         provider: 'github',
         callbackURL: resolvedCallbackURL,
@@ -113,7 +111,6 @@ export function SocialLoginButtons({
     setErrorMessage('')
     try {
       await beforeSignIn?.()
-      rememberAuthErrorCallback(resolvedCallbackURL)
       const result = await client.signIn.social({
         provider: 'google',
         callbackURL: resolvedCallbackURL,

--- a/apps/tradinggoose/app/(auth)/components/social-login-buttons.tsx
+++ b/apps/tradinggoose/app/(auth)/components/social-login-buttons.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { type ReactNode, useEffect, useState } from 'react'
+import { useMessages } from 'next-intl'
 import { GithubIcon, GoogleIcon } from '@/components/icons/icons'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
@@ -8,7 +9,6 @@ import { useAuthRedirectUrls } from '@/lib/auth/redirect-urls'
 import { client } from '@/lib/auth-client'
 import { createLogger } from '@/lib/logs/console/logger'
 import { inter } from '@/app/fonts/inter'
-import { useMessages } from 'next-intl'
 import { formatTemplate } from '@/i18n/utils'
 
 const logger = createLogger('SocialLoginButtons')
@@ -36,6 +36,7 @@ export function SocialLoginButtons({
   const copy = useMessages()
   const socialCopy = copy.auth.social
   const resolvedCallbackURL = authRedirectUrls.providerCallbackPath(callbackURL)
+  const errorCallbackURL = authRedirectUrls.providerErrorPath('/error')
 
   useEffect(() => {
     setMounted(true)
@@ -85,6 +86,7 @@ export function SocialLoginButtons({
       const result = await client.signIn.social({
         provider: 'github',
         callbackURL: resolvedCallbackURL,
+        errorCallbackURL,
       })
 
       if (result?.error) {
@@ -108,6 +110,7 @@ export function SocialLoginButtons({
       const result = await client.signIn.social({
         provider: 'google',
         callbackURL: resolvedCallbackURL,
+        errorCallbackURL,
       })
 
       if (result?.error) {

--- a/apps/tradinggoose/app/(auth)/components/sso-login-button.tsx
+++ b/apps/tradinggoose/app/(auth)/components/sso-login-button.tsx
@@ -1,15 +1,16 @@
 'use client'
 
+import { useMessages } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { getEnv, isTruthy } from '@/lib/env'
 import { cn } from '@/lib/utils'
-import { useMessages } from 'next-intl'
 import { useRouter } from '@/i18n/navigation'
 import { normalizeCallbackUrl } from '@/i18n/utils'
 
 interface SSOLoginButtonProps {
   callbackURL?: string
   className?: string
+  beforeSignIn?: () => Promise<void>
   // Visual variant for button styling and placement contexts
   // - 'primary' matches the main auth action button style
   // - 'outline' matches social provider buttons
@@ -19,6 +20,7 @@ interface SSOLoginButtonProps {
 export function SSOLoginButton({
   callbackURL,
   className,
+  beforeSignIn,
   variant = 'outline',
 }: SSOLoginButtonProps) {
   const router = useRouter()
@@ -31,7 +33,8 @@ export function SSOLoginButton({
 
   const resolvedCallbackURL = callbackURL ? normalizeCallbackUrl(callbackURL) : undefined
 
-  const handleSSOClick = () => {
+  const handleSSOClick = async () => {
+    await beforeSignIn?.()
     const ssoUrl = `/sso${
       resolvedCallbackURL ? `?callbackUrl=${encodeURIComponent(resolvedCallbackURL)}` : ''
     }`

--- a/apps/tradinggoose/app/(auth)/login/login-form.tsx
+++ b/apps/tradinggoose/app/(auth)/login/login-form.tsx
@@ -15,7 +15,6 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { normalizeAuthErrorCode } from '@/lib/auth/auth-error-copy'
-import { handleAuthError } from '@/lib/auth/auth-error-handler'
 import { useAuthRedirectUrls } from '@/lib/auth/redirect-urls'
 import { client } from '@/lib/auth-client'
 import { quickValidateEmail } from '@/lib/email/validation'
@@ -28,7 +27,7 @@ import { AuthWaitlistNote } from '@/app/(auth)/components/auth-waitlist-note'
 import { SocialLoginButtons } from '@/app/(auth)/components/social-login-buttons'
 import { SSOLoginButton } from '@/app/(auth)/components/sso-login-button'
 import { inter } from '@/app/fonts/inter'
-import { Link, usePathname, useRouter } from '@/i18n/navigation'
+import { Link, useRouter } from '@/i18n/navigation'
 import { normalizeCallbackUrl } from '@/i18n/utils'
 
 const logger = createLogger('LoginForm')
@@ -93,7 +92,6 @@ export default function LoginPage({
   registrationMode: RegistrationMode
 }) {
   const router = useRouter()
-  const pathname = usePathname()
   const authRedirectUrls = useAuthRedirectUrls()
   const copy = useMessages()
   const loginCopy = copy.auth.login
@@ -302,19 +300,8 @@ export default function LoginPage({
             const errorMessage: string[] = []
             const resolvedMessage = resolveLoginErrorMessage(ctx.error)
 
-            const status =
-              (ctx.error as any)?.status ??
-              (ctx.error as any)?.statusCode ??
-              (ctx.error as any)?.response?.status
-
             if (resolvedMessage === null) {
               return
-            }
-
-            // If the backend rejected the request due to an invalid/expired auth state, hard reset auth.
-            if (status === 401) {
-              handleAuthError('login-unauthorized', pathname).catch(() => {})
-              errorMessage.push(loginCopy.errors.sessionExpired)
             }
 
             if (resolvedMessage) {

--- a/apps/tradinggoose/app/(auth)/login/login-form.tsx
+++ b/apps/tradinggoose/app/(auth)/login/login-form.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Eye, EyeOff } from 'lucide-react'
 import { useSearchParams } from 'next/navigation'
 import { useMessages } from 'next-intl'
@@ -122,6 +122,20 @@ export default function LoginPage({
   const [emailErrors, setEmailErrors] = useState<string[]>([])
   const [showEmailValidationError, setShowEmailValidationError] = useState(false)
   const isReauth = searchParams.get('reauth') === '1'
+  const [isReauthCleaned, setIsReauthCleaned] = useState(!isReauth)
+  const [reauthCleanupFailed, setReauthCleanupFailed] = useState(false)
+
+  const runReauthCleanup = useCallback(async () => {
+    setReauthCleanupFailed(false)
+
+    try {
+      await client.signOut()
+      setIsReauthCleaned(true)
+    } catch (error) {
+      logger.warn('Reauth sign-out failed', { error })
+      setReauthCleanupFailed(true)
+    }
+  }, [])
 
   useEffect(() => {
     if (searchParams) {
@@ -145,14 +159,10 @@ export default function LoginPage({
   }, [searchParams])
 
   useEffect(() => {
-    if (!isReauth) {
-      return
+    if (isReauth && !isReauthCleaned && !reauthCleanupFailed) {
+      void runReauthCleanup()
     }
-
-    client.signOut().catch((error) => {
-      logger.warn('Reauth sign-out failed', { error })
-    })
-  }, [isReauth])
+  }, [isReauth, isReauthCleaned, reauthCleanupFailed, runReauthCleanup])
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -431,6 +441,34 @@ export default function LoginPage({
     ? `/signup?invite_flow=true&callbackUrl=${encodeURIComponent(callbackUrl)}`
     : getAuthRegistrationHref(registrationMode)
   const registrationLabel = isInviteFlow ? commonCopy.signUp : authRegistrationLabel
+
+  if (!isReauthCleaned) {
+    return (
+      <>
+        <AuthPageHeader
+          eyebrow={loginCopy.eyebrow}
+          title={loginCopy.title}
+          description={loginCopy.description}
+        />
+
+        <div className={`${inter.className} mt-8 space-y-3`}>
+          <Button
+            type='button'
+            className={primaryButtonClasses}
+            disabled={!reauthCleanupFailed}
+            onClick={() => {
+              void runReauthCleanup()
+            }}
+          >
+            {reauthCleanupFailed ? commonCopy.signIn : commonCopy.loading}
+          </Button>
+          {reauthCleanupFailed ? (
+            <p className='text-center text-red-400 text-sm'>{loginCopy.errors.unableToSignInNow}</p>
+          ) : null}
+        </div>
+      </>
+    )
+  }
 
   return (
     <>

--- a/apps/tradinggoose/app/(auth)/login/login-form.tsx
+++ b/apps/tradinggoose/app/(auth)/login/login-form.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Eye, EyeOff } from 'lucide-react'
 import { useSearchParams } from 'next/navigation'
 import { useMessages } from 'next-intl'
@@ -124,8 +124,14 @@ export default function LoginPage({
   const isReauth = searchParams.get('reauth') === '1'
   const [isReauthCleaned, setIsReauthCleaned] = useState(!isReauth)
   const [reauthCleanupFailed, setReauthCleanupFailed] = useState(false)
+  const isReauthCleanupRunningRef = useRef(false)
 
   const runReauthCleanup = useCallback(async () => {
+    if (isReauthCleanupRunningRef.current) {
+      return
+    }
+
+    isReauthCleanupRunningRef.current = true
     setReauthCleanupFailed(false)
 
     try {
@@ -134,6 +140,8 @@ export default function LoginPage({
     } catch (error) {
       logger.warn('Reauth sign-out failed', { error })
       setReauthCleanupFailed(true)
+    } finally {
+      isReauthCleanupRunningRef.current = false
     }
   }, [])
 

--- a/apps/tradinggoose/app/(auth)/login/login-form.tsx
+++ b/apps/tradinggoose/app/(auth)/login/login-form.tsx
@@ -137,6 +137,11 @@ export default function LoginPage({
     }
   }, [])
 
+  const startReauthCleanup = useCallback(() => {
+    setIsReauthCleaned(false)
+    void runReauthCleanup()
+  }, [runReauthCleanup])
+
   useEffect(() => {
     if (searchParams) {
       const callback = searchParams.get('callbackUrl')
@@ -201,6 +206,15 @@ export default function LoginPage({
     setShowValidationError(false)
   }
 
+  const isSessionCreationError = (error: any) =>
+    [
+      error?.code,
+      error?.error,
+      error?.message,
+      error?.response?.data?.error,
+      error?.response?.data?.message,
+    ].some((value) => normalizeAuthErrorCode(value) === 'FAILED_TO_CREATE_SESSION')
+
   const resolveLoginErrorMessage = (error: any) => {
     const rawMessage =
       error?.message ??
@@ -246,9 +260,6 @@ export default function LoginPage({
     }
     if (authErrorCode === 'EMAIL_PASSWORD_DISABLED') {
       return loginCopy.errors.emailPasswordDisabled
-    }
-    if (authErrorCode === 'FAILED_TO_CREATE_SESSION') {
-      return loginCopy.errors.failedToCreateSession
     }
     if (authErrorCode === 'TOO_MANY_ATTEMPTS' || searchable.includes('too many attempts')) {
       return loginCopy.errors.tooManyAttempts
@@ -298,6 +309,7 @@ export default function LoginPage({
     }
 
     try {
+      let requiresReauthCleanup = false
       const result = await client.signIn.email(
         {
           email,
@@ -307,6 +319,11 @@ export default function LoginPage({
         {
           onError: (ctx) => {
             console.error('Login error:', ctx.error)
+            if (isSessionCreationError(ctx.error)) {
+              requiresReauthCleanup = true
+              return
+            }
+
             const errorMessage: string[] = []
             const resolvedMessage = resolveLoginErrorMessage(ctx.error)
 
@@ -329,6 +346,12 @@ export default function LoginPage({
       )
 
       if (!result || result.error) {
+        if (requiresReauthCleanup || isSessionCreationError(result?.error)) {
+          startReauthCleanup()
+          setIsLoading(false)
+          return
+        }
+
         const message =
           resolveLoginErrorMessage(result?.error) ?? loginCopy.errors.unableToSignInNow
 
@@ -343,6 +366,10 @@ export default function LoginPage({
           sessionStorage.setItem('verificationEmail', email)
         }
         router.push('/verify')
+        return
+      }
+      if (isSessionCreationError(err)) {
+        startReauthCleanup()
         return
       }
 

--- a/apps/tradinggoose/app/(auth)/login/login-form.tsx
+++ b/apps/tradinggoose/app/(auth)/login/login-form.tsx
@@ -122,8 +122,6 @@ export default function LoginPage({
   const [emailErrors, setEmailErrors] = useState<string[]>([])
   const [showEmailValidationError, setShowEmailValidationError] = useState(false)
   const isReauth = searchParams.get('reauth') === '1'
-  const [isReauthCleaned, setIsReauthCleaned] = useState(!isReauth)
-  const [reauthCleanupFailed, setReauthCleanupFailed] = useState(false)
   const isReauthCleanupRunningRef = useRef(false)
 
   const runReauthCleanup = useCallback(async () => {
@@ -132,23 +130,15 @@ export default function LoginPage({
     }
 
     isReauthCleanupRunningRef.current = true
-    setReauthCleanupFailed(false)
 
     try {
       await client.signOut()
-      setIsReauthCleaned(true)
     } catch (error) {
       logger.warn('Reauth sign-out failed', { error })
-      setReauthCleanupFailed(true)
     } finally {
       isReauthCleanupRunningRef.current = false
     }
   }, [])
-
-  const startReauthCleanup = useCallback(() => {
-    setIsReauthCleaned(false)
-    void runReauthCleanup()
-  }, [runReauthCleanup])
 
   useEffect(() => {
     if (searchParams) {
@@ -172,10 +162,10 @@ export default function LoginPage({
   }, [searchParams])
 
   useEffect(() => {
-    if (isReauth && !isReauthCleaned && !reauthCleanupFailed) {
+    if (isReauth) {
       void runReauthCleanup()
     }
-  }, [isReauth, isReauthCleaned, reauthCleanupFailed, runReauthCleanup])
+  }, [isReauth, runReauthCleanup])
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -221,7 +211,10 @@ export default function LoginPage({
       error?.message,
       error?.response?.data?.error,
       error?.response?.data?.message,
-    ].some((value) => normalizeAuthErrorCode(value) === 'FAILED_TO_CREATE_SESSION')
+    ].some((value) => {
+      const code = normalizeAuthErrorCode(value)
+      return code === 'FAILED_TO_CREATE_SESSION' || code === 'UNABLE_TO_CREATE_SESSION'
+    })
 
   const resolveLoginErrorMessage = (error: any) => {
     const rawMessage =
@@ -355,7 +348,9 @@ export default function LoginPage({
 
       if (!result || result.error) {
         if (requiresReauthCleanup || isSessionCreationError(result?.error)) {
-          startReauthCleanup()
+          void runReauthCleanup()
+          setPasswordErrors([loginCopy.errors.unableToSignInNow])
+          setShowValidationError(true)
           setIsLoading(false)
           return
         }
@@ -377,7 +372,9 @@ export default function LoginPage({
         return
       }
       if (isSessionCreationError(err)) {
-        startReauthCleanup()
+        void runReauthCleanup()
+        setPasswordErrors([loginCopy.errors.unableToSignInNow])
+        setShowValidationError(true)
         return
       }
 
@@ -476,34 +473,6 @@ export default function LoginPage({
     ? `/signup?invite_flow=true&callbackUrl=${encodeURIComponent(callbackUrl)}`
     : getAuthRegistrationHref(registrationMode)
   const registrationLabel = isInviteFlow ? commonCopy.signUp : authRegistrationLabel
-
-  if (!isReauthCleaned) {
-    return (
-      <>
-        <AuthPageHeader
-          eyebrow={loginCopy.eyebrow}
-          title={loginCopy.title}
-          description={loginCopy.description}
-        />
-
-        <div className={`${inter.className} mt-8 space-y-3`}>
-          <Button
-            type='button'
-            className={primaryButtonClasses}
-            disabled={!reauthCleanupFailed}
-            onClick={() => {
-              void runReauthCleanup()
-            }}
-          >
-            {reauthCleanupFailed ? commonCopy.signIn : commonCopy.loading}
-          </Button>
-          {reauthCleanupFailed ? (
-            <p className='text-center text-red-400 text-sm'>{loginCopy.errors.unableToSignInNow}</p>
-          ) : null}
-        </div>
-      </>
-    )
-  }
 
   return (
     <>

--- a/apps/tradinggoose/app/(auth)/login/login-form.tsx
+++ b/apps/tradinggoose/app/(auth)/login/login-form.tsx
@@ -189,6 +189,9 @@ export default function LoginPage({
 
   useEffect(() => {
     shouldRunReauthCleanupRef.current = isReauth
+    if (isReauth) {
+      void runReauthCleanup()
+    }
   }, [isReauth])
 
   useEffect(() => {

--- a/apps/tradinggoose/app/(auth)/login/login-form.tsx
+++ b/apps/tradinggoose/app/(auth)/login/login-form.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Eye, EyeOff } from 'lucide-react'
 import { useSearchParams } from 'next/navigation'
 import { useMessages } from 'next-intl'
@@ -126,7 +126,7 @@ export default function LoginPage({
   const shouldRunReauthCleanupRef = useRef(isReauth)
   const reauthCleanupPromiseRef = useRef<Promise<void> | null>(null)
 
-  function runReauthCleanup() {
+  const runReauthCleanup = useCallback(() => {
     if (reauthCleanupPromiseRef.current) {
       return reauthCleanupPromiseRef.current
     }
@@ -158,13 +158,13 @@ export default function LoginPage({
 
     reauthCleanupPromiseRef.current = cleanupPromise
     return cleanupPromise
-  }
+  }, [])
 
-  async function prepareAuthStart() {
+  const prepareAuthStart = useCallback(async () => {
     if (shouldRunReauthCleanupRef.current || reauthCleanupPromiseRef.current) {
       await runReauthCleanup()
     }
-  }
+  }, [runReauthCleanup])
 
   useEffect(() => {
     if (searchParams) {
@@ -192,7 +192,7 @@ export default function LoginPage({
     if (isReauth) {
       void runReauthCleanup()
     }
-  }, [isReauth])
+  }, [isReauth, runReauthCleanup])
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/apps/tradinggoose/app/(auth)/login/login-form.tsx
+++ b/apps/tradinggoose/app/(auth)/login/login-form.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { normalizeAuthErrorCode } from '@/lib/auth/auth-error-copy'
+import { isSessionRecoveryAuthError, normalizeAuthErrorCode } from '@/lib/auth/auth-error-copy'
 import { useAuthRedirectUrls } from '@/lib/auth/redirect-urls'
 import { client } from '@/lib/auth-client'
 import { quickValidateEmail } from '@/lib/email/validation'
@@ -231,7 +231,7 @@ export default function LoginPage({
     setShowValidationError(false)
   }
 
-  const isSessionCreationError = (error: any) =>
+  const isSessionRecoveryError = (error: any) =>
     [
       error?.code,
       error?.error,
@@ -239,8 +239,7 @@ export default function LoginPage({
       error?.response?.data?.error,
       error?.response?.data?.message,
     ].some((value) => {
-      const code = normalizeAuthErrorCode(value)
-      return code === 'FAILED_TO_CREATE_SESSION' || code === 'UNABLE_TO_CREATE_SESSION'
+      return isSessionRecoveryAuthError(value)
     })
 
   const resolveLoginErrorMessage = (error: any) => {
@@ -349,7 +348,7 @@ export default function LoginPage({
         {
           onError: (ctx) => {
             console.error('Login error:', ctx.error)
-            if (isSessionCreationError(ctx.error)) {
+            if (isSessionRecoveryError(ctx.error)) {
               requiresReauthCleanup = true
               return
             }
@@ -376,7 +375,7 @@ export default function LoginPage({
       )
 
       if (!result || result.error) {
-        if (requiresReauthCleanup || isSessionCreationError(result?.error)) {
+        if (requiresReauthCleanup || isSessionRecoveryError(result?.error)) {
           shouldRunReauthCleanupRef.current = true
           void runReauthCleanup()
           setPasswordErrors([loginCopy.errors.unableToSignInNow])
@@ -401,7 +400,7 @@ export default function LoginPage({
         router.push('/verify')
         return
       }
-      if (isSessionCreationError(err)) {
+      if (isSessionRecoveryError(err)) {
         shouldRunReauthCleanupRef.current = true
         void runReauthCleanup()
         setPasswordErrors([loginCopy.errors.unableToSignInNow])

--- a/apps/tradinggoose/app/(auth)/login/login-form.tsx
+++ b/apps/tradinggoose/app/(auth)/login/login-form.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Eye, EyeOff } from 'lucide-react'
 import { useSearchParams } from 'next/navigation'
 import { useMessages } from 'next-intl'
@@ -31,6 +31,7 @@ import { Link, useRouter } from '@/i18n/navigation'
 import { normalizeCallbackUrl } from '@/i18n/utils'
 
 const logger = createLogger('LoginForm')
+const REAUTH_CLEANUP_TIMEOUT_MS = 4000
 
 const validateEmailField = (
   emailValue: string,
@@ -122,23 +123,48 @@ export default function LoginPage({
   const [emailErrors, setEmailErrors] = useState<string[]>([])
   const [showEmailValidationError, setShowEmailValidationError] = useState(false)
   const isReauth = searchParams.get('reauth') === '1'
-  const isReauthCleanupRunningRef = useRef(false)
+  const shouldRunReauthCleanupRef = useRef(isReauth)
+  const reauthCleanupPromiseRef = useRef<Promise<void> | null>(null)
 
-  const runReauthCleanup = useCallback(async () => {
-    if (isReauthCleanupRunningRef.current) {
-      return
+  function runReauthCleanup() {
+    if (reauthCleanupPromiseRef.current) {
+      return reauthCleanupPromiseRef.current
     }
 
-    isReauthCleanupRunningRef.current = true
+    const abortController = new AbortController()
+    let timeoutId: ReturnType<typeof setTimeout> | null = null
+    const signOutPromise = client
+      .signOut({ fetchOptions: { signal: abortController.signal } })
+      .then(() => undefined)
+      .catch((error) => {
+        if (!abortController.signal.aborted) {
+          logger.warn('Reauth sign-out failed', { error })
+        }
+      })
+    const timeoutPromise = new Promise<void>((resolve) => {
+      timeoutId = setTimeout(() => {
+        abortController.abort()
+        resolve()
+      }, REAUTH_CLEANUP_TIMEOUT_MS)
+    })
 
-    try {
-      await client.signOut()
-    } catch (error) {
-      logger.warn('Reauth sign-out failed', { error })
-    } finally {
-      isReauthCleanupRunningRef.current = false
+    const cleanupPromise = Promise.race([signOutPromise, timeoutPromise]).finally(() => {
+      if (timeoutId) {
+        clearTimeout(timeoutId)
+      }
+      shouldRunReauthCleanupRef.current = false
+      reauthCleanupPromiseRef.current = null
+    })
+
+    reauthCleanupPromiseRef.current = cleanupPromise
+    return cleanupPromise
+  }
+
+  async function prepareAuthStart() {
+    if (shouldRunReauthCleanupRef.current || reauthCleanupPromiseRef.current) {
+      await runReauthCleanup()
     }
-  }, [])
+  }
 
   useEffect(() => {
     if (searchParams) {
@@ -162,10 +188,8 @@ export default function LoginPage({
   }, [searchParams])
 
   useEffect(() => {
-    if (isReauth) {
-      void runReauthCleanup()
-    }
-  }, [isReauth, runReauthCleanup])
+    shouldRunReauthCleanupRef.current = isReauth
+  }, [isReauth])
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -310,6 +334,8 @@ export default function LoginPage({
     }
 
     try {
+      await prepareAuthStart()
+
       let requiresReauthCleanup = false
       const result = await client.signIn.email(
         {
@@ -348,6 +374,7 @@ export default function LoginPage({
 
       if (!result || result.error) {
         if (requiresReauthCleanup || isSessionCreationError(result?.error)) {
+          shouldRunReauthCleanupRef.current = true
           void runReauthCleanup()
           setPasswordErrors([loginCopy.errors.unableToSignInNow])
           setShowValidationError(true)
@@ -372,6 +399,7 @@ export default function LoginPage({
         return
       }
       if (isSessionCreationError(err)) {
+        shouldRunReauthCleanupRef.current = true
         void runReauthCleanup()
         setPasswordErrors([loginCopy.errors.unableToSignInNow])
         setShowValidationError(true)
@@ -592,8 +620,15 @@ export default function LoginPage({
             githubAvailable={githubAvailable}
             isProduction={isProduction}
             callbackURL={callbackUrl}
+            beforeSignIn={prepareAuthStart}
           >
-            {ssoEnabled && <SSOLoginButton callbackURL={callbackUrl} variant='outline' />}
+            {ssoEnabled && (
+              <SSOLoginButton
+                callbackURL={callbackUrl}
+                variant='outline'
+                beforeSignIn={prepareAuthStart}
+              />
+            )}
           </SocialLoginButtons>
         </div>
       )}

--- a/apps/tradinggoose/app/(auth)/sso/sso-form.tsx
+++ b/apps/tradinggoose/app/(auth)/sso/sso-form.tsx
@@ -2,22 +2,22 @@
 
 import { useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
+import { useMessages } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { normalizeAuthErrorCode } from '@/lib/auth/auth-error-copy'
 import { useAuthRedirectUrls } from '@/lib/auth/redirect-urls'
 import { client } from '@/lib/auth-client'
 import { quickValidateEmail } from '@/lib/email/validation'
-import { normalizeAuthErrorCode } from '@/lib/auth/auth-error-copy'
 import { createLogger } from '@/lib/logs/console/logger'
 import { getAuthRegistrationHref, type RegistrationMode } from '@/lib/registration/shared'
 import { cn } from '@/lib/utils'
-import { Link } from '@/i18n/navigation'
-import { useMessages } from 'next-intl'
-import { normalizeCallbackUrl } from '@/i18n/utils'
 import { AuthPageHeader } from '@/app/(auth)/components/auth-page-header'
 import { AuthWaitlistNote } from '@/app/(auth)/components/auth-waitlist-note'
 import { inter } from '@/app/fonts/inter'
+import { Link } from '@/i18n/navigation'
+import { normalizeCallbackUrl } from '@/i18n/utils'
 
 const logger = createLogger('SSOForm')
 
@@ -81,24 +81,8 @@ export default function SSOForm({ registrationMode }: { registrationMode: Regist
       if (emailParam) {
         setEmail(emailParam)
       }
-
-      const error = searchParams.get('error')
-      if (error) {
-        const errorMessages: Record<string, string> = {
-          account_not_found: ssoCopy.errors.accountNotFound,
-          sso_failed: ssoCopy.errors.ssoFailed,
-          invalid_provider: ssoCopy.errors.providerNotConfigured,
-        }
-        setEmailErrors([errorMessages[error] || ssoCopy.errors.ssoFailed])
-        setShowEmailValidationError(true)
-      }
     }
-  }, [
-    searchParams,
-    ssoCopy.errors.accountNotFound,
-    ssoCopy.errors.providerNotConfigured,
-    ssoCopy.errors.ssoFailed,
-  ])
+  }, [searchParams])
 
   const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newEmail = e.target.value
@@ -136,9 +120,7 @@ export default function SSOForm({ registrationMode }: { registrationMode: Regist
       await client.signIn.sso({
         email: emailValue,
         callbackURL: authRedirectUrls.providerCallbackPath(callbackUrl),
-        errorCallbackURL: authRedirectUrls.providerErrorPath(
-          `/sso?error=sso_failed&callbackUrl=${callbackUrlParam}`
-        ),
+        errorCallbackURL: authRedirectUrls.providerErrorPath('/error'),
       })
     } catch (err) {
       logger.error('SSO sign-in failed', { error: err, email: emailValue })
@@ -252,14 +234,14 @@ export default function SSOForm({ registrationMode }: { registrationMode: Regist
       )}
 
       <div
-        className={`${inter.className} text-muted-foreground absolute right-0 bottom-0 left-0 px-8 pb-8 text-center font-[340] text-[13px] leading-relaxed sm:px-8 md:px-[44px]`}
+        className={`${inter.className} absolute right-0 bottom-0 left-0 px-8 pb-8 text-center font-[340] text-[13px] text-muted-foreground leading-relaxed sm:px-8 md:px-[44px]`}
       >
         {commonCopy.termsLeadSigningIn}{' '}
         <Link
           href='/terms'
           target='_blank'
           rel='noopener noreferrer'
-          className='hover:text-primary underline underline-offset-4'
+          className='underline underline-offset-4 hover:text-primary'
         >
           {commonCopy.termsOfService}
         </Link>{' '}
@@ -268,7 +250,7 @@ export default function SSOForm({ registrationMode }: { registrationMode: Regist
           href='/privacy'
           target='_blank'
           rel='noopener noreferrer'
-          className='hover:text-primary underline underline-offset-4'
+          className='underline underline-offset-4 hover:text-primary'
         >
           {commonCopy.privacyPolicy}
         </Link>

--- a/apps/tradinggoose/app/(auth)/sso/sso-form.tsx
+++ b/apps/tradinggoose/app/(auth)/sso/sso-form.tsx
@@ -6,7 +6,7 @@ import { useMessages } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { normalizeAuthErrorCode, rememberAuthErrorCallback } from '@/lib/auth/auth-error-copy'
+import { normalizeAuthErrorCode } from '@/lib/auth/auth-error-copy'
 import { useAuthRedirectUrls } from '@/lib/auth/redirect-urls'
 import { client } from '@/lib/auth-client'
 import { quickValidateEmail } from '@/lib/email/validation'
@@ -117,11 +117,10 @@ export default function SSOForm({ registrationMode }: { registrationMode: Regist
     }
 
     try {
-      rememberAuthErrorCallback(callbackUrl)
       await client.signIn.sso({
         email: emailValue,
         callbackURL: authRedirectUrls.providerCallbackPath(callbackUrl),
-        errorCallbackURL: authRedirectUrls.providerErrorPath('/error'),
+        errorCallbackURL: authRedirectUrls.providerErrorPath(callbackUrl),
       })
     } catch (err) {
       logger.error('SSO sign-in failed', { error: err, email: emailValue })

--- a/apps/tradinggoose/app/(auth)/sso/sso-form.tsx
+++ b/apps/tradinggoose/app/(auth)/sso/sso-form.tsx
@@ -6,7 +6,7 @@ import { useMessages } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { normalizeAuthErrorCode } from '@/lib/auth/auth-error-copy'
+import { resolveSsoAuthErrorMessage } from '@/lib/auth/auth-error-copy'
 import { useAuthRedirectUrls } from '@/lib/auth/redirect-urls'
 import { client } from '@/lib/auth-client'
 import { quickValidateEmail } from '@/lib/email/validation'
@@ -124,26 +124,10 @@ export default function SSOForm({ registrationMode }: { registrationMode: Regist
       })
     } catch (err) {
       logger.error('SSO sign-in failed', { error: err, email: emailValue })
-      const authErrorCode = err instanceof Error ? normalizeAuthErrorCode(err.message) : null
+      const errorMessage =
+        err instanceof Error ? resolveSsoAuthErrorMessage(copy, err.message) : null
 
-      let errorMessage = ssoCopy.errors.failed
-      if (err instanceof Error) {
-        if (authErrorCode === 'NO_PROVIDER_FOUND' || authErrorCode === 'INVALID_PROVIDER') {
-          errorMessage = ssoCopy.errors.providerNotConfigured
-        } else if (authErrorCode === 'INVALID_EMAIL_DOMAIN') {
-          errorMessage = ssoCopy.errors.invalidEmailDomain
-        } else if (authErrorCode === 'NETWORK_ERROR') {
-          errorMessage = ssoCopy.errors.network
-        } else if (authErrorCode === 'RATE_LIMIT' || authErrorCode === 'TOO_MANY_REQUESTS') {
-          errorMessage = ssoCopy.errors.rateLimit
-        } else if (authErrorCode === 'SSO_DISABLED') {
-          errorMessage = ssoCopy.errors.ssoDisabled
-        } else {
-          errorMessage = ssoCopy.errors.failed
-        }
-      }
-
-      setEmailErrors([errorMessage])
+      setEmailErrors([errorMessage ?? ssoCopy.errors.failed])
       setShowEmailValidationError(true)
       setIsLoading(false)
     }

--- a/apps/tradinggoose/app/(auth)/sso/sso-form.tsx
+++ b/apps/tradinggoose/app/(auth)/sso/sso-form.tsx
@@ -6,7 +6,7 @@ import { useMessages } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { normalizeAuthErrorCode } from '@/lib/auth/auth-error-copy'
+import { normalizeAuthErrorCode, rememberAuthErrorCallback } from '@/lib/auth/auth-error-copy'
 import { useAuthRedirectUrls } from '@/lib/auth/redirect-urls'
 import { client } from '@/lib/auth-client'
 import { quickValidateEmail } from '@/lib/email/validation'
@@ -117,6 +117,7 @@ export default function SSOForm({ registrationMode }: { registrationMode: Regist
     }
 
     try {
+      rememberAuthErrorCallback(callbackUrl)
       await client.signIn.sso({
         email: emailValue,
         callbackURL: authRedirectUrls.providerCallbackPath(callbackUrl),

--- a/apps/tradinggoose/app/(landing)/components/nav/nav.test.tsx
+++ b/apps/tradinggoose/app/(landing)/components/nav/nav.test.tsx
@@ -240,6 +240,29 @@ describe('landing nav registration mode', () => {
     expect(container.textContent).toContain(getPublicCopy('en').registration.open.primary)
   })
 
+  it('routes ordinary login navigation without reauth cleanup', async () => {
+    await act(async () => {
+      root.render(
+        <NextIntlClientProvider locale='en' messages={getPublicCopy('en')}>
+          <Nav registrationMode='open' />
+        </NextIntlClientProvider>
+      )
+    })
+
+    const loginButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === getPublicCopy('en').nav.login
+    )
+    if (!(loginButton instanceof HTMLButtonElement)) {
+      throw new Error('Expected login button to render')
+    }
+
+    await act(async () => {
+      loginButton.click()
+    })
+
+    expect(mockPush).toHaveBeenCalledWith('/login')
+  })
+
   it('replaces login and registration controls with profile and dashboard actions for authenticated users', async () => {
     mockSessionUser = {
       id: 'user-1',

--- a/apps/tradinggoose/app/(landing)/components/nav/nav.tsx
+++ b/apps/tradinggoose/app/(landing)/components/nav/nav.tsx
@@ -156,7 +156,7 @@ export default function Nav({
   }, [variant])
 
   const navigateToLogin = useCallback(() => {
-    router.push('/login?reauth=1')
+    router.push('/login')
   }, [router])
 
   const navigateToPrimaryCta = useCallback(() => {

--- a/apps/tradinggoose/app/[locale]/(auth)/auth-entry-pages.test.tsx
+++ b/apps/tradinggoose/app/[locale]/(auth)/auth-entry-pages.test.tsx
@@ -1,30 +1,19 @@
 import type React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import {
-  AUTH_ERROR_CALLBACK_COOKIE,
-  getClearAuthErrorCallbackCookie,
-} from '@/lib/auth/auth-error-copy'
+import { getAuthErrorCallbackPath } from '@/lib/auth/auth-error-copy'
 
 const mockGetLocale = vi.fn()
 const mockGetSession = vi.fn()
 const mockRedirect = vi.fn((url: string) => {
   throw new Error(`redirect:${url}`)
 })
-const mockCookiesGet = vi.fn()
 const mockGetBrandConfig = vi.fn()
 const mockGetOAuthProviderStatus = vi.fn()
 const mockGetRegistrationModeForRender = vi.fn()
 
 vi.mock('next-intl/server', () => ({
   getLocale: () => mockGetLocale(),
-}))
-
-vi.mock('next/headers', () => ({
-  cookies: () =>
-    Promise.resolve({
-      get: mockCookiesGet,
-    }),
 }))
 
 vi.mock('@/lib/auth', () => ({
@@ -94,7 +83,6 @@ describe('localized auth entry pages', () => {
       isProduction: false,
     })
     mockGetRegistrationModeForRender.mockResolvedValue('open')
-    mockCookiesGet.mockReturnValue(undefined)
     mockGetBrandConfig.mockReturnValue({ supportEmail: 'support@tradinggoose.ai' })
   })
 
@@ -169,21 +157,21 @@ describe('localized auth entry pages', () => {
     expect(mockRedirect).not.toHaveBeenCalled()
   })
 
-  it('consumes auth error callback cookies once', async () => {
-    mockCookiesGet.mockReturnValue({
-      value: encodeURIComponent('/invite/invitation-1?token=workspace-token'),
-    })
-    const ErrorPage = (await import('./error/page')).default
+  it('keeps provider error callback state in the per-flow error URL', async () => {
+    const callbackPath = getAuthErrorCallbackPath('/invite/invitation-1?token=workspace-token')
+    const ErrorPage = (await import('./error/[[...callback]]/page')).default
 
     const result = await ErrorPage({
+      params: Promise.resolve({
+        callback: callbackPath?.split('/').filter(Boolean).slice(1),
+      }),
       searchParams: Promise.resolve({ error: 'UNABLE_TO_CREATE_SESSION' }),
     })
     const markup = renderToStaticMarkup(result)
 
-    expect(mockCookiesGet).toHaveBeenCalledWith(AUTH_ERROR_CALLBACK_COOKIE)
     expect(markup).toContain(
       '/login?reauth=1&amp;callbackUrl=%2Finvite%2Finvitation-1%3Ftoken%3Dworkspace-token'
     )
-    expect(markup).toContain(`document.cookie=${JSON.stringify(getClearAuthErrorCallbackCookie())}`)
+    expect(markup).not.toContain('document.cookie')
   })
 })

--- a/apps/tradinggoose/app/[locale]/(auth)/auth-entry-pages.test.tsx
+++ b/apps/tradinggoose/app/[locale]/(auth)/auth-entry-pages.test.tsx
@@ -1,12 +1,18 @@
 import type React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  AUTH_ERROR_CALLBACK_COOKIE,
+  getClearAuthErrorCallbackCookie,
+} from '@/lib/auth/auth-error-copy'
 
 const mockGetLocale = vi.fn()
 const mockGetSession = vi.fn()
 const mockRedirect = vi.fn((url: string) => {
   throw new Error(`redirect:${url}`)
 })
+const mockCookiesGet = vi.fn()
+const mockGetBrandConfig = vi.fn()
 const mockGetOAuthProviderStatus = vi.fn()
 const mockGetRegistrationModeForRender = vi.fn()
 
@@ -14,8 +20,19 @@ vi.mock('next-intl/server', () => ({
   getLocale: () => mockGetLocale(),
 }))
 
+vi.mock('next/headers', () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: mockCookiesGet,
+    }),
+}))
+
 vi.mock('@/lib/auth', () => ({
   getSession: (...args: unknown[]) => mockGetSession(...args),
+}))
+
+vi.mock('@/lib/branding/branding', () => ({
+  getBrandConfig: () => mockGetBrandConfig(),
 }))
 
 vi.mock('@/i18n/navigation', () => ({
@@ -77,6 +94,8 @@ describe('localized auth entry pages', () => {
       isProduction: false,
     })
     mockGetRegistrationModeForRender.mockResolvedValue('open')
+    mockCookiesGet.mockReturnValue(undefined)
+    mockGetBrandConfig.mockReturnValue({ supportEmail: 'support@tradinggoose.ai' })
   })
 
   it('redirects login to the localized workspace when a session is present', async () => {
@@ -148,5 +167,23 @@ describe('localized auth entry pages', () => {
     expect(markup).toContain('data-testid="signup-form"')
     expect(markup).toContain('data-registration-mode="open"')
     expect(mockRedirect).not.toHaveBeenCalled()
+  })
+
+  it('consumes auth error callback cookies once', async () => {
+    mockCookiesGet.mockReturnValue({
+      value: encodeURIComponent('/invite/invitation-1?token=workspace-token'),
+    })
+    const ErrorPage = (await import('./error/page')).default
+
+    const result = await ErrorPage({
+      searchParams: Promise.resolve({ error: 'UNABLE_TO_CREATE_SESSION' }),
+    })
+    const markup = renderToStaticMarkup(result)
+
+    expect(mockCookiesGet).toHaveBeenCalledWith(AUTH_ERROR_CALLBACK_COOKIE)
+    expect(markup).toContain(
+      '/login?reauth=1&amp;callbackUrl=%2Finvite%2Finvitation-1%3Ftoken%3Dworkspace-token'
+    )
+    expect(markup).toContain(`document.cookie=${JSON.stringify(getClearAuthErrorCallbackCookie())}`)
   })
 })

--- a/apps/tradinggoose/app/[locale]/(auth)/error/[[...callback]]/page.tsx
+++ b/apps/tradinggoose/app/[locale]/(auth)/error/[[...callback]]/page.tsx
@@ -1,12 +1,6 @@
-import { cookies } from 'next/headers'
 import { getLocale } from 'next-intl/server'
 import { Button } from '@/components/ui/button'
-import {
-  AUTH_ERROR_CALLBACK_COOKIE,
-  getAuthErrorContent,
-  getClearAuthErrorCallbackCookie,
-  normalizeStoredAuthErrorCallback,
-} from '@/lib/auth/auth-error-copy'
+import { getAuthErrorContent, normalizeAuthErrorCallbackSegments } from '@/lib/auth/auth-error-copy'
 import { getBrandConfig } from '@/lib/branding/branding'
 import { AuthPageHeader } from '@/app/(auth)/components/auth-page-header'
 import { inter } from '@/app/fonts/inter'
@@ -14,25 +8,24 @@ import { Link } from '@/i18n/navigation'
 import { getPublicCopy } from '@/i18n/public-copy'
 import type { LocaleCode } from '@/i18n/utils'
 
-export const dynamic = 'force-dynamic'
-
 function getSingleSearchParam(value: string | string[] | undefined) {
   return Array.isArray(value) ? value[0] : value
 }
 
 export default async function AuthErrorPage({
+  params,
   searchParams,
 }: {
+  params?: Promise<{ callback?: string[] }>
   searchParams?: Promise<{
     error?: string | string[]
     error_description?: string | string[]
   }>
 }) {
-  const resolvedSearchParams = (await searchParams) ?? {}
-  const error = getSingleSearchParam(resolvedSearchParams.error)
-  const errorDescription = getSingleSearchParam(resolvedSearchParams.error_description)
-  const storedCallback = (await cookies()).get(AUTH_ERROR_CALLBACK_COOKIE)?.value
-  const callbackUrl = normalizeStoredAuthErrorCallback(storedCallback)
+  const [resolvedParams, resolvedSearchParams] = await Promise.all([params, searchParams])
+  const error = getSingleSearchParam(resolvedSearchParams?.error)
+  const errorDescription = getSingleSearchParam(resolvedSearchParams?.error_description)
+  const callbackUrl = normalizeAuthErrorCallbackSegments(resolvedParams?.callback)
   const locale = (await getLocale()) as LocaleCode
   const copy = getPublicCopy(locale)
   const { code, content } = getAuthErrorContent(copy, error, errorDescription, callbackUrl)
@@ -42,14 +35,6 @@ export default async function AuthErrorPage({
 
   return (
     <div className='space-y-8 text-center'>
-      {storedCallback ? (
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `document.cookie=${JSON.stringify(getClearAuthErrorCallbackCookie())}`,
-          }}
-        />
-      ) : null}
-
       <AuthPageHeader
         eyebrow={errorCopy.eyebrow}
         title={content.title}

--- a/apps/tradinggoose/app/[locale]/(auth)/error/page.tsx
+++ b/apps/tradinggoose/app/[locale]/(auth)/error/page.tsx
@@ -1,12 +1,17 @@
+import { cookies } from 'next/headers'
 import { getLocale } from 'next-intl/server'
 import { Button } from '@/components/ui/button'
-import { getAuthErrorContent } from '@/lib/auth/auth-error-copy'
+import {
+  AUTH_ERROR_CALLBACK_COOKIE,
+  getAuthErrorContent,
+  normalizeStoredAuthErrorCallback,
+} from '@/lib/auth/auth-error-copy'
 import { getBrandConfig } from '@/lib/branding/branding'
 import { AuthPageHeader } from '@/app/(auth)/components/auth-page-header'
 import { inter } from '@/app/fonts/inter'
 import { Link } from '@/i18n/navigation'
 import { getPublicCopy } from '@/i18n/public-copy'
-import { type LocaleCode } from '@/i18n/utils'
+import type { LocaleCode } from '@/i18n/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -25,9 +30,12 @@ export default async function AuthErrorPage({
   const resolvedSearchParams = (await searchParams) ?? {}
   const error = getSingleSearchParam(resolvedSearchParams.error)
   const errorDescription = getSingleSearchParam(resolvedSearchParams.error_description)
+  const callbackUrl = normalizeStoredAuthErrorCallback(
+    (await cookies()).get(AUTH_ERROR_CALLBACK_COOKIE)?.value
+  )
   const locale = (await getLocale()) as LocaleCode
   const copy = getPublicCopy(locale)
-  const { code, content } = getAuthErrorContent(copy, error, errorDescription)
+  const { code, content } = getAuthErrorContent(copy, error, errorDescription, callbackUrl)
   const brand = getBrandConfig()
   const supportEmail = brand.supportEmail
   const errorCopy = copy.auth.error
@@ -47,9 +55,7 @@ export default async function AuthErrorPage({
           >
             {errorCopy.codeLabel}
           </p>
-          <code className='mt-2 block break-all font-mono text-[13px] text-foreground'>
-            {code}
-          </code>
+          <code className='mt-2 block break-all font-mono text-[13px] text-foreground'>{code}</code>
         </div>
       ) : null}
 

--- a/apps/tradinggoose/app/[locale]/(auth)/error/page.tsx
+++ b/apps/tradinggoose/app/[locale]/(auth)/error/page.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import {
   AUTH_ERROR_CALLBACK_COOKIE,
   getAuthErrorContent,
+  getClearAuthErrorCallbackCookie,
   normalizeStoredAuthErrorCallback,
 } from '@/lib/auth/auth-error-copy'
 import { getBrandConfig } from '@/lib/branding/branding'
@@ -30,9 +31,8 @@ export default async function AuthErrorPage({
   const resolvedSearchParams = (await searchParams) ?? {}
   const error = getSingleSearchParam(resolvedSearchParams.error)
   const errorDescription = getSingleSearchParam(resolvedSearchParams.error_description)
-  const callbackUrl = normalizeStoredAuthErrorCallback(
-    (await cookies()).get(AUTH_ERROR_CALLBACK_COOKIE)?.value
-  )
+  const storedCallback = (await cookies()).get(AUTH_ERROR_CALLBACK_COOKIE)?.value
+  const callbackUrl = normalizeStoredAuthErrorCallback(storedCallback)
   const locale = (await getLocale()) as LocaleCode
   const copy = getPublicCopy(locale)
   const { code, content } = getAuthErrorContent(copy, error, errorDescription, callbackUrl)
@@ -42,6 +42,14 @@ export default async function AuthErrorPage({
 
   return (
     <div className='space-y-8 text-center'>
+      {storedCallback ? (
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `document.cookie=${JSON.stringify(getClearAuthErrorCallbackCookie())}`,
+          }}
+        />
+      ) : null}
+
       <AuthPageHeader
         eyebrow={errorCopy.eyebrow}
         title={content.title}

--- a/apps/tradinggoose/app/[locale]/(auth)/login/page.tsx
+++ b/apps/tradinggoose/app/[locale]/(auth)/login/page.tsx
@@ -13,7 +13,8 @@ export default async function LoginPage({
 }: {
   searchParams?: Promise<{ reauth?: string }>
 } = {}) {
-  const isReauth = (await searchParams)?.reauth === '1'
+  const query = await searchParams
+  const isReauth = query?.reauth === '1'
   const [locale, session] = await Promise.all([
     getLocale(),
     isReauth ? Promise.resolve(null) : getSession(),

--- a/apps/tradinggoose/app/api/auth/socket-token/route.test.ts
+++ b/apps/tradinggoose/app/api/auth/socket-token/route.test.ts
@@ -53,4 +53,22 @@ describe('socket token route', () => {
     expect(await response.json()).toEqual({ error: 'Authentication required' })
     expect(mockGenerateOneTimeToken).not.toHaveBeenCalled()
   })
+
+  it('does not issue a token when canonical session lookup rejects stale cookie data', async () => {
+    const staleCookieHeaders = new Headers([
+      [
+        'cookie',
+        'better-auth.session_token=revoked; better-auth.session_data=stale-session-payload',
+      ],
+    ])
+    mockHeaders.mockResolvedValue(staleCookieHeaders)
+    mockGetSession.mockResolvedValue(null)
+
+    const { POST } = await import('./route')
+    const response = await POST()
+
+    expect(response.status).toBe(401)
+    expect(mockGetSession).toHaveBeenCalledWith(staleCookieHeaders)
+    expect(mockGenerateOneTimeToken).not.toHaveBeenCalled()
+  })
 })

--- a/apps/tradinggoose/app/api/auth/socket-token/route.test.ts
+++ b/apps/tradinggoose/app/api/auth/socket-token/route.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment node
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGenerateOneTimeToken, mockGetSession, mockHeaders } = vi.hoisted(() => ({
+  mockGenerateOneTimeToken: vi.fn(),
+  mockGetSession: vi.fn(),
+  mockHeaders: vi.fn(),
+}))
+
+vi.mock('next/headers', () => ({
+  headers: () => mockHeaders(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  auth: {
+    api: {
+      generateOneTimeToken: (...args: unknown[]) => mockGenerateOneTimeToken(...args),
+    },
+  },
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+}))
+
+describe('socket token route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    mockHeaders.mockResolvedValue(new Headers([['cookie', 'better-auth.session_token=token']]))
+    mockGetSession.mockResolvedValue({ user: { id: 'user-1' } })
+    mockGenerateOneTimeToken.mockResolvedValue({ token: 'socket-token' })
+  })
+
+  it('uses the canonical app session before issuing a socket token', async () => {
+    const { POST } = await import('./route')
+
+    const response = await POST()
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ token: 'socket-token' })
+    expect(mockGetSession).toHaveBeenCalledWith(expect.any(Headers))
+    expect(mockGenerateOneTimeToken).toHaveBeenCalledWith({ headers: expect.any(Headers) })
+  })
+
+  it('rejects socket token requests without an app session', async () => {
+    mockGetSession.mockResolvedValue(null)
+
+    const { POST } = await import('./route')
+    const response = await POST()
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Authentication required' })
+    expect(mockGenerateOneTimeToken).not.toHaveBeenCalled()
+  })
+})

--- a/apps/tradinggoose/app/api/auth/socket-token/route.ts
+++ b/apps/tradinggoose/app/api/auth/socket-token/route.ts
@@ -5,7 +5,7 @@ import { auth, getSession } from '@/lib/auth'
 export async function POST() {
   try {
     const hdrs = await headers()
-    const session = await getSession(hdrs, { disableCookieCache: true })
+    const session = await getSession(hdrs)
 
     if (!session?.user?.id) {
       return NextResponse.json({ error: 'Authentication required' }, { status: 401 })

--- a/apps/tradinggoose/hooks/use-workspace-permissions.test.tsx
+++ b/apps/tradinggoose/hooks/use-workspace-permissions.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useWorkspacePermissions } from './use-workspace-permissions'
+
+const mockHandleAuthError = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/auth/auth-error-handler', () => ({
+  handleAuthError: mockHandleAuthError,
+  isAuthErrorStatus: (status?: number | null) => status === 401,
+}))
+
+vi.mock('@/i18n/navigation', () => ({
+  usePathname: () => '/workspace/workspace-1/dashboard',
+}))
+
+function WorkspacePermissionsProbe() {
+  useWorkspacePermissions('workspace-401')
+  return null
+}
+
+describe('useWorkspacePermissions', () => {
+  let container: HTMLDivElement
+  let root: Root
+  const reactActEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean
+  }
+
+  beforeEach(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+    mockHandleAuthError.mockResolvedValue(undefined)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(null, { status: 401, statusText: 'Unauthorized' }))
+    )
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = false
+  })
+
+  it('routes workspace permission 401 responses through auth recovery', async () => {
+    await act(async () => {
+      root.render(<WorkspacePermissionsProbe />)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(mockHandleAuthError).toHaveBeenCalledWith(
+      'workspace-permissions',
+      '/workspace/workspace-1/dashboard'
+    )
+  })
+})

--- a/apps/tradinggoose/hooks/use-workspace-permissions.ts
+++ b/apps/tradinggoose/hooks/use-workspace-permissions.ts
@@ -3,7 +3,9 @@
 import { useCallback, useEffect } from 'react'
 import type { permissionTypeEnum } from '@tradinggoose/db/schema'
 import { createWithEqualityFn as create } from 'zustand/traditional'
+import { handleAuthError, isAuthErrorStatus } from '@/lib/auth/auth-error-handler'
 import { createLogger } from '@/lib/logs/console/logger'
+import { usePathname } from '@/i18n/navigation'
 import { API_ENDPOINTS } from '@/stores/constants'
 
 const logger = createLogger('useWorkspacePermissions')
@@ -47,7 +49,10 @@ interface WorkspacePermissionsStoreState {
   records: Record<string, WorkspacePermissionsRecord>
   inFlight: Partial<Record<string, Promise<void>>>
   setRecord: (workspaceId: string, partial: Partial<WorkspacePermissionsRecord>) => void
-  fetchPermissions: (workspaceId: string, options?: { force?: boolean }) => Promise<void>
+  fetchPermissions: (
+    workspaceId: string,
+    options: { callbackPathname: string; force?: boolean }
+  ) => Promise<void>
 }
 
 const createDefaultRecord = (): WorkspacePermissionsRecord => ({
@@ -73,7 +78,7 @@ const useWorkspacePermissionsStore = create<WorkspacePermissionsStoreState>((set
       }
     }),
   fetchPermissions: async (workspaceId, options) => {
-    const { force = false } = options ?? {}
+    const { callbackPathname, force = false } = options
     const { records, inFlight, setRecord } = get()
 
     if (!force) {
@@ -97,7 +102,8 @@ const useWorkspacePermissionsStore = create<WorkspacePermissionsStoreState>((set
           if (response.status === 404) {
             throw new Error('Workspace not found or access denied')
           }
-          if (response.status === 401) {
+          if (isAuthErrorStatus(response.status)) {
+            await handleAuthError('workspace-permissions', callbackPathname)
             throw new Error('Authentication required')
           }
           throw new Error(`Failed to fetch permissions: ${response.statusText}`)
@@ -147,6 +153,7 @@ const useWorkspacePermissionsStore = create<WorkspacePermissionsStoreState>((set
 }))
 
 export function useWorkspacePermissions(workspaceId: string | null): UseWorkspacePermissionsReturn {
+  const callbackPathname = usePathname()
   const record = useWorkspacePermissionsStore((state) =>
     workspaceId ? state.records[workspaceId] : undefined
   )
@@ -157,15 +164,15 @@ export function useWorkspacePermissions(workspaceId: string | null): UseWorkspac
     if (!workspaceId) {
       return () => {}
     }
-    fetchPermissions(workspaceId).catch((error) => {
+    fetchPermissions(workspaceId, { callbackPathname }).catch((error) => {
       logger.error('Failed to load workspace permissions', { workspaceId, error })
     })
-  }, [workspaceId, fetchPermissions])
+  }, [workspaceId, callbackPathname, fetchPermissions])
 
   const refetch = useCallback(async () => {
     if (!workspaceId) return
-    await fetchPermissions(workspaceId, { force: true })
-  }, [workspaceId, fetchPermissions])
+    await fetchPermissions(workspaceId, { callbackPathname, force: true })
+  }, [workspaceId, callbackPathname, fetchPermissions])
 
   const updatePermissions = useCallback(
     (newPermissions: WorkspacePermissions) => {

--- a/apps/tradinggoose/hooks/use-workspace-permissions.ts
+++ b/apps/tradinggoose/hooks/use-workspace-permissions.ts
@@ -3,9 +3,7 @@
 import { useCallback, useEffect } from 'react'
 import type { permissionTypeEnum } from '@tradinggoose/db/schema'
 import { createWithEqualityFn as create } from 'zustand/traditional'
-import { handleAuthError } from '@/lib/auth/auth-error-handler'
 import { createLogger } from '@/lib/logs/console/logger'
-import { usePathname } from '@/i18n/navigation'
 import { API_ENDPOINTS } from '@/stores/constants'
 
 const logger = createLogger('useWorkspacePermissions')
@@ -49,10 +47,7 @@ interface WorkspacePermissionsStoreState {
   records: Record<string, WorkspacePermissionsRecord>
   inFlight: Partial<Record<string, Promise<void>>>
   setRecord: (workspaceId: string, partial: Partial<WorkspacePermissionsRecord>) => void
-  fetchPermissions: (
-    workspaceId: string,
-    options: { callbackPathname: string; force?: boolean }
-  ) => Promise<void>
+  fetchPermissions: (workspaceId: string, options?: { force?: boolean }) => Promise<void>
 }
 
 const createDefaultRecord = (): WorkspacePermissionsRecord => ({
@@ -78,7 +73,7 @@ const useWorkspacePermissionsStore = create<WorkspacePermissionsStoreState>((set
       }
     }),
   fetchPermissions: async (workspaceId, options) => {
-    const { callbackPathname, force = false } = options
+    const { force = false } = options ?? {}
     const { records, inFlight, setRecord } = get()
 
     if (!force) {
@@ -103,7 +98,6 @@ const useWorkspacePermissionsStore = create<WorkspacePermissionsStoreState>((set
             throw new Error('Workspace not found or access denied')
           }
           if (response.status === 401) {
-            await handleAuthError('workspace-permissions', callbackPathname)
             throw new Error('Authentication required')
           }
           throw new Error(`Failed to fetch permissions: ${response.statusText}`)
@@ -153,7 +147,6 @@ const useWorkspacePermissionsStore = create<WorkspacePermissionsStoreState>((set
 }))
 
 export function useWorkspacePermissions(workspaceId: string | null): UseWorkspacePermissionsReturn {
-  const pathname = usePathname()
   const record = useWorkspacePermissionsStore((state) =>
     workspaceId ? state.records[workspaceId] : undefined
   )
@@ -164,15 +157,15 @@ export function useWorkspacePermissions(workspaceId: string | null): UseWorkspac
     if (!workspaceId) {
       return () => {}
     }
-    fetchPermissions(workspaceId, { callbackPathname: pathname }).catch((error) => {
+    fetchPermissions(workspaceId).catch((error) => {
       logger.error('Failed to load workspace permissions', { workspaceId, error })
     })
-  }, [workspaceId, fetchPermissions, pathname])
+  }, [workspaceId, fetchPermissions])
 
   const refetch = useCallback(async () => {
     if (!workspaceId) return
-    await fetchPermissions(workspaceId, { callbackPathname: pathname, force: true })
-  }, [workspaceId, fetchPermissions, pathname])
+    await fetchPermissions(workspaceId, { force: true })
+  }, [workspaceId, fetchPermissions])
 
   const updatePermissions = useCallback(
     (newPermissions: WorkspacePermissions) => {

--- a/apps/tradinggoose/i18n/messages/en.json
+++ b/apps/tradinggoose/i18n/messages/en.json
@@ -238,7 +238,6 @@
         "noAccount": "No account found with this email. Please sign up first.",
         "missingCredentials": "Please enter both email and password.",
         "emailPasswordDisabled": "Email and password login is disabled.",
-        "failedToCreateSession": "Failed to create session. Please try again later.",
         "tooManyAttempts": "Too many login attempts. Please try again later or reset your password.",
         "accountLocked": "Your account has been locked for security. Please reset your password.",
         "network": "Network error. Please check your connection and try again.",

--- a/apps/tradinggoose/i18n/messages/es.json
+++ b/apps/tradinggoose/i18n/messages/es.json
@@ -238,7 +238,6 @@
         "noAccount": "No se encontró ninguna cuenta con este correo electrónico. Regístrese primero.",
         "missingCredentials": "Por favor, ingrese tanto el correo electrónico como la contraseña.",
         "emailPasswordDisabled": "El inicio de sesión con correo electrónico y contraseña está deshabilitado.",
-        "failedToCreateSession": "Error al crear la sesión. Intente nuevamente más tarde.",
         "tooManyAttempts": "Demasiados intentos de inicio de sesión. Intente nuevamente más tarde o restablezca su contraseña.",
         "accountLocked": "Su cuenta ha sido bloqueada por seguridad. Restablezca su contraseña.",
         "network": "Error de red. Verifique su conexión e intente nuevamente.",

--- a/apps/tradinggoose/i18n/messages/zh.json
+++ b/apps/tradinggoose/i18n/messages/zh.json
@@ -238,7 +238,6 @@
         "noAccount": "此邮箱未找到账户，请先注册。",
         "missingCredentials": "请输入邮箱和密码。",
         "emailPasswordDisabled": "邮箱和密码登录已禁用。",
-        "failedToCreateSession": "创建会话失败，请稍后重试。",
         "tooManyAttempts": "登录尝试次数过多，请稍后重试或重置密码。",
         "accountLocked": "出于安全原因，您的账户已被锁定，请重置密码。",
         "network": "网络错误，请检查连接后重试。",

--- a/apps/tradinggoose/lib/auth.ts
+++ b/apps/tradinggoose/lib/auth.ts
@@ -1818,15 +1818,11 @@ export const auth = betterAuth({
   },
 })
 
-export async function getSession(
-  headersOverride?: Headers,
-  options?: { disableCookieCache?: boolean }
-) {
+export async function getSession(headersOverride?: Headers) {
   const hdrs = headersOverride ?? (await headers())
   try {
     return await auth.api.getSession({
       headers: hdrs,
-      ...(options ? { query: options } : {}),
     })
   } catch (error) {
     logger.warn('Failed to fetch session', { error })

--- a/apps/tradinggoose/lib/auth.ts
+++ b/apps/tradinggoose/lib/auth.ts
@@ -646,7 +646,6 @@ export const auth = betterAuth({
     }),
   },
   plugins: [
-    nextCookies(),
     oneTimeToken({
       expiresIn: 24 * 60 * 60, // 24 hours - Socket.IO handles connection persistence with heartbeats
     }),
@@ -1806,6 +1805,7 @@ export const auth = betterAuth({
         },
       },
     }),
+    nextCookies(),
   ],
   onAPIError: {
     errorURL: '/error',

--- a/apps/tradinggoose/lib/auth.ts
+++ b/apps/tradinggoose/lib/auth.ts
@@ -433,10 +433,6 @@ export const auth = betterAuth({
     schema,
   }),
   session: {
-    cookieCache: {
-      enabled: true,
-      maxAge: 24 * 60 * 60, // 24 hours in seconds
-    },
     expiresIn: 30 * 24 * 60 * 60, // 30 days (how long a session can last overall)
     updateAge: 24 * 60 * 60, // 24 hours (how often to refresh the expiry)
     freshAge: 60 * 60, // 1 hour (or set to 0 to disable completely)

--- a/apps/tradinggoose/lib/auth/auth-error-copy.test.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-copy.test.ts
@@ -36,6 +36,17 @@ describe('getAuthErrorContent', () => {
     expect(content.primaryAction.href).toBe('/login')
   })
 
+  it.each(['FAILED_TO_CREATE_SESSION', 'FAILED_TO_GET_SESSION', 'SESSION_EXPIRED'])(
+    'routes %s through reauth cleanup',
+    (errorCode) => {
+      const { code, content } = getAuthErrorContent(copy, errorCode)
+
+      expect(code).toBe(errorCode)
+      expect(content.primaryAction.href).toBe('/login?reauth=1')
+      expect(content.secondaryAction.href).toBe('/')
+    }
+  )
+
   it('maps the waitlist registration reason to waitlist recovery copy', () => {
     const { code, content } = getAuthErrorContent(copy, REGISTRATION_WAITLIST_REASON)
 

--- a/apps/tradinggoose/lib/auth/auth-error-copy.test.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-copy.test.ts
@@ -36,16 +36,18 @@ describe('getAuthErrorContent', () => {
     expect(content.primaryAction.href).toBe('/login')
   })
 
-  it.each(['FAILED_TO_CREATE_SESSION', 'FAILED_TO_GET_SESSION', 'SESSION_EXPIRED'])(
-    'routes %s through reauth cleanup',
-    (errorCode) => {
-      const { code, content } = getAuthErrorContent(copy, errorCode)
+  it.each([
+    'UNABLE_TO_CREATE_SESSION',
+    'FAILED_TO_CREATE_SESSION',
+    'FAILED_TO_GET_SESSION',
+    'SESSION_EXPIRED',
+  ])('routes %s through reauth cleanup', (errorCode) => {
+    const { code, content } = getAuthErrorContent(copy, errorCode)
 
-      expect(code).toBe(errorCode)
-      expect(content.primaryAction.href).toBe('/login?reauth=1')
-      expect(content.secondaryAction.href).toBe('/')
-    }
-  )
+    expect(code).toBe(errorCode)
+    expect(content.primaryAction.href).toBe('/login?reauth=1')
+    expect(content.secondaryAction.href).toBe('/')
+  })
 
   it('maps the waitlist registration reason to waitlist recovery copy', () => {
     const { code, content } = getAuthErrorContent(copy, REGISTRATION_WAITLIST_REASON)

--- a/apps/tradinggoose/lib/auth/auth-error-copy.test.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-copy.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest'
 import {
   getAuthErrorCallbackPath,
   getAuthErrorContent,
+  isSessionRecoveryAuthError,
   normalizeAuthErrorCallbackSegments,
   normalizeAuthErrorCode,
+  resolveSsoAuthErrorMessage,
 } from '@/lib/auth/auth-error-copy'
 import {
   REGISTRATION_DISABLED_REASON,
@@ -52,6 +54,28 @@ describe('getAuthErrorContent', () => {
     expect(code).toBe(errorCode)
     expect(content.primaryAction.href).toBe('/login?reauth=1')
     expect(content.secondaryAction.href).toBe('/')
+  })
+
+  it.each([
+    'UNABLE_TO_CREATE_SESSION',
+    'FAILED_TO_CREATE_SESSION',
+    'FAILED_TO_GET_SESSION',
+    'SESSION_EXPIRED',
+  ])('classifies %s as a session recovery auth error', (errorCode) => {
+    expect(isSessionRecoveryAuthError(errorCode)).toBe(true)
+  })
+
+  it.each([
+    ['ACCOUNT_NOT_FOUND', 'accountNotFound'],
+    ['SSO_FAILED', 'ssoFailed'],
+    ['INVALID_PROVIDER', 'providerNotConfigured'],
+    ['NO_PROVIDER_FOUND', 'providerNotConfigured'],
+  ] as const)('uses SSO-specific guidance for %s callback failures', (errorCode, copyKey) => {
+    const { content } = getAuthErrorContent(copy, errorCode)
+
+    expect(resolveSsoAuthErrorMessage(copy, errorCode)).toBe(copy.auth.sso.errors[copyKey])
+    expect(content.description).toBe(copy.auth.sso.errors[copyKey])
+    expect(content.primaryAction.href).toBe('/login')
   })
 
   it('keeps the stored canonical destination on session recovery actions', () => {

--- a/apps/tradinggoose/lib/auth/auth-error-copy.test.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-copy.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
+  getAuthErrorCallbackPath,
   getAuthErrorContent,
+  normalizeAuthErrorCallbackSegments,
   normalizeAuthErrorCode,
-  normalizeStoredAuthErrorCallback,
 } from '@/lib/auth/auth-error-copy'
 import {
   REGISTRATION_DISABLED_REASON,
@@ -54,14 +55,17 @@ describe('getAuthErrorContent', () => {
   })
 
   it('keeps the stored canonical destination on session recovery actions', () => {
-    const callback = normalizeStoredAuthErrorCallback(
-      encodeURIComponent('/invite/invitation-1?token=workspace-token')
+    const callbackPath = getAuthErrorCallbackPath('/invite/invitation-1?token=workspace-token')
+    const callback = normalizeAuthErrorCallbackSegments(
+      callbackPath?.split('/').filter(Boolean).slice(1)
     )
     const { content } = getAuthErrorContent(copy, 'UNABLE_TO_CREATE_SESSION', null, callback)
 
+    expect(callbackPath).toMatch(/^\/error\/callback\//)
     expect(callback).toBe('/invite/invitation-1?token=workspace-token')
-    expect(normalizeStoredAuthErrorCallback(encodeURIComponent('/en/workspace'))).toBeNull()
-    expect(normalizeStoredAuthErrorCallback('https://evil.example/workspace')).toBeNull()
+    expect(getAuthErrorCallbackPath('/en/workspace')).toBeNull()
+    expect(getAuthErrorCallbackPath('https://evil.example/workspace')).toBeNull()
+    expect(normalizeAuthErrorCallbackSegments(['callback', 'not-valid-base64*'])).toBeNull()
     expect(content.primaryAction.href).toBe(
       '/login?reauth=1&callbackUrl=%2Finvite%2Finvitation-1%3Ftoken%3Dworkspace-token'
     )

--- a/apps/tradinggoose/lib/auth/auth-error-copy.test.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-copy.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { getAuthErrorContent, normalizeAuthErrorCode } from '@/lib/auth/auth-error-copy'
+import {
+  getAuthErrorContent,
+  normalizeAuthErrorCode,
+  normalizeStoredAuthErrorCallback,
+} from '@/lib/auth/auth-error-copy'
 import {
   REGISTRATION_DISABLED_REASON,
   REGISTRATION_WAITLIST_REASON,
@@ -47,6 +51,20 @@ describe('getAuthErrorContent', () => {
     expect(code).toBe(errorCode)
     expect(content.primaryAction.href).toBe('/login?reauth=1')
     expect(content.secondaryAction.href).toBe('/')
+  })
+
+  it('keeps the stored canonical destination on session recovery actions', () => {
+    const callback = normalizeStoredAuthErrorCallback(
+      encodeURIComponent('/invite/invitation-1?token=workspace-token')
+    )
+    const { content } = getAuthErrorContent(copy, 'UNABLE_TO_CREATE_SESSION', null, callback)
+
+    expect(callback).toBe('/invite/invitation-1?token=workspace-token')
+    expect(normalizeStoredAuthErrorCallback(encodeURIComponent('/en/workspace'))).toBeNull()
+    expect(normalizeStoredAuthErrorCallback('https://evil.example/workspace')).toBeNull()
+    expect(content.primaryAction.href).toBe(
+      '/login?reauth=1&callbackUrl=%2Finvite%2Finvitation-1%3Ftoken%3Dworkspace-token'
+    )
   })
 
   it('maps the waitlist registration reason to waitlist recovery copy', () => {

--- a/apps/tradinggoose/lib/auth/auth-error-copy.test.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-copy.test.ts
@@ -25,7 +25,7 @@ describe('getAuthErrorContent', () => {
     expect(code).toBe('UNABLE_TO_CREATE_USER')
     expect(content.title).toBe("We couldn't create your account")
     expect(content.primaryAction.href).toBe('/signup')
-    expect(content.secondaryAction.href).toBe('/login?reauth=1')
+    expect(content.secondaryAction.href).toBe('/login')
   })
 
   it('falls back to the default auth error copy for unknown codes', () => {
@@ -33,7 +33,7 @@ describe('getAuthErrorContent', () => {
 
     expect(code).toBe('TOTALLY_UNKNOWN_ERROR')
     expect(content.title).toBe(copy.auth.error.default.title)
-    expect(content.primaryAction.href).toBe('/login?reauth=1')
+    expect(content.primaryAction.href).toBe('/login')
   })
 
   it('maps the waitlist registration reason to waitlist recovery copy', () => {
@@ -51,6 +51,6 @@ describe('getAuthErrorContent', () => {
     expect(code).toBe('REGISTRATION_DISABLED')
     expect(content.title).toBe(copy.auth.error.groups.registrationDisabled.title)
     expect(content.description).toBe(copy.auth.error.groups.registrationDisabled.description)
-    expect(content.primaryAction.href).toBe('/login?reauth=1')
+    expect(content.primaryAction.href).toBe('/login')
   })
 })

--- a/apps/tradinggoose/lib/auth/auth-error-copy.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-copy.ts
@@ -26,6 +26,7 @@ const HOME_HREF = '/'
 const VERIFY_HREF = '/verify'
 const WAITLIST_HREF = '/waitlist'
 const AUTH_ERROR_CALLBACK_SEGMENT = 'callback'
+type SsoErrorCopyKey = keyof PublicCopy['auth']['sso']['errors']
 
 const AUTH_ERROR_GROUP_BY_CODE: Partial<Record<string, AuthErrorGroupKey>> = {
   UNABLE_TO_CREATE_USER: 'accountCreation',
@@ -44,8 +45,12 @@ const AUTH_ERROR_GROUP_BY_CODE: Partial<Record<string, AuthErrorGroupKey>> = {
   FAILED_TO_CREATE_SESSION: 'sessionCreation',
   FAILED_TO_GET_SESSION: 'sessionRestore',
   SESSION_EXPIRED: 'sessionExpired',
+  ACCOUNT_NOT_FOUND: 'userInfo',
+  SSO_FAILED: 'userInfo',
   FAILED_TO_GET_USER_INFO: 'userInfo',
   USER_EMAIL_NOT_FOUND: 'userInfo',
+  INVALID_PROVIDER: 'providerUnavailable',
+  NO_PROVIDER_FOUND: 'providerUnavailable',
   PROVIDER_NOT_FOUND: 'providerUnavailable',
   SOCIAL_ACCOUNT_ALREADY_LINKED: 'linkedAccount',
   LINKED_ACCOUNT_ALREADY_EXISTS: 'linkedAccount',
@@ -54,6 +59,18 @@ const AUTH_ERROR_GROUP_BY_CODE: Partial<Record<string, AuthErrorGroupKey>> = {
   EMAIL_AND_PASSWORD_SIGN_IN_IS_NOT_ENABLED: 'providerUnavailable',
   EMAIL_AND_PASSWORD_SIGN_UP_IS_NOT_ENABLED: 'accountCreation',
   EMAIL_PASSWORD_DISABLED: 'providerUnavailable',
+}
+
+const SSO_ERROR_COPY_BY_CODE: Partial<Record<string, SsoErrorCopyKey>> = {
+  ACCOUNT_NOT_FOUND: 'accountNotFound',
+  SSO_FAILED: 'ssoFailed',
+  INVALID_PROVIDER: 'providerNotConfigured',
+  NO_PROVIDER_FOUND: 'providerNotConfigured',
+  INVALID_EMAIL_DOMAIN: 'invalidEmailDomain',
+  NETWORK_ERROR: 'network',
+  RATE_LIMIT: 'rateLimit',
+  TOO_MANY_REQUESTS: 'rateLimit',
+  SSO_DISABLED: 'ssoDisabled',
 }
 
 export function normalizeAuthErrorCode(error: string | null | undefined) {
@@ -150,6 +167,21 @@ function isSessionRecoveryGroup(groupKey: AuthErrorGroupKey) {
   )
 }
 
+export function isSessionRecoveryAuthError(
+  error: string | null | undefined,
+  errorDescription?: string | null
+) {
+  const groupKey = resolveAuthErrorGroup(error, errorDescription)
+  return Boolean(groupKey && isSessionRecoveryGroup(groupKey))
+}
+
+export function resolveSsoAuthErrorMessage(copy: PublicCopy, error: string | null | undefined) {
+  const code = normalizeAuthErrorCode(error)
+  const copyKey = code ? SSO_ERROR_COPY_BY_CODE[code] : null
+
+  return copyKey ? copy.auth.sso.errors[copyKey] : null
+}
+
 export function getAuthErrorContent(
   copy: PublicCopy,
   error: string | null | undefined,
@@ -161,6 +193,8 @@ export function getAuthErrorContent(
   const groupKey = resolveAuthErrorGroupKey(code) ?? resolveAuthErrorGroupKey(descriptionCode)
   const actionCopy = getAuthErrorActionCopy(copy, callbackUrl)
   const normalizedDescription = errorDescription?.trim() || null
+  const ssoErrorDescription =
+    resolveSsoAuthErrorMessage(copy, code) ?? resolveSsoAuthErrorMessage(copy, descriptionCode)
 
   if (groupKey) {
     const group = copy.auth.error.groups[groupKey]
@@ -185,9 +219,10 @@ export function getAuthErrorContent(
     const content: AuthErrorContent = {
       title: group.title,
       description:
-        normalizedDescription && descriptionCode && !resolveAuthErrorGroupKey(descriptionCode)
+        ssoErrorDescription ??
+        (normalizedDescription && descriptionCode && !resolveAuthErrorGroupKey(descriptionCode)
           ? normalizedDescription
-          : group.description,
+          : group.description),
       primaryAction,
       secondaryAction,
     }
@@ -202,7 +237,8 @@ export function getAuthErrorContent(
     code,
     content: {
       title: copy.auth.error.default.title,
-      description: normalizedDescription ?? copy.auth.error.default.description,
+      description:
+        ssoErrorDescription ?? normalizedDescription ?? copy.auth.error.default.description,
       primaryAction: actionCopy.login,
       secondaryAction: actionCopy.home,
     },

--- a/apps/tradinggoose/lib/auth/auth-error-copy.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-copy.ts
@@ -95,6 +95,10 @@ export function rememberAuthErrorCallback(value: string | null | undefined) {
   document.cookie = `${AUTH_ERROR_CALLBACK_COOKIE}=${encodeURIComponent(callback)}; path=/; max-age=600; samesite=lax`
 }
 
+export function getClearAuthErrorCallbackCookie() {
+  return `${AUTH_ERROR_CALLBACK_COOKIE}=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=lax`
+}
+
 function appendCallbackUrl(href: string, callbackUrl: string | null | undefined) {
   if (!callbackUrl) {
     return href

--- a/apps/tradinggoose/lib/auth/auth-error-copy.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-copy.ts
@@ -19,6 +19,7 @@ export interface AuthErrorContent {
 type AuthErrorGroupKey = keyof PublicCopy['auth']['error']['groups']
 
 const LOGIN_HREF = '/login'
+const REAUTH_LOGIN_HREF = '/login?reauth=1'
 const SIGNUP_HREF = '/signup'
 const HOME_HREF = '/'
 const VERIFY_HREF = '/verify'
@@ -72,6 +73,10 @@ function getAuthErrorActionCopy(localeCopy: PublicCopy) {
       href: LOGIN_HREF,
       label: localeCopy.auth.common.backToLogin,
     },
+    reauthLogin: {
+      href: REAUTH_LOGIN_HREF,
+      label: localeCopy.auth.common.backToLogin,
+    },
     signup: {
       href: SIGNUP_HREF,
       label: localeCopy.auth.common.backToSignup,
@@ -99,6 +104,14 @@ function resolveAuthErrorGroupKey(errorCode: string | null): AuthErrorGroupKey |
   return AUTH_ERROR_GROUP_BY_CODE[errorCode] ?? null
 }
 
+function isSessionRecoveryGroup(groupKey: AuthErrorGroupKey) {
+  return (
+    groupKey === 'sessionCreation' ||
+    groupKey === 'sessionRestore' ||
+    groupKey === 'sessionExpired'
+  )
+}
+
 export function getAuthErrorContent(
   copy: PublicCopy,
   error: string | null | undefined,
@@ -119,7 +132,9 @@ export function getAuthErrorContent(
           ? actionCopy.verify
           : groupKey === 'waitlistLimited'
             ? actionCopy.waitlist
-            : actionCopy.login
+            : isSessionRecoveryGroup(groupKey)
+              ? actionCopy.reauthLogin
+              : actionCopy.login
     const secondaryAction =
       groupKey === 'accountCreation' ||
       groupKey === 'emailVerification' ||

--- a/apps/tradinggoose/lib/auth/auth-error-copy.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-copy.ts
@@ -3,6 +3,7 @@ import {
   REGISTRATION_WAITLIST_REASON,
 } from '@/lib/registration/shared'
 import type { PublicCopy } from '@/i18n/public-copy'
+import { normalizeCallbackUrl } from '@/i18n/utils'
 
 export interface AuthErrorAction {
   href: string
@@ -24,6 +25,7 @@ const SIGNUP_HREF = '/signup'
 const HOME_HREF = '/'
 const VERIFY_HREF = '/verify'
 const WAITLIST_HREF = '/waitlist'
+export const AUTH_ERROR_CALLBACK_COOKIE = 'tradinggoose_auth_error_callback'
 
 const AUTH_ERROR_GROUP_BY_CODE: Partial<Record<string, AuthErrorGroupKey>> = {
   UNABLE_TO_CREATE_USER: 'accountCreation',
@@ -68,18 +70,52 @@ export function normalizeAuthErrorCode(error: string | null | undefined) {
   return normalized || null
 }
 
-function getAuthErrorActionCopy(localeCopy: PublicCopy) {
+export function normalizeStoredAuthErrorCallback(value: string | null | undefined) {
+  if (!value) {
+    return null
+  }
+
+  try {
+    return normalizeCallbackUrl(decodeURIComponent(value))
+  } catch {
+    return null
+  }
+}
+
+export function rememberAuthErrorCallback(value: string | null | undefined) {
+  if (typeof document === 'undefined') {
+    return
+  }
+
+  const callback = normalizeCallbackUrl(value)
+  if (!callback) {
+    return
+  }
+
+  document.cookie = `${AUTH_ERROR_CALLBACK_COOKIE}=${encodeURIComponent(callback)}; path=/; max-age=600; samesite=lax`
+}
+
+function appendCallbackUrl(href: string, callbackUrl: string | null | undefined) {
+  if (!callbackUrl) {
+    return href
+  }
+
+  const separator = href.includes('?') ? '&' : '?'
+  return `${href}${separator}callbackUrl=${encodeURIComponent(callbackUrl)}`
+}
+
+function getAuthErrorActionCopy(localeCopy: PublicCopy, callbackUrl?: string | null) {
   return {
     login: {
-      href: LOGIN_HREF,
+      href: appendCallbackUrl(LOGIN_HREF, callbackUrl),
       label: localeCopy.auth.common.backToLogin,
     },
     reauthLogin: {
-      href: REAUTH_LOGIN_HREF,
+      href: appendCallbackUrl(REAUTH_LOGIN_HREF, callbackUrl),
       label: localeCopy.auth.common.backToLogin,
     },
     signup: {
-      href: SIGNUP_HREF,
+      href: appendCallbackUrl(SIGNUP_HREF, callbackUrl),
       label: localeCopy.auth.common.backToSignup,
     },
     home: {
@@ -114,12 +150,13 @@ function isSessionRecoveryGroup(groupKey: AuthErrorGroupKey) {
 export function getAuthErrorContent(
   copy: PublicCopy,
   error: string | null | undefined,
-  errorDescription?: string | null
+  errorDescription?: string | null,
+  callbackUrl?: string | null
 ) {
   const code = normalizeAuthErrorCode(error)
   const descriptionCode = normalizeAuthErrorCode(errorDescription)
   const groupKey = resolveAuthErrorGroupKey(code) ?? resolveAuthErrorGroupKey(descriptionCode)
-  const actionCopy = getAuthErrorActionCopy(copy)
+  const actionCopy = getAuthErrorActionCopy(copy, callbackUrl)
   const normalizedDescription = errorDescription?.trim() || null
 
   if (groupKey) {

--- a/apps/tradinggoose/lib/auth/auth-error-copy.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-copy.ts
@@ -25,7 +25,7 @@ const SIGNUP_HREF = '/signup'
 const HOME_HREF = '/'
 const VERIFY_HREF = '/verify'
 const WAITLIST_HREF = '/waitlist'
-export const AUTH_ERROR_CALLBACK_COOKIE = 'tradinggoose_auth_error_callback'
+const AUTH_ERROR_CALLBACK_SEGMENT = 'callback'
 
 const AUTH_ERROR_GROUP_BY_CODE: Partial<Record<string, AuthErrorGroupKey>> = {
   UNABLE_TO_CREATE_USER: 'accountCreation',
@@ -70,33 +70,32 @@ export function normalizeAuthErrorCode(error: string | null | undefined) {
   return normalized || null
 }
 
-export function normalizeStoredAuthErrorCallback(value: string | null | undefined) {
-  if (!value) {
+export function getAuthErrorCallbackPath(value: string | null | undefined) {
+  const callback = normalizeCallbackUrl(value)
+  if (!callback) {
+    return null
+  }
+
+  const encoded = btoa(encodeURIComponent(callback))
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replace(/=+$/g, '')
+  return `/error/${AUTH_ERROR_CALLBACK_SEGMENT}/${encoded}`
+}
+
+export function normalizeAuthErrorCallbackSegments(value: string[] | undefined) {
+  if (!value || value.length !== 2 || value[0] !== AUTH_ERROR_CALLBACK_SEGMENT) {
     return null
   }
 
   try {
-    return normalizeCallbackUrl(decodeURIComponent(value))
+    const base64 = value[1].replaceAll('-', '+').replaceAll('_', '/')
+    const paddedBase64 = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=')
+
+    return normalizeCallbackUrl(decodeURIComponent(atob(paddedBase64)))
   } catch {
     return null
   }
-}
-
-export function rememberAuthErrorCallback(value: string | null | undefined) {
-  if (typeof document === 'undefined') {
-    return
-  }
-
-  const callback = normalizeCallbackUrl(value)
-  if (!callback) {
-    return
-  }
-
-  document.cookie = `${AUTH_ERROR_CALLBACK_COOKIE}=${encodeURIComponent(callback)}; path=/; max-age=600; samesite=lax`
-}
-
-export function getClearAuthErrorCallbackCookie() {
-  return `${AUTH_ERROR_CALLBACK_COOKIE}=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=lax`
 }
 
 function appendCallbackUrl(href: string, callbackUrl: string | null | undefined) {

--- a/apps/tradinggoose/lib/auth/auth-error-copy.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-copy.ts
@@ -18,7 +18,7 @@ export interface AuthErrorContent {
 
 type AuthErrorGroupKey = keyof PublicCopy['auth']['error']['groups']
 
-const LOGIN_HREF = '/login?reauth=1'
+const LOGIN_HREF = '/login'
 const SIGNUP_HREF = '/signup'
 const HOME_HREF = '/'
 const VERIFY_HREF = '/verify'

--- a/apps/tradinggoose/lib/auth/auth-error-copy.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-copy.ts
@@ -38,6 +38,7 @@ const AUTH_ERROR_GROUP_BY_CODE: Partial<Record<string, AuthErrorGroupKey>> = {
   CALLBACK_URL_REQUIRED: 'invalidCallback',
   INVALID_TOKEN: 'invalidToken',
   TOKEN_EXPIRED: 'expiredToken',
+  UNABLE_TO_CREATE_SESSION: 'sessionCreation',
   FAILED_TO_CREATE_SESSION: 'sessionCreation',
   FAILED_TO_GET_SESSION: 'sessionRestore',
   SESSION_EXPIRED: 'sessionExpired',
@@ -106,9 +107,7 @@ function resolveAuthErrorGroupKey(errorCode: string | null): AuthErrorGroupKey |
 
 function isSessionRecoveryGroup(groupKey: AuthErrorGroupKey) {
   return (
-    groupKey === 'sessionCreation' ||
-    groupKey === 'sessionRestore' ||
-    groupKey === 'sessionExpired'
+    groupKey === 'sessionCreation' || groupKey === 'sessionRestore' || groupKey === 'sessionExpired'
   )
 }
 

--- a/apps/tradinggoose/lib/auth/auth-error-handler.test.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-handler.test.ts
@@ -29,14 +29,11 @@ describe('handleAuthError', () => {
     vi.resetModules()
     vi.clearAllMocks()
     stubWindow('https://app.tradinggoose.ai/login?callbackUrl=%2Fworkspace#credentials')
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })))
 
     const { handleAuthError } = await import('./auth-error-handler')
 
     await handleAuthError('socket-auth', '/login')
 
-    expect(replaceMock).toHaveBeenCalledWith(
-      '/login?callbackUrl=%2Fworkspace&reauth=1#credentials'
-    )
+    expect(replaceMock).toHaveBeenCalledWith('/login?callbackUrl=%2Fworkspace&reauth=1#credentials')
   })
 })

--- a/apps/tradinggoose/lib/auth/auth-error-handler.test.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-handler.test.ts
@@ -33,7 +33,7 @@ describe('handleAuthError', () => {
 
     const { handleAuthError } = await import('./auth-error-handler')
 
-    await handleAuthError('login-unauthorized', '/login')
+    await handleAuthError('socket-auth', '/login')
 
     expect(replaceMock).toHaveBeenCalledWith(
       '/login?callbackUrl=%2Fworkspace&reauth=1#credentials'

--- a/apps/tradinggoose/lib/auth/auth-error-handler.ts
+++ b/apps/tradinggoose/lib/auth/auth-error-handler.ts
@@ -30,22 +30,8 @@ function isLoginPathname(pathname: string) {
   return segments[0] === 'login' || (segments[1] === 'login' && isLocaleCode(segments[0]))
 }
 
-async function safeServerSignOut() {
-  try {
-    await fetch('/api/auth/sign-out', {
-      method: 'POST',
-      credentials: 'include',
-      headers: { 'cache-control': 'no-store' },
-    })
-  } catch (error) {
-    logger.warn('Fallback sign-out failed', { error })
-  }
-}
-
 /**
- * Clears the current auth session when we detect an unauthorized response.
- * This removes any stale tokens/cookies and forces a navigation to login so
- * the user can authenticate again.
+ * Routes stale auth state to the login reauth flow.
  */
 export async function handleAuthError(reason: string, callbackPathname: string) {
   if (typeof window === 'undefined') return
@@ -58,7 +44,6 @@ export async function handleAuthError(reason: string, callbackPathname: string) 
   }
 
   isHandlingAuthError = true
-  await safeServerSignOut()
 
   if (isLoginPathname(window.location.pathname)) {
     const loginUrl = new URL(window.location.href)

--- a/apps/tradinggoose/lib/auth/redirect-urls.ts
+++ b/apps/tradinggoose/lib/auth/redirect-urls.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useLocale } from 'next-intl'
+import { getAuthErrorCallbackPath } from '@/lib/auth/auth-error-copy'
 import { getBaseUrl } from '@/lib/urls/utils'
 import { localizeUrl, normalizeCallbackUrl } from '@/i18n/utils'
 
@@ -12,8 +13,8 @@ export function useAuthRedirectUrls() {
       const canonicalFallbackPath = normalizeCallbackUrl(fallbackPath) ?? '/workspace'
       return normalizeCallbackUrl(callbackPath) ?? canonicalFallbackPath
     },
-    providerErrorPath(path: string) {
-      return normalizeCallbackUrl(path) ?? '/sso'
+    providerErrorPath(callbackPath: string | null | undefined) {
+      return getAuthErrorCallbackPath(callbackPath) ?? '/error'
     },
     passwordResetUrl() {
       return localizeUrl(getBaseUrl(), locale, '/reset-password')

--- a/apps/tradinggoose/lib/copilot/tools/client/workflow/workflow-review-tool-utils.test.ts
+++ b/apps/tradinggoose/lib/copilot/tools/client/workflow/workflow-review-tool-utils.test.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildWorkflowDocumentToolResult,
+  buildWorkflowSummary,
+  getReadableWorkflowState,
+} from './workflow-review-tool-utils'
 
-const mockGetRegisteredWorkflowSession = vi.fn()
-const mockAcquireWritableWorkflowSessionLease = vi.fn()
+const mockGetRegisteredWorkflowSession = vi.hoisted(() => vi.fn())
+const mockAcquireWritableWorkflowSessionLease = vi.hoisted(() => vi.fn())
 
 vi.mock('@/lib/yjs/workflow-session-registry', () => ({
   getRegisteredWorkflowSession: (...args: unknown[]) => mockGetRegisteredWorkflowSession(...args),
@@ -55,7 +60,6 @@ describe('workflow-review-tool-utils', () => {
       doc,
     })
 
-    const { getReadableWorkflowState } = await import('./workflow-review-tool-utils')
     const result = await getReadableWorkflowState(
       {
         toolCallId: 'tool-1',
@@ -95,7 +99,6 @@ describe('workflow-review-tool-utils', () => {
       release,
     })
 
-    const { getReadableWorkflowState } = await import('./workflow-review-tool-utils')
     const result = await getReadableWorkflowState(
       {
         toolCallId: 'tool-1',
@@ -130,7 +133,6 @@ describe('workflow-review-tool-utils', () => {
   })
 
   it('fails fast when workflow execution context is missing a workflow target', async () => {
-    const { getReadableWorkflowState } = await import('./workflow-review-tool-utils')
     await expect(
       getReadableWorkflowState({
         toolCallId: 'tool-1',
@@ -142,8 +144,6 @@ describe('workflow-review-tool-utils', () => {
   })
 
   it('builds workflow document payloads with canonical workflow identity', async () => {
-    const { buildWorkflowDocumentToolResult } = await import('./workflow-review-tool-utils')
-
     expect(
       buildWorkflowDocumentToolResult({
         workflowId: 'workflow-entity',
@@ -160,8 +160,6 @@ describe('workflow-review-tool-utils', () => {
   })
 
   it('surfaces invalid external edges into container end handles', async () => {
-    const { buildWorkflowSummary } = await import('./workflow-review-tool-utils')
-
     expect(
       buildWorkflowSummary({
         blocks: {
@@ -192,8 +190,6 @@ describe('workflow-review-tool-utils', () => {
   })
 
   it('surfaces missing outer input handles on incoming container edges', async () => {
-    const { buildWorkflowSummary } = await import('./workflow-review-tool-utils')
-
     const summary = buildWorkflowSummary({
       blocks: {
         input: block('input', 'input_trigger', 'Input'),
@@ -230,8 +226,6 @@ describe('workflow-review-tool-utils', () => {
   })
 
   it('marks container branch edges as internal so missing outer edges stay visible', async () => {
-    const { buildWorkflowSummary } = await import('./workflow-review-tool-utils')
-
     const child = {
       ...block('child', 'function', 'Child'),
       data: { parentId: 'parallel', extent: 'parent' as const },

--- a/apps/tradinggoose/lib/copilot/tools/server/blocks/get-blocks-metadata.test.ts
+++ b/apps/tradinggoose/lib/copilot/tools/server/blocks/get-blocks-metadata.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getBlocksMetadataServerTool } from '@/lib/copilot/tools/server/blocks/get-blocks-metadata'
 
 const mockGetOAuthProviderAvailability = vi.hoisted(() => vi.fn())
 
@@ -131,17 +132,13 @@ vi.mock('@/tools/registry', () => ({
 
 describe('getBlocksMetadataServerTool', () => {
   beforeEach(() => {
-    vi.resetModules()
+    mockGetOAuthProviderAvailability.mockReset()
     mockGetOAuthProviderAvailability.mockImplementation(async (providerIds: string[]) =>
       Object.fromEntries(providerIds.map((providerId) => [providerId, false]))
     )
   })
 
   it('returns Mermaid profiles and operation variants instead of schema-shaped metadata', async () => {
-    const { getBlocksMetadataServerTool } = await import(
-      '@/lib/copilot/tools/server/blocks/get-blocks-metadata'
-    )
-
     const result = await getBlocksMetadataServerTool.execute({
       blockTypes: [
         'github',

--- a/apps/tradinggoose/lib/copilot/tools/server/workflow/edit-workflow-block.test.ts
+++ b/apps/tradinggoose/lib/copilot/tools/server/workflow/edit-workflow-block.test.ts
@@ -34,30 +34,34 @@ const CURRENT_WORKFLOW_STATE = JSON.stringify({
 })
 
 describe('editWorkflowBlockServerTool', () => {
-  it('patches only the selected block config and preserves the workflow document envelope', async () => {
-    const { editWorkflowBlockServerTool } = await import(
-      '@/lib/copilot/tools/server/workflow/edit-workflow-block'
-    )
+  it(
+    'patches only the selected block config and preserves the workflow document envelope',
+    { timeout: 10_000 },
+    async () => {
+      const { editWorkflowBlockServerTool } = await import(
+        '@/lib/copilot/tools/server/workflow/edit-workflow-block'
+      )
 
-    const result = await editWorkflowBlockServerTool.execute(
-      {
-        entityId: 'wf-1',
-        blockId: 'fn1',
-        blockType: 'function',
-        name: 'Compute Market Indicators',
-        subBlocks: {
-          code: 'return { rsi: 50 }',
+      const result = await editWorkflowBlockServerTool.execute(
+        {
+          entityId: 'wf-1',
+          blockId: 'fn1',
+          blockType: 'function',
+          name: 'Compute Market Indicators',
+          subBlocks: {
+            code: 'return { rsi: 50 }',
+          },
+          currentWorkflowState: CURRENT_WORKFLOW_STATE,
         },
-        currentWorkflowState: CURRENT_WORKFLOW_STATE,
-      },
-      { userId: 'user-1' }
-    )
+        { userId: 'user-1' }
+      )
 
-    expect(result.workflowState.blocks.fn1.name).toBe('Compute Market Indicators')
-    expect(result.workflowState.blocks.fn1.subBlocks.code.value).toBe('return { rsi: 50 }')
-    expect(result.workflowState.edges).toEqual([])
-    expect(result.entityDocument).toContain('Compute Market Indicators')
-  })
+      expect(result.workflowState.blocks.fn1.name).toBe('Compute Market Indicators')
+      expect(result.workflowState.blocks.fn1.subBlocks.code.value).toBe('return { rsi: 50 }')
+      expect(result.workflowState.edges).toEqual([])
+      expect(result.entityDocument).toContain('Compute Market Indicators')
+    }
+  )
 
   it('rejects non-canonical sub-block ids with structured issues', async () => {
     const { editWorkflowBlockServerTool } = await import(

--- a/apps/tradinggoose/lib/copilot/tools/server/workflow/edit-workflow-block.test.ts
+++ b/apps/tradinggoose/lib/copilot/tools/server/workflow/edit-workflow-block.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { editWorkflowBlockServerTool } from '@/lib/copilot/tools/server/workflow/edit-workflow-block'
 
 vi.mock('@/lib/workflows/validation', () => ({
   validateWorkflowState: (state: any) => ({
@@ -7,6 +8,17 @@ vi.mock('@/lib/workflows/validation', () => ({
     warnings: [],
     sanitizedState: state,
   }),
+}))
+
+vi.mock('@/blocks', () => ({
+  getBlock: (blockType: string) =>
+    blockType === 'function'
+      ? {
+          type: 'function',
+          name: 'Function',
+          subBlocks: [{ id: 'code', type: 'code' }],
+        }
+      : undefined,
 }))
 
 const CURRENT_WORKFLOW_STATE = JSON.stringify({
@@ -34,40 +46,28 @@ const CURRENT_WORKFLOW_STATE = JSON.stringify({
 })
 
 describe('editWorkflowBlockServerTool', () => {
-  it(
-    'patches only the selected block config and preserves the workflow document envelope',
-    { timeout: 10_000 },
-    async () => {
-      const { editWorkflowBlockServerTool } = await import(
-        '@/lib/copilot/tools/server/workflow/edit-workflow-block'
-      )
-
-      const result = await editWorkflowBlockServerTool.execute(
-        {
-          entityId: 'wf-1',
-          blockId: 'fn1',
-          blockType: 'function',
-          name: 'Compute Market Indicators',
-          subBlocks: {
-            code: 'return { rsi: 50 }',
-          },
-          currentWorkflowState: CURRENT_WORKFLOW_STATE,
+  it('patches only the selected block config and preserves the workflow document envelope', async () => {
+    const result = await editWorkflowBlockServerTool.execute(
+      {
+        entityId: 'wf-1',
+        blockId: 'fn1',
+        blockType: 'function',
+        name: 'Compute Market Indicators',
+        subBlocks: {
+          code: 'return { rsi: 50 }',
         },
-        { userId: 'user-1' }
-      )
-
-      expect(result.workflowState.blocks.fn1.name).toBe('Compute Market Indicators')
-      expect(result.workflowState.blocks.fn1.subBlocks.code.value).toBe('return { rsi: 50 }')
-      expect(result.workflowState.edges).toEqual([])
-      expect(result.entityDocument).toContain('Compute Market Indicators')
-    }
-  )
-
-  it('rejects non-canonical sub-block ids with structured issues', async () => {
-    const { editWorkflowBlockServerTool } = await import(
-      '@/lib/copilot/tools/server/workflow/edit-workflow-block'
+        currentWorkflowState: CURRENT_WORKFLOW_STATE,
+      },
+      { userId: 'user-1' }
     )
 
+    expect(result.workflowState.blocks.fn1.name).toBe('Compute Market Indicators')
+    expect(result.workflowState.blocks.fn1.subBlocks.code.value).toBe('return { rsi: 50 }')
+    expect(result.workflowState.edges).toEqual([])
+    expect(result.entityDocument).toContain('Compute Market Indicators')
+  })
+
+  it('rejects non-canonical sub-block ids with structured issues', async () => {
     await expect(
       editWorkflowBlockServerTool.execute(
         {

--- a/apps/tradinggoose/lib/copilot/tools/server/workflow/edit-workflow.test.ts
+++ b/apps/tradinggoose/lib/copilot/tools/server/workflow/edit-workflow.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { editWorkflowServerTool } from '@/lib/copilot/tools/server/workflow/edit-workflow'
 import { WORKFLOW_GRAPH_MERMAID_DOCUMENT_FORMAT } from '@/lib/workflows/document-format'
 
 vi.mock('@/lib/workflows/validation', () => ({
@@ -55,10 +56,6 @@ function graph(lines: string[]): string {
 
 describe('editWorkflowServerTool', () => {
   it('connects existing blocks without rewriting block internals', async () => {
-    const { editWorkflowServerTool } = await import(
-      '@/lib/copilot/tools/server/workflow/edit-workflow'
-    )
-
     const result = await editWorkflowServerTool.execute(
       {
         entityId: 'wf-1',
@@ -88,10 +85,6 @@ describe('editWorkflowServerTool', () => {
   })
 
   it('rejects existing block label renames instead of ignoring them', async () => {
-    const { editWorkflowServerTool } = await import(
-      '@/lib/copilot/tools/server/workflow/edit-workflow'
-    )
-
     await expect(
       editWorkflowServerTool.execute(
         {
@@ -126,10 +119,6 @@ describe('editWorkflowServerTool', () => {
   })
 
   it('rejects existing block type changes instead of treating them as replacements', async () => {
-    const { editWorkflowServerTool } = await import(
-      '@/lib/copilot/tools/server/workflow/edit-workflow'
-    )
-
     await expect(
       editWorkflowServerTool.execute(
         {
@@ -150,10 +139,6 @@ describe('editWorkflowServerTool', () => {
   })
 
   it('adds new blocks with canonical block defaults from metadata-only labels', async () => {
-    const { editWorkflowServerTool } = await import(
-      '@/lib/copilot/tools/server/workflow/edit-workflow'
-    )
-
     const result = await editWorkflowServerTool.execute(
       {
         entityId: 'wf-1',
@@ -189,10 +174,6 @@ describe('editWorkflowServerTool', () => {
   })
 
   it('places new blocks after existing siblings regardless of Mermaid order', async () => {
-    const { editWorkflowServerTool } = await import(
-      '@/lib/copilot/tools/server/workflow/edit-workflow'
-    )
-
     const result = await editWorkflowServerTool.execute(
       {
         entityId: 'wf-1',
@@ -211,10 +192,6 @@ describe('editWorkflowServerTool', () => {
   })
 
   it('preserves existing block absolute position when moving into a container', async () => {
-    const { editWorkflowServerTool } = await import(
-      '@/lib/copilot/tools/server/workflow/edit-workflow'
-    )
-
     const result = await editWorkflowServerTool.execute(
       {
         entityId: 'wf-1',
@@ -254,10 +231,6 @@ describe('editWorkflowServerTool', () => {
   })
 
   it('rejects block-internal fields in graph-only workflow edits', async () => {
-    const { editWorkflowServerTool } = await import(
-      '@/lib/copilot/tools/server/workflow/edit-workflow'
-    )
-
     await expect(
       editWorkflowServerTool.execute(
         {
@@ -276,10 +249,6 @@ describe('editWorkflowServerTool', () => {
   })
 
   it('rejects omitted existing blocks without explicit removedBlockIds', async () => {
-    const { editWorkflowServerTool } = await import(
-      '@/lib/copilot/tools/server/workflow/edit-workflow'
-    )
-
     await expect(
       editWorkflowServerTool.execute(
         {
@@ -298,10 +267,6 @@ describe('editWorkflowServerTool', () => {
   })
 
   it('removes omitted blocks only when removedBlockIds declares intent', async () => {
-    const { editWorkflowServerTool } = await import(
-      '@/lib/copilot/tools/server/workflow/edit-workflow'
-    )
-
     const result = await editWorkflowServerTool.execute(
       {
         entityId: 'wf-1',
@@ -337,10 +302,6 @@ describe('editWorkflowServerTool', () => {
   })
 
   it('rejects removedBlockIds that still appear in the graph', async () => {
-    const { editWorkflowServerTool } = await import(
-      '@/lib/copilot/tools/server/workflow/edit-workflow'
-    )
-
     await expect(
       editWorkflowServerTool.execute(
         {
@@ -359,10 +320,6 @@ describe('editWorkflowServerTool', () => {
   })
 
   it('rejects old TG metadata comments in mutation input', async () => {
-    const { editWorkflowServerTool } = await import(
-      '@/lib/copilot/tools/server/workflow/edit-workflow'
-    )
-
     await expect(
       editWorkflowServerTool.execute(
         {


### PR DESCRIPTION
## Summary
- Replace cookie-based auth error handling with callback-safe auth error routes.
- Preserve callback URLs through login, SSO, social auth, provider failure, and reauth cleanup flows.
- Force failed or unauthorized session states through reauth cleanup instead of relying on stale session cookie state.
- Use the canonical app session for the socket token route.
- Add and update auth, socket-token, nav, and workflow test coverage.

## Why
Auth failures could lose callback context, leave stale session state behind, or route provider/session errors inconsistently. This change makes failed auth recovery deterministic by centralizing error handling and reauth cleanup while keeping the original callback target intact.

## Affected Areas
- [x] `apps/tradinggoose`
- [ ] `apps/docs`
- [ ] `packages/*`
- [x] Workflows / execution
- [x] Realtime / sockets
- [ ] Market data / charting
- [ ] Dev tooling / CI / infra
- [ ] Documentation only
- [ ] Other:

## Issue Links( if any )
N/A

## Validation
```bash
# Not run locally; PR body drafted from branch diff against upstream/staging.
```

## Risk / Rollout Notes
Auth login, SSO, social provider callback, and session recovery behavior changed. Validate these flows in staging before promotion.

Backout plan: revert this PR to restore the previous auth error cookie flow and session handling behavior.

## Config / Data Changes
- Env vars added or changed: None
- Database schema or migration impact: None
- External services or provider behavior changed: OAuth/SSO provider failures now route through the app auth error callback and reauth cleanup flow; no provider configuration changes required.

## Screenshots / Video
N/A; no visible UI layout changes.

## Checklist
- [x] I kept the change focused and reviewed my own diff
- [ ] I validated the change locally and documented the results above
- [x] I updated docs, examples, or copy if behavior/user-facing flows changed
- [x] I called out any env, schema, provider, or rollout impact
- [x] I did not include secrets, tokens, or private credentials in this PR