### PR TITLE
fix(workspaces): centralize access checks and auth redirects

### DIFF
--- a/apps/tradinggoose/app/(auth)/login/login-form.tsx
+++ b/apps/tradinggoose/app/(auth)/login/login-form.tsx
@@ -29,6 +29,7 @@ import { SSOLoginButton } from '@/app/(auth)/components/sso-login-button'
 import { inter } from '@/app/fonts/inter'
 import { Link, useRouter } from '@/i18n/navigation'
 import { normalizeCallbackUrl } from '@/i18n/utils'
+import { clearUserData } from '@/stores'
 
 const logger = createLogger('LoginForm')
 const REAUTH_CLEANUP_TIMEOUT_MS = 4000
@@ -148,10 +149,11 @@ export default function LoginPage({
       }, REAUTH_CLEANUP_TIMEOUT_MS)
     })
 
-    const cleanupPromise = Promise.race([signOutPromise, timeoutPromise]).finally(() => {
+    const cleanupPromise = Promise.race([signOutPromise, timeoutPromise]).finally(async () => {
       if (timeoutId) {
         clearTimeout(timeoutId)
       }
+      await clearUserData()
       shouldRunReauthCleanupRef.current = false
       reauthCleanupPromiseRef.current = null
     })

--- a/apps/tradinggoose/app/[locale]/admin/layout.test.tsx
+++ b/apps/tradinggoose/app/[locale]/admin/layout.test.tsx
@@ -123,6 +123,34 @@ describe('Admin layout', () => {
     expect(mockNotFound).not.toHaveBeenCalled()
   })
 
+  it('routes invalid admin session cookies through reauth cleanup', async () => {
+    mockHeaders.mockResolvedValue(
+      new Headers([
+        [CANONICAL_CALLBACK_PATH_HEADER, '/admin/billing?from=nav'],
+        ['cookie', 'better-auth.session_token=stale'],
+      ])
+    )
+    mockGetSystemAdminAccess.mockResolvedValue({
+      isAuthenticated: false,
+      isSystemAdmin: false,
+      canBootstrapSystemAdmin: false,
+    })
+
+    const AdminLayout = (await import('./layout')).default
+
+    await expect(
+      AdminLayout({
+        children: <div>admin content</div>,
+        params: Promise.resolve({ locale: 'es' }),
+      })
+    ).rejects.toThrow('redirect:/es/login?reauth=1&callbackUrl=%2Fadmin%2Fbilling%3Ffrom%3Dnav')
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      '/es/login?reauth=1&callbackUrl=%2Fadmin%2Fbilling%3Ffrom%3Dnav'
+    )
+    expect(mockNotFound).not.toHaveBeenCalled()
+  })
+
   it('calls notFound when the user cannot access admin routes', async () => {
     mockGetSystemAdminAccess.mockResolvedValue({
       isAuthenticated: true,

--- a/apps/tradinggoose/app/[locale]/admin/layout.test.tsx
+++ b/apps/tradinggoose/app/[locale]/admin/layout.test.tsx
@@ -1,6 +1,7 @@
 import type React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CANONICAL_CALLBACK_PATH_HEADER } from '@/i18n/utils'
 
 let capturedGlobalNavbarProps:
   | {
@@ -12,10 +13,37 @@ let capturedGlobalNavbarProps:
 const mockNotFound = vi.fn(() => {
   throw new Error('notFound')
 })
+const mockRedirect = vi.fn((url: string) => {
+  throw new Error(`redirect:${url}`)
+})
 const mockGetSystemAdminAccess = vi.fn()
+const mockHeaders = vi.fn()
 
 vi.mock('next/navigation', () => ({
   notFound: () => mockNotFound(),
+}))
+
+vi.mock('next/headers', () => ({
+  headers: () => mockHeaders(),
+}))
+
+vi.mock('@/i18n/navigation', () => ({
+  redirect: ({
+    href,
+    locale,
+  }: {
+    href: string | { pathname: string; query?: Record<string, string> }
+    locale?: string
+  }) => {
+    const canonicalPath =
+      typeof href === 'string'
+        ? href
+        : `${href.pathname}${href.query ? `?${new URLSearchParams(href.query).toString()}` : ''}`
+    const localizedPath =
+      locale && canonicalPath.startsWith('/') ? `/${locale}${canonicalPath}` : canonicalPath
+
+    return mockRedirect(localizedPath)
+  },
 }))
 
 vi.mock('@/lib/admin/access', () => ({
@@ -42,10 +70,16 @@ describe('Admin layout', () => {
     vi.clearAllMocks()
     vi.resetModules()
     capturedGlobalNavbarProps = undefined
+    mockHeaders.mockResolvedValue(new Headers())
+
+    mockRedirect.mockImplementation((url: string) => {
+      throw new Error(`redirect:${url}`)
+    })
   })
 
   it('renders admin content inside the admin navbar', async () => {
     mockGetSystemAdminAccess.mockResolvedValue({
+      isAuthenticated: true,
       isSystemAdmin: false,
       canBootstrapSystemAdmin: true,
     })
@@ -61,10 +95,37 @@ describe('Admin layout', () => {
       isSystemAdmin: false,
       navigationMode: 'admin',
     })
+    expect(mockGetSystemAdminAccess).toHaveBeenCalledWith(expect.any(Headers))
+  })
+
+  it('redirects signed-out admin entry to login with the current callback target', async () => {
+    mockHeaders.mockResolvedValue(
+      new Headers([[CANONICAL_CALLBACK_PATH_HEADER, '/admin/billing?from=nav']])
+    )
+    mockGetSystemAdminAccess.mockResolvedValue({
+      isAuthenticated: false,
+      isSystemAdmin: false,
+      canBootstrapSystemAdmin: false,
+    })
+
+    const AdminLayout = (await import('./layout')).default
+
+    await expect(
+      AdminLayout({
+        children: <div>admin content</div>,
+        params: Promise.resolve({ locale: 'es' }),
+      })
+    ).rejects.toThrow('redirect:/es/login?reauth=1&callbackUrl=%2Fadmin%2Fbilling%3Ffrom%3Dnav')
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      '/es/login?reauth=1&callbackUrl=%2Fadmin%2Fbilling%3Ffrom%3Dnav'
+    )
+    expect(mockNotFound).not.toHaveBeenCalled()
   })
 
   it('calls notFound when the user cannot access admin routes', async () => {
     mockGetSystemAdminAccess.mockResolvedValue({
+      isAuthenticated: true,
       isSystemAdmin: false,
       canBootstrapSystemAdmin: false,
     })

--- a/apps/tradinggoose/app/[locale]/admin/layout.test.tsx
+++ b/apps/tradinggoose/app/[locale]/admin/layout.test.tsx
@@ -115,10 +115,10 @@ describe('Admin layout', () => {
         children: <div>admin content</div>,
         params: Promise.resolve({ locale: 'es' }),
       })
-    ).rejects.toThrow('redirect:/es/login?reauth=1&callbackUrl=%2Fadmin%2Fbilling%3Ffrom%3Dnav')
+    ).rejects.toThrow('redirect:/es/login?callbackUrl=%2Fadmin%2Fbilling%3Ffrom%3Dnav')
 
     expect(mockRedirect).toHaveBeenCalledWith(
-      '/es/login?reauth=1&callbackUrl=%2Fadmin%2Fbilling%3Ffrom%3Dnav'
+      '/es/login?callbackUrl=%2Fadmin%2Fbilling%3Ffrom%3Dnav'
     )
     expect(mockNotFound).not.toHaveBeenCalled()
   })

--- a/apps/tradinggoose/app/[locale]/admin/layout.tsx
+++ b/apps/tradinggoose/app/[locale]/admin/layout.tsx
@@ -24,7 +24,6 @@ export default async function AdminLayout({
       href: {
         pathname: '/login',
         query: {
-          reauth: '1',
           callbackUrl: requireCanonicalCallbackPath(requestHeaders, 'admin'),
         },
       },

--- a/apps/tradinggoose/app/[locale]/admin/layout.tsx
+++ b/apps/tradinggoose/app/[locale]/admin/layout.tsx
@@ -1,4 +1,5 @@
 import type React from 'react'
+import { getSessionCookie } from 'better-auth/cookies'
 import { headers } from 'next/headers'
 import { notFound } from 'next/navigation'
 import { NextIntlClientProvider } from 'next-intl'
@@ -24,6 +25,7 @@ export default async function AdminLayout({
       href: {
         pathname: '/login',
         query: {
+          ...(getSessionCookie(requestHeaders) ? { reauth: '1' } : {}),
           callbackUrl: requireCanonicalCallbackPath(requestHeaders, 'admin'),
         },
       },

--- a/apps/tradinggoose/app/[locale]/admin/layout.tsx
+++ b/apps/tradinggoose/app/[locale]/admin/layout.tsx
@@ -1,10 +1,12 @@
 import type React from 'react'
+import { headers } from 'next/headers'
 import { notFound } from 'next/navigation'
 import { NextIntlClientProvider } from 'next-intl'
 import { getSystemAdminAccess } from '@/lib/admin/access'
 import { GlobalNavbar } from '@/global-navbar'
+import { redirect } from '@/i18n/navigation'
 import { getClientMessages } from '@/i18n/public-copy'
-import type { LocaleCode } from '@/i18n/utils'
+import { CANONICAL_CALLBACK_PATH_HEADER, type LocaleCode } from '@/i18n/utils'
 
 export default async function AdminLayout({
   children,
@@ -13,8 +15,27 @@ export default async function AdminLayout({
   children: React.ReactNode
   params: Promise<{ locale: string }>
 }) {
-  const [{ locale: routeLocale }, access] = await Promise.all([params, getSystemAdminAccess()])
+  const [{ locale: routeLocale }, requestHeaders] = await Promise.all([params, headers()])
   const locale = routeLocale as LocaleCode
+  const access = await getSystemAdminAccess(requestHeaders)
+
+  if (!access.isAuthenticated) {
+    const callbackUrl = requestHeaders.get(CANONICAL_CALLBACK_PATH_HEADER)
+    if (!callbackUrl) {
+      throw new Error('Missing canonical callback path for admin reauth redirect')
+    }
+
+    return redirect({
+      href: {
+        pathname: '/login',
+        query: {
+          reauth: '1',
+          callbackUrl,
+        },
+      },
+      locale,
+    })
+  }
 
   if (!access.isSystemAdmin && !access.canBootstrapSystemAdmin) {
     notFound()

--- a/apps/tradinggoose/app/[locale]/admin/layout.tsx
+++ b/apps/tradinggoose/app/[locale]/admin/layout.tsx
@@ -6,7 +6,7 @@ import { getSystemAdminAccess } from '@/lib/admin/access'
 import { GlobalNavbar } from '@/global-navbar'
 import { redirect } from '@/i18n/navigation'
 import { getClientMessages } from '@/i18n/public-copy'
-import { CANONICAL_CALLBACK_PATH_HEADER, type LocaleCode } from '@/i18n/utils'
+import { type LocaleCode, requireCanonicalCallbackPath } from '@/i18n/utils'
 
 export default async function AdminLayout({
   children,
@@ -20,17 +20,12 @@ export default async function AdminLayout({
   const access = await getSystemAdminAccess(requestHeaders)
 
   if (!access.isAuthenticated) {
-    const callbackUrl = requestHeaders.get(CANONICAL_CALLBACK_PATH_HEADER)
-    if (!callbackUrl) {
-      throw new Error('Missing canonical callback path for admin reauth redirect')
-    }
-
     return redirect({
       href: {
         pathname: '/login',
         query: {
           reauth: '1',
-          callbackUrl,
+          callbackUrl: requireCanonicalCallbackPath(requestHeaders, 'admin'),
         },
       },
       locale,

--- a/apps/tradinggoose/app/[locale]/workspace/[workspaceId]/layout.test.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/[workspaceId]/layout.test.tsx
@@ -82,6 +82,32 @@ describe('Workspace layout access guard', () => {
     expect(mockCheckWorkspaceAccess).not.toHaveBeenCalled()
   })
 
+  it('routes invalid session cookies through reauth cleanup', async () => {
+    mockHeaders.mockResolvedValue(
+      new Headers([
+        [CANONICAL_CALLBACK_PATH_HEADER, '/workspace/ws-1/files?layoutId=layout-1'],
+        ['cookie', 'better-auth.session_token=stale'],
+      ])
+    )
+    mockGetSession.mockResolvedValue(null)
+
+    const WorkspaceLayout = (await import('./layout')).default
+
+    await expect(
+      WorkspaceLayout({
+        children: <div>workspace</div>,
+        params: Promise.resolve({ locale: 'es', workspaceId: 'ws-1' }),
+      })
+    ).rejects.toThrow(
+      'redirect:/es/login?reauth=1&callbackUrl=%2Fworkspace%2Fws-1%2Ffiles%3FlayoutId%3Dlayout-1'
+    )
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      '/es/login?reauth=1&callbackUrl=%2Fworkspace%2Fws-1%2Ffiles%3FlayoutId%3Dlayout-1'
+    )
+    expect(mockCheckWorkspaceAccess).not.toHaveBeenCalled()
+  })
+
   it('redirects to the localized workspace root when the user cannot access the workspace', async () => {
     mockGetSession.mockResolvedValue({
       user: {

--- a/apps/tradinggoose/app/[locale]/workspace/[workspaceId]/layout.test.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/[workspaceId]/layout.test.tsx
@@ -72,11 +72,11 @@ describe('Workspace layout access guard', () => {
         params: Promise.resolve({ locale: 'es', workspaceId: 'ws-1' }),
       })
     ).rejects.toThrow(
-      'redirect:/es/login?reauth=1&callbackUrl=%2Fworkspace%2Fws-1%2Ffiles%3FlayoutId%3Dlayout-1'
+      'redirect:/es/login?callbackUrl=%2Fworkspace%2Fws-1%2Ffiles%3FlayoutId%3Dlayout-1'
     )
 
     expect(mockRedirect).toHaveBeenCalledWith(
-      '/es/login?reauth=1&callbackUrl=%2Fworkspace%2Fws-1%2Ffiles%3FlayoutId%3Dlayout-1'
+      '/es/login?callbackUrl=%2Fworkspace%2Fws-1%2Ffiles%3FlayoutId%3Dlayout-1'
     )
     expect(mockGetSession).toHaveBeenCalledWith(expect.any(Headers))
     expect(mockCheckWorkspaceAccess).not.toHaveBeenCalled()

--- a/apps/tradinggoose/app/[locale]/workspace/[workspaceId]/layout.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/[workspaceId]/layout.tsx
@@ -23,7 +23,6 @@ export default async function WorkspaceLayout({
       href: {
         pathname: '/login',
         query: {
-          reauth: '1',
           callbackUrl: requireCanonicalCallbackPath(requestHeaders, 'workspace'),
         },
       },

--- a/apps/tradinggoose/app/[locale]/workspace/[workspaceId]/layout.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/[workspaceId]/layout.tsx
@@ -1,3 +1,4 @@
+import { getSessionCookie } from 'better-auth/cookies'
 import { headers } from 'next/headers'
 import { getSession } from '@/lib/auth'
 import { checkWorkspaceAccess } from '@/lib/permissions/utils'
@@ -23,6 +24,7 @@ export default async function WorkspaceLayout({
       href: {
         pathname: '/login',
         query: {
+          ...(getSessionCookie(requestHeaders) ? { reauth: '1' } : {}),
           callbackUrl: requireCanonicalCallbackPath(requestHeaders, 'workspace'),
         },
       },

--- a/apps/tradinggoose/app/[locale]/workspace/[workspaceId]/layout.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/[workspaceId]/layout.tsx
@@ -3,7 +3,7 @@ import { getSession } from '@/lib/auth'
 import { checkWorkspaceAccess } from '@/lib/permissions/utils'
 import Providers from '@/app/workspace/[workspaceId]/providers/providers'
 import { redirect } from '@/i18n/navigation'
-import { CANONICAL_CALLBACK_PATH_HEADER, type LocaleCode } from '@/i18n/utils'
+import { type LocaleCode, requireCanonicalCallbackPath } from '@/i18n/utils'
 
 export default async function WorkspaceLayout({
   children,
@@ -19,17 +19,12 @@ export default async function WorkspaceLayout({
   const userId = session?.user?.id
 
   if (!userId) {
-    const callbackUrl = requestHeaders.get(CANONICAL_CALLBACK_PATH_HEADER)
-    if (!callbackUrl) {
-      throw new Error('Missing canonical callback path for workspace reauth redirect')
-    }
-
     return redirect({
       href: {
         pathname: '/login',
         query: {
           reauth: '1',
-          callbackUrl,
+          callbackUrl: requireCanonicalCallbackPath(requestHeaders, 'workspace'),
         },
       },
       locale,

--- a/apps/tradinggoose/app/[locale]/workspace/page.test.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/page.test.tsx
@@ -125,6 +125,18 @@ describe('Workspace root page access guard', () => {
     expect(mockGetUserWorkspaces).not.toHaveBeenCalled()
   })
 
+  it('redirects authenticated users to host-only local absolute callback URLs', async () => {
+    mockHeaders.mockResolvedValue(new Headers([['host', 'localhost:3000']]))
+
+    await expect(
+      renderWorkspacePage('en', {
+        callbackUrl: 'http://localhost:3000/workspace/workspace-2/dashboard?layoutId=layout-1',
+      })
+    ).rejects.toThrow('redirect:/en/workspace/workspace-2/dashboard?layoutId=layout-1')
+
+    expect(mockGetUserWorkspaces).not.toHaveBeenCalled()
+  })
+
   it('redirects authenticated users to their first workspace dashboard', async () => {
     await expect(renderWorkspacePage('es')).rejects.toThrow(
       'redirect:/es/workspace/workspace-1/dashboard'
@@ -133,6 +145,19 @@ describe('Workspace root page access guard', () => {
     expect(mockGetUserWorkspaces).toHaveBeenCalledWith({
       userId: 'user-1',
       userName: 'Ada Lovelace',
+      autoCreate: false,
+    })
+  })
+
+  it('renders without bootstrapping workspaces during server render', async () => {
+    mockGetUserWorkspaces.mockResolvedValue([])
+
+    await expect(renderWorkspacePage('en')).resolves.toBeNull()
+
+    expect(mockGetUserWorkspaces).toHaveBeenCalledWith({
+      userId: 'user-1',
+      userName: 'Ada Lovelace',
+      autoCreate: false,
     })
   })
 })

--- a/apps/tradinggoose/app/[locale]/workspace/page.test.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/page.test.tsx
@@ -82,11 +82,11 @@ describe('Workspace root page access guard', () => {
     mockGetSession.mockResolvedValue(null)
 
     await expect(renderWorkspacePage('zh')).rejects.toThrow(
-      'redirect:/zh/login?reauth=1&callbackUrl=%2Fworkspace%3Fredirect_workflow%3Dworkflow-1'
+      'redirect:/zh/login?callbackUrl=%2Fworkspace%3Fredirect_workflow%3Dworkflow-1'
     )
 
     expect(mockRedirect).toHaveBeenCalledWith(
-      '/zh/login?reauth=1&callbackUrl=%2Fworkspace%3Fredirect_workflow%3Dworkflow-1'
+      '/zh/login?callbackUrl=%2Fworkspace%3Fredirect_workflow%3Dworkflow-1'
     )
     expect(mockGetSession).toHaveBeenCalledWith(expect.any(Headers))
   })
@@ -109,9 +109,11 @@ describe('Workspace root page access guard', () => {
   })
 
   it('redirects authenticated users to same-origin absolute callback URLs', async () => {
+    mockHeaders.mockResolvedValue(new Headers([['host', 'preview.local:3000']]))
+
     await expect(
       renderWorkspacePage('en', {
-        callbackUrl: 'http://localhost:3000/workspace/workspace-2/dashboard?layoutId=layout-1',
+        callbackUrl: 'http://preview.local:3000/workspace/workspace-2/dashboard?layoutId=layout-1',
       })
     ).rejects.toThrow('redirect:/en/workspace/workspace-2/dashboard?layoutId=layout-1')
 

--- a/apps/tradinggoose/app/[locale]/workspace/page.test.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/page.test.tsx
@@ -91,6 +91,25 @@ describe('Workspace root page access guard', () => {
     expect(mockGetSession).toHaveBeenCalledWith(expect.any(Headers))
   })
 
+  it('routes invalid session cookies through reauth cleanup', async () => {
+    mockHeaders.mockResolvedValue(
+      new Headers([
+        [CANONICAL_CALLBACK_PATH_HEADER, '/workspace?redirect_workflow=workflow-1'],
+        ['cookie', 'better-auth.session_token=stale'],
+      ])
+    )
+    mockGetSession.mockResolvedValue(null)
+
+    await expect(renderWorkspacePage('zh')).rejects.toThrow(
+      'redirect:/zh/login?reauth=1&callbackUrl=%2Fworkspace%3Fredirect_workflow%3Dworkflow-1'
+    )
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      '/zh/login?reauth=1&callbackUrl=%2Fworkspace%3Fredirect_workflow%3Dworkflow-1'
+    )
+    expect(mockGetSession).toHaveBeenCalledWith(expect.any(Headers))
+  })
+
   it('redirects authenticated users to the requested workflow workspace', async () => {
     mockReadWorkflowAccessContext.mockResolvedValue({
       workflow: {

--- a/apps/tradinggoose/app/[locale]/workspace/page.test.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/page.test.tsx
@@ -37,6 +37,10 @@ vi.mock('@/lib/auth', () => ({
   getSession: (...args: unknown[]) => mockGetSession(...args),
 }))
 
+vi.mock('@/lib/urls/utils', () => ({
+  getBaseUrl: () => 'https://app.example.com',
+}))
+
 vi.mock('@/lib/workspaces/service', () => ({
   getUserWorkspaces: (...args: unknown[]) => mockGetUserWorkspaces(...args),
 }))
@@ -105,6 +109,16 @@ describe('Workspace root page access guard', () => {
     )
 
     expect(mockReadWorkflowAccessContext).toHaveBeenCalledWith('workflow-1', 'user-1')
+    expect(mockGetUserWorkspaces).not.toHaveBeenCalled()
+  })
+
+  it('redirects authenticated users to same-origin absolute callback URLs', async () => {
+    await expect(
+      renderWorkspacePage('en', {
+        callbackUrl: 'https://app.example.com/workspace/workspace-2/dashboard?layoutId=layout-1',
+      })
+    ).rejects.toThrow('redirect:/en/workspace/workspace-2/dashboard?layoutId=layout-1')
+
     expect(mockGetUserWorkspaces).not.toHaveBeenCalled()
   })
 

--- a/apps/tradinggoose/app/[locale]/workspace/page.test.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/page.test.tsx
@@ -37,10 +37,6 @@ vi.mock('@/lib/auth', () => ({
   getSession: (...args: unknown[]) => mockGetSession(...args),
 }))
 
-vi.mock('@/lib/urls/utils', () => ({
-  getBaseUrl: () => 'https://app.example.com',
-}))
-
 vi.mock('@/lib/workspaces/service', () => ({
   getUserWorkspaces: (...args: unknown[]) => mockGetUserWorkspaces(...args),
 }))
@@ -113,9 +109,16 @@ describe('Workspace root page access guard', () => {
   })
 
   it('redirects authenticated users to same-origin absolute callback URLs', async () => {
+    mockHeaders.mockResolvedValue(
+      new Headers([
+        ['x-forwarded-proto', 'http'],
+        ['x-forwarded-host', 'localhost:3000'],
+      ])
+    )
+
     await expect(
       renderWorkspacePage('en', {
-        callbackUrl: 'https://app.example.com/workspace/workspace-2/dashboard?layoutId=layout-1',
+        callbackUrl: 'http://localhost:3000/workspace/workspace-2/dashboard?layoutId=layout-1',
       })
     ).rejects.toThrow('redirect:/en/workspace/workspace-2/dashboard?layoutId=layout-1')
 

--- a/apps/tradinggoose/app/[locale]/workspace/page.test.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/page.test.tsx
@@ -109,25 +109,6 @@ describe('Workspace root page access guard', () => {
   })
 
   it('redirects authenticated users to same-origin absolute callback URLs', async () => {
-    mockHeaders.mockResolvedValue(
-      new Headers([
-        ['x-forwarded-proto', 'http'],
-        ['x-forwarded-host', 'localhost:3000'],
-      ])
-    )
-
-    await expect(
-      renderWorkspacePage('en', {
-        callbackUrl: 'http://localhost:3000/workspace/workspace-2/dashboard?layoutId=layout-1',
-      })
-    ).rejects.toThrow('redirect:/en/workspace/workspace-2/dashboard?layoutId=layout-1')
-
-    expect(mockGetUserWorkspaces).not.toHaveBeenCalled()
-  })
-
-  it('redirects authenticated users to host-only local absolute callback URLs', async () => {
-    mockHeaders.mockResolvedValue(new Headers([['host', 'localhost:3000']]))
-
     await expect(
       renderWorkspacePage('en', {
         callbackUrl: 'http://localhost:3000/workspace/workspace-2/dashboard?layoutId=layout-1',
@@ -145,19 +126,19 @@ describe('Workspace root page access guard', () => {
     expect(mockGetUserWorkspaces).toHaveBeenCalledWith({
       userId: 'user-1',
       userName: 'Ada Lovelace',
-      autoCreate: false,
     })
   })
 
-  it('renders without bootstrapping workspaces during server render', async () => {
-    mockGetUserWorkspaces.mockResolvedValue([])
+  it('bootstraps a workspace on the server when the user has none and redirects to it', async () => {
+    mockGetUserWorkspaces.mockResolvedValue([{ id: 'workspace-bootstrapped' }])
 
-    await expect(renderWorkspacePage('en')).resolves.toBeNull()
+    await expect(renderWorkspacePage('en')).rejects.toThrow(
+      'redirect:/en/workspace/workspace-bootstrapped/dashboard'
+    )
 
     expect(mockGetUserWorkspaces).toHaveBeenCalledWith({
       userId: 'user-1',
       userName: 'Ada Lovelace',
-      autoCreate: false,
     })
   })
 })

--- a/apps/tradinggoose/app/[locale]/workspace/page.test.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/page.test.tsx
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CANONICAL_CALLBACK_PATH_HEADER } from '@/i18n/utils'
+
+const mockRedirect = vi.fn((url: string) => {
+  throw new Error(`redirect:${url}`)
+})
+const mockGetSession = vi.fn()
+const mockHeaders = vi.fn()
+const mockGetUserWorkspaces = vi.fn()
+const mockReadWorkflowAccessContext = vi.fn()
+
+function mockLocalizedRedirect({
+  href,
+  locale,
+}: {
+  href: string | { pathname: string; query?: Record<string, string> }
+  locale?: string
+}) {
+  const canonicalPath =
+    typeof href === 'string'
+      ? href
+      : `${href.pathname}${href.query ? `?${new URLSearchParams(href.query).toString()}` : ''}`
+  const localizedPath =
+    locale && canonicalPath.startsWith('/') ? `/${locale}${canonicalPath}` : canonicalPath
+  return mockRedirect(localizedPath)
+}
+
+vi.mock('@/i18n/navigation', () => ({
+  redirect: mockLocalizedRedirect,
+}))
+
+vi.mock('next/headers', () => ({
+  headers: () => mockHeaders(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+}))
+
+vi.mock('@/lib/workspaces/service', () => ({
+  getUserWorkspaces: (...args: unknown[]) => mockGetUserWorkspaces(...args),
+}))
+
+vi.mock('@/lib/workflows/utils', () => ({
+  readWorkflowAccessContext: (...args: unknown[]) => mockReadWorkflowAccessContext(...args),
+}))
+
+async function renderWorkspacePage(
+  locale = 'en',
+  searchParams: { callbackUrl?: string; redirect_workflow?: string } = {}
+) {
+  const WorkspacePage = (await import('./page')).default
+  return WorkspacePage({
+    params: Promise.resolve({ locale }),
+    searchParams: Promise.resolve(searchParams),
+  })
+}
+
+describe('Workspace root page access guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    mockHeaders.mockResolvedValue(new Headers())
+
+    mockRedirect.mockImplementation((url: string) => {
+      throw new Error(`redirect:${url}`)
+    })
+    mockGetSession.mockResolvedValue({
+      user: {
+        id: 'user-1',
+        name: 'Ada Lovelace',
+      },
+    })
+    mockGetUserWorkspaces.mockResolvedValue([{ id: 'workspace-1' }])
+    mockReadWorkflowAccessContext.mockResolvedValue(null)
+  })
+
+  it('redirects signed-out users to login with the current callback target', async () => {
+    mockHeaders.mockResolvedValue(
+      new Headers([[CANONICAL_CALLBACK_PATH_HEADER, '/workspace?redirect_workflow=workflow-1']])
+    )
+    mockGetSession.mockResolvedValue(null)
+
+    await expect(renderWorkspacePage('zh')).rejects.toThrow(
+      'redirect:/zh/login?reauth=1&callbackUrl=%2Fworkspace%3Fredirect_workflow%3Dworkflow-1'
+    )
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      '/zh/login?reauth=1&callbackUrl=%2Fworkspace%3Fredirect_workflow%3Dworkflow-1'
+    )
+    expect(mockGetSession).toHaveBeenCalledWith(expect.any(Headers))
+  })
+
+  it('redirects authenticated users to the requested workflow workspace', async () => {
+    mockReadWorkflowAccessContext.mockResolvedValue({
+      workflow: {
+        workspaceId: 'workspace-from-workflow',
+      },
+      isOwner: false,
+      isWorkspaceOwner: false,
+      workspacePermission: 'read',
+    })
+    await expect(renderWorkspacePage('en', { redirect_workflow: 'workflow-1' })).rejects.toThrow(
+      'redirect:/en/workspace/workspace-from-workflow/dashboard'
+    )
+
+    expect(mockReadWorkflowAccessContext).toHaveBeenCalledWith('workflow-1', 'user-1')
+    expect(mockGetUserWorkspaces).not.toHaveBeenCalled()
+  })
+
+  it('redirects authenticated users to their first workspace dashboard', async () => {
+    await expect(renderWorkspacePage('es')).rejects.toThrow(
+      'redirect:/es/workspace/workspace-1/dashboard'
+    )
+
+    expect(mockGetUserWorkspaces).toHaveBeenCalledWith({
+      userId: 'user-1',
+      userName: 'Ada Lovelace',
+    })
+  })
+})

--- a/apps/tradinggoose/app/[locale]/workspace/page.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/page.tsx
@@ -1,5 +1,6 @@
 import { headers } from 'next/headers'
 import { getSession } from '@/lib/auth'
+import { getBaseUrl } from '@/lib/urls/utils'
 import { readWorkflowAccessContext } from '@/lib/workflows/utils'
 import { getUserWorkspaces } from '@/lib/workspaces/service'
 import { redirect } from '@/i18n/navigation'
@@ -52,7 +53,7 @@ export default async function WorkspacePage({
     })
   }
 
-  const callbackUrl = normalizeCallbackUrl(getSearchParam(query, 'callbackUrl'))
+  const callbackUrl = normalizeCallbackUrl(getSearchParam(query, 'callbackUrl'), getBaseUrl())
   if (callbackUrl && callbackUrl.split(/[?#]/, 1)[0] !== '/workspace') {
     return redirect({ href: callbackUrl, locale })
   }

--- a/apps/tradinggoose/app/[locale]/workspace/page.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/page.tsx
@@ -1,5 +1,6 @@
 import { headers } from 'next/headers'
 import { getSession } from '@/lib/auth'
+import { getBaseUrl } from '@/lib/urls/utils'
 import { readWorkflowAccessContext } from '@/lib/workflows/utils'
 import { getUserWorkspaces } from '@/lib/workspaces/service'
 import { redirect } from '@/i18n/navigation'
@@ -16,20 +17,6 @@ function getSearchParam(
 ) {
   const value = searchParams[key]
   return Array.isArray(value) ? value[0] : value
-}
-
-function getRequestOrigin(headers: Headers) {
-  const host = (headers.get('x-forwarded-host') ?? headers.get('host'))?.split(',', 1)[0]?.trim()
-  if (!host) {
-    return undefined
-  }
-
-  const forwardedProtocol = headers.get('x-forwarded-proto')?.split(',', 1)[0]?.trim()
-  const protocol =
-    forwardedProtocol ||
-    (host.startsWith('localhost') || host.startsWith('127.0.0.1') ? 'http' : 'https')
-
-  return `${protocol}://${host}`
 }
 
 export default async function WorkspacePage({
@@ -61,10 +48,7 @@ export default async function WorkspacePage({
     })
   }
 
-  const callbackUrl = normalizeCallbackUrl(
-    getSearchParam(query, 'callbackUrl'),
-    getRequestOrigin(requestHeaders)
-  )
+  const callbackUrl = normalizeCallbackUrl(getSearchParam(query, 'callbackUrl'), getBaseUrl())
   if (callbackUrl && callbackUrl.split(/[?#]/, 1)[0] !== '/workspace') {
     return redirect({ href: callbackUrl, locale })
   }
@@ -83,11 +67,10 @@ export default async function WorkspacePage({
   const [workspace] = await getUserWorkspaces({
     userId,
     userName: session.user.name,
-    autoCreate: false,
   })
 
   if (!workspace) {
-    return null
+    throw new Error('Expected workspace bootstrap to return a workspace')
   }
 
   return redirect({ href: `/workspace/${workspace.id}/dashboard`, locale })

--- a/apps/tradinggoose/app/[locale]/workspace/page.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/page.tsx
@@ -1,151 +1,81 @@
-'use client'
+import { headers } from 'next/headers'
+import { getSession } from '@/lib/auth'
+import { readWorkflowAccessContext } from '@/lib/workflows/utils'
+import { getUserWorkspaces } from '@/lib/workspaces/service'
+import { redirect } from '@/i18n/navigation'
+import { CANONICAL_CALLBACK_PATH_HEADER, type LocaleCode, normalizeCallbackUrl } from '@/i18n/utils'
 
-import { useEffect } from 'react'
-import { useTranslations } from 'next-intl'
-import { LoadingAgent } from '@/components/ui/loading-agent'
-import { useSession } from '@/lib/auth-client'
-import { createLogger } from '@/lib/logs/console/logger'
-import { usePathname, useRouter } from '@/i18n/navigation'
-import { normalizeCallbackUrl } from '@/i18n/utils'
+type WorkspaceSearchParams = Promise<{
+  callbackUrl?: string | string[]
+  redirect_workflow?: string | string[]
+}>
 
-const logger = createLogger('WorkspacePage')
+function getSearchParam(
+  searchParams: Awaited<WorkspaceSearchParams>,
+  key: keyof Awaited<WorkspaceSearchParams>
+) {
+  const value = searchParams[key]
+  return Array.isArray(value) ? value[0] : value
+}
 
-export default function WorkspacePage() {
-  const router = useRouter()
-  const pathname = usePathname()
-  const tWorkspace = useTranslations('workspace')
-  const { data: session, isPending, error: sessionError } = useSession()
+export default async function WorkspacePage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ locale: string }>
+  searchParams: WorkspaceSearchParams
+}) {
+  const [{ locale: routeLocale }, query, requestHeaders] = await Promise.all([
+    params,
+    searchParams,
+    headers(),
+  ])
+  const locale = routeLocale as LocaleCode
+  const session = await getSession(requestHeaders)
+  const userId = session?.user?.id
 
-  useEffect(() => {
-    const redirectToFirstWorkspace = async () => {
-      if (isPending) {
-        return
-      }
-
-      if (sessionError || !session?.user) {
-        logger.info('User not authenticated, redirecting to home', {
-          hasSessionError: Boolean(sessionError),
-        })
-        router.replace('/')
-        return
-      }
-
-      try {
-        const urlParams = new URLSearchParams(window.location.search)
-        const callbackUrl = normalizeCallbackUrl(urlParams.get('callbackUrl'), window.location.origin)
-        const redirectWorkflowId = urlParams.get('redirect_workflow')
-
-        if (callbackUrl) {
-          const callbackPath = new URL(callbackUrl, window.location.origin).pathname
-
-          if (callbackPath !== pathname) {
-            logger.info('Redirecting to callback URL from workspace root', { callbackUrl })
-            router.replace(callbackUrl)
-            return
-          }
-        }
-
-        if (redirectWorkflowId) {
-          try {
-            const workflowResponse = await fetch(`/api/workflows/${redirectWorkflowId}`)
-            if (workflowResponse.ok) {
-              const workflowData = await workflowResponse.json()
-              const workspaceId = workflowData.data?.workspaceId
-
-              if (workspaceId) {
-                logger.info(
-                  `Redirecting workflow ${redirectWorkflowId} to workspace ${workspaceId} dashboard`
-                )
-                router.replace(`/workspace/${workspaceId}/dashboard`)
-                return
-              }
-            }
-          } catch (error) {
-            logger.error('Error fetching workflow for redirect:', error)
-          }
-        }
-
-        const response = await fetch('/api/workspaces', {
-          credentials: 'include',
-        })
-
-        if (response.status === 401 || response.status === 403) {
-          logger.info('Unauthorized to fetch workspaces, redirecting to home', {
-            status: response.status,
-          })
-          router.replace('/')
-          return
-        }
-
-        if (!response.ok) {
-          let errorBody = ''
-          try {
-            errorBody = await response.text()
-          } catch {}
-
-          logger.error('Failed to fetch workspaces for redirect', {
-            status: response.status,
-            body: errorBody,
-          })
-          router.replace('/')
-          return
-        }
-
-        const data = await response.json()
-        const workspaces = data.workspaces || []
-
-        if (workspaces.length === 0) {
-          logger.warn('No workspaces found for user, creating default workspace')
-
-          try {
-            const createResponse = await fetch('/api/workspaces', {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-              },
-              body: JSON.stringify({ name: tWorkspace('defaults.newWorkspaceName') }),
-            })
-
-            if (createResponse.ok) {
-              const createData = await createResponse.json()
-              const newWorkspace = createData.workspace
-
-              if (newWorkspace?.id) {
-                logger.info(
-                  `Created default workspace ${newWorkspace.id}, redirecting to dashboard`
-                )
-                router.replace(`/workspace/${newWorkspace.id}/dashboard`)
-                return
-              }
-            }
-
-            logger.error('Failed to create default workspace')
-          } catch (createError) {
-            logger.error('Error creating default workspace:', createError)
-          }
-
-          router.replace('/')
-          return
-        }
-
-        const firstWorkspace = workspaces[0]
-        logger.info(`Redirecting to workspace ${firstWorkspace.id} dashboard`)
-        router.replace(`/workspace/${firstWorkspace.id}/dashboard`)
-      } catch (error) {
-        logger.error('Error fetching workspaces for redirect:', error)
-        router.replace('/')
-      }
+  if (!userId) {
+    const callbackUrl = requestHeaders.get(CANONICAL_CALLBACK_PATH_HEADER)
+    if (!callbackUrl) {
+      throw new Error('Missing canonical callback path for workspace reauth redirect')
     }
 
-    void redirectToFirstWorkspace()
-  }, [isPending, pathname, router, session, sessionError, tWorkspace])
+    return redirect({
+      href: {
+        pathname: '/login',
+        query: {
+          reauth: '1',
+          callbackUrl,
+        },
+      },
+      locale,
+    })
+  }
 
-  return (
-    <div className='flex h-screen w-full items-center justify-center'>
-      <div className='flex flex-col items-center justify-center text-center align-middle'>
-        <LoadingAgent size='lg' />
-        <span className='sr-only'>{tWorkspace('entry.loading')}</span>
-      </div>
-    </div>
-  )
+  const callbackUrl = normalizeCallbackUrl(getSearchParam(query, 'callbackUrl'))
+  if (callbackUrl && callbackUrl.split(/[?#]/, 1)[0] !== '/workspace') {
+    return redirect({ href: callbackUrl, locale })
+  }
+
+  const redirectWorkflowId = getSearchParam(query, 'redirect_workflow')
+  if (redirectWorkflowId) {
+    const access = await readWorkflowAccessContext(redirectWorkflowId, userId)
+    if (
+      access?.workflow.workspaceId &&
+      (access.isOwner || access.isWorkspaceOwner || access.workspacePermission)
+    ) {
+      return redirect({ href: `/workspace/${access.workflow.workspaceId}/dashboard`, locale })
+    }
+  }
+
+  const [workspace] = await getUserWorkspaces({
+    userId,
+    userName: session.user.name,
+  })
+
+  if (!workspace) {
+    throw new Error('Expected workspace bootstrap to return a workspace')
+  }
+
+  return redirect({ href: `/workspace/${workspace.id}/dashboard`, locale })
 }

--- a/apps/tradinggoose/app/[locale]/workspace/page.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/page.tsx
@@ -1,6 +1,5 @@
 import { headers } from 'next/headers'
 import { getSession } from '@/lib/auth'
-import { getBaseUrl } from '@/lib/urls/utils'
 import { readWorkflowAccessContext } from '@/lib/workflows/utils'
 import { getUserWorkspaces } from '@/lib/workspaces/service'
 import { redirect } from '@/i18n/navigation'
@@ -17,6 +16,13 @@ function getSearchParam(
 ) {
   const value = searchParams[key]
   return Array.isArray(value) ? value[0] : value
+}
+
+function getRequestOrigin(headers: Headers) {
+  const protocol = headers.get('x-forwarded-proto')?.split(',', 1)[0]?.trim()
+  const host = (headers.get('x-forwarded-host') ?? headers.get('host'))?.split(',', 1)[0]?.trim()
+
+  return protocol && host ? `${protocol}://${host}` : undefined
 }
 
 export default async function WorkspacePage({
@@ -53,7 +59,10 @@ export default async function WorkspacePage({
     })
   }
 
-  const callbackUrl = normalizeCallbackUrl(getSearchParam(query, 'callbackUrl'), getBaseUrl())
+  const callbackUrl = normalizeCallbackUrl(
+    getSearchParam(query, 'callbackUrl'),
+    getRequestOrigin(requestHeaders)
+  )
   if (callbackUrl && callbackUrl.split(/[?#]/, 1)[0] !== '/workspace') {
     return redirect({ href: callbackUrl, locale })
   }

--- a/apps/tradinggoose/app/[locale]/workspace/page.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/page.tsx
@@ -19,10 +19,17 @@ function getSearchParam(
 }
 
 function getRequestOrigin(headers: Headers) {
-  const protocol = headers.get('x-forwarded-proto')?.split(',', 1)[0]?.trim()
   const host = (headers.get('x-forwarded-host') ?? headers.get('host'))?.split(',', 1)[0]?.trim()
+  if (!host) {
+    return undefined
+  }
 
-  return protocol && host ? `${protocol}://${host}` : undefined
+  const forwardedProtocol = headers.get('x-forwarded-proto')?.split(',', 1)[0]?.trim()
+  const protocol =
+    forwardedProtocol ||
+    (host.startsWith('localhost') || host.startsWith('127.0.0.1') ? 'http' : 'https')
+
+  return `${protocol}://${host}`
 }
 
 export default async function WorkspacePage({
@@ -76,10 +83,11 @@ export default async function WorkspacePage({
   const [workspace] = await getUserWorkspaces({
     userId,
     userName: session.user.name,
+    autoCreate: false,
   })
 
   if (!workspace) {
-    throw new Error('Expected workspace bootstrap to return a workspace')
+    return null
   }
 
   return redirect({ href: `/workspace/${workspace.id}/dashboard`, locale })

--- a/apps/tradinggoose/app/[locale]/workspace/page.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/page.tsx
@@ -3,7 +3,7 @@ import { getSession } from '@/lib/auth'
 import { readWorkflowAccessContext } from '@/lib/workflows/utils'
 import { getUserWorkspaces } from '@/lib/workspaces/service'
 import { redirect } from '@/i18n/navigation'
-import { CANONICAL_CALLBACK_PATH_HEADER, type LocaleCode, normalizeCallbackUrl } from '@/i18n/utils'
+import { type LocaleCode, normalizeCallbackUrl, requireCanonicalCallbackPath } from '@/i18n/utils'
 
 type WorkspaceSearchParams = Promise<{
   callbackUrl?: string | string[]
@@ -42,17 +42,12 @@ export default async function WorkspacePage({
   const userId = session?.user?.id
 
   if (!userId) {
-    const callbackUrl = requestHeaders.get(CANONICAL_CALLBACK_PATH_HEADER)
-    if (!callbackUrl) {
-      throw new Error('Missing canonical callback path for workspace reauth redirect')
-    }
-
     return redirect({
       href: {
         pathname: '/login',
         query: {
           reauth: '1',
-          callbackUrl,
+          callbackUrl: requireCanonicalCallbackPath(requestHeaders, 'workspace'),
         },
       },
       locale,

--- a/apps/tradinggoose/app/[locale]/workspace/page.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/page.tsx
@@ -1,6 +1,5 @@
 import { headers } from 'next/headers'
 import { getSession } from '@/lib/auth'
-import { getBaseUrl } from '@/lib/urls/utils'
 import { readWorkflowAccessContext } from '@/lib/workflows/utils'
 import { getUserWorkspaces } from '@/lib/workspaces/service'
 import { redirect } from '@/i18n/navigation'
@@ -17,6 +16,26 @@ function getSearchParam(
 ) {
   const value = searchParams[key]
   return Array.isArray(value) ? value[0] : value
+}
+
+function normalizeRequestCallbackUrl(href: string | null | undefined, headers: Headers) {
+  const internalCallback = normalizeCallbackUrl(href)
+  if (internalCallback) {
+    return internalCallback
+  }
+
+  const host = (headers.get('x-forwarded-host') ?? headers.get('host'))?.split(',', 1)[0]?.trim()
+  const forwardedProtocol = headers.get('x-forwarded-proto')?.split(',', 1)[0]?.trim()
+  const protocols = forwardedProtocol ? [forwardedProtocol] : ['http', 'https']
+
+  for (const protocol of host ? protocols : []) {
+    const callback = normalizeCallbackUrl(href, `${protocol}://${host}`)
+    if (callback) {
+      return callback
+    }
+  }
+
+  return null
 }
 
 export default async function WorkspacePage({
@@ -40,7 +59,6 @@ export default async function WorkspacePage({
       href: {
         pathname: '/login',
         query: {
-          reauth: '1',
           callbackUrl: requireCanonicalCallbackPath(requestHeaders, 'workspace'),
         },
       },
@@ -48,7 +66,10 @@ export default async function WorkspacePage({
     })
   }
 
-  const callbackUrl = normalizeCallbackUrl(getSearchParam(query, 'callbackUrl'), getBaseUrl())
+  const callbackUrl = normalizeRequestCallbackUrl(
+    getSearchParam(query, 'callbackUrl'),
+    requestHeaders
+  )
   if (callbackUrl && callbackUrl.split(/[?#]/, 1)[0] !== '/workspace') {
     return redirect({ href: callbackUrl, locale })
   }

--- a/apps/tradinggoose/app/[locale]/workspace/page.tsx
+++ b/apps/tradinggoose/app/[locale]/workspace/page.tsx
@@ -1,3 +1,4 @@
+import { getSessionCookie } from 'better-auth/cookies'
 import { headers } from 'next/headers'
 import { getSession } from '@/lib/auth'
 import { readWorkflowAccessContext } from '@/lib/workflows/utils'
@@ -59,6 +60,7 @@ export default async function WorkspacePage({
       href: {
         pathname: '/login',
         query: {
+          ...(getSessionCookie(requestHeaders) ? { reauth: '1' } : {}),
           callbackUrl: requireCanonicalCallbackPath(requestHeaders, 'workspace'),
         },
       },

--- a/apps/tradinggoose/app/api/chat/utils.ts
+++ b/apps/tradinggoose/app/api/chat/utils.ts
@@ -4,7 +4,7 @@ import { and, eq, gte, isNull, or } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { isDev } from '@/lib/environment'
 import { createLogger } from '@/lib/logs/console/logger'
-import { hasAdminPermission } from '@/lib/permissions/utils'
+import { hasWorkspaceAdminAccess } from '@/lib/permissions/utils'
 import { decryptSecret } from '@/lib/utils-server'
 import { CHAT_ERROR_CODES } from '@/app/chat/constants'
 
@@ -31,7 +31,7 @@ export async function checkWorkflowAccessForChatCreation(
   }
 
   if (workflowRecord.workspaceId) {
-    const hasAdmin = await hasAdminPermission(userId, workflowRecord.workspaceId)
+    const hasAdmin = await hasWorkspaceAdminAccess(userId, workflowRecord.workspaceId)
     if (hasAdmin) {
       return { hasAccess: true, workflow: workflowRecord }
     }
@@ -69,7 +69,7 @@ export async function checkChatAccess(
   }
 
   if (workflowWorkspaceId) {
-    const hasAdmin = await hasAdminPermission(userId, workflowWorkspaceId)
+    const hasAdmin = await hasWorkspaceAdminAccess(userId, workflowWorkspaceId)
     if (hasAdmin) {
       return { hasAccess: true, chat: chatRecord, workspaceId: workflowWorkspaceId }
     }

--- a/apps/tradinggoose/app/api/templates/[id]/route.ts
+++ b/apps/tradinggoose/app/api/templates/[id]/route.ts
@@ -5,7 +5,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
-import { hasAdminPermission } from '@/lib/permissions/utils'
+import { hasWorkspaceAdminAccess } from '@/lib/permissions/utils'
 import { generateRequestId } from '@/lib/utils'
 
 const logger = createLogger('TemplateByIdAPI')
@@ -121,7 +121,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
       const workspaceId = wfRows[0]?.workspaceId as string | null | undefined
       if (workspaceId) {
-        const hasAdmin = await hasAdminPermission(session.user.id, workspaceId)
+        const hasAdmin = await hasWorkspaceAdminAccess(session.user.id, workspaceId)
         if (hasAdmin) canUpdate = true
       }
     }
@@ -196,7 +196,7 @@ export async function DELETE(
 
       const workspaceId = wfRows[0]?.workspaceId as string | null | undefined
       if (workspaceId) {
-        const hasAdmin = await hasAdminPermission(session.user.id, workspaceId)
+        const hasAdmin = await hasWorkspaceAdminAccess(session.user.id, workspaceId)
         if (hasAdmin) canDelete = true
       }
     }

--- a/apps/tradinggoose/app/api/workflows/[id]/autolayout/route.ts
+++ b/apps/tradinggoose/app/api/workflows/[id]/autolayout/route.ts
@@ -1,11 +1,10 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
-import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
 import { generateRequestId } from '@/lib/utils'
 import { applyAutoLayout } from '@/lib/workflows/autolayout'
 import { loadWorkflowFromNormalizedTables } from '@/lib/workflows/db-helpers'
-import { readWorkflowAccessContext } from '@/lib/workflows/utils'
+import { validateWorkflowPermissions } from '@/lib/workflows/utils'
 
 export const dynamic = 'force-dynamic'
 
@@ -35,10 +34,12 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const { id: workflowId } = await params
 
   try {
-    const session = await getSession()
-    if (!session?.user?.id) {
-      logger.warn(`[${requestId}] Unauthorized autolayout attempt for workflow ${workflowId}`)
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    const { error, session } = await validateWorkflowPermissions(workflowId, requestId, 'write')
+    if (error || !session?.user?.id) {
+      return NextResponse.json(
+        { error: error?.message ?? 'Unauthorized' },
+        { status: error?.status ?? 401 }
+      )
     }
 
     const userId = session.user.id
@@ -49,28 +50,6 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     logger.info(`[${requestId}] Processing autolayout request for workflow ${workflowId}`, {
       userId,
     })
-
-    const accessContext = await readWorkflowAccessContext(workflowId, userId)
-    const workflowData = accessContext?.workflow
-
-    if (!workflowData) {
-      logger.warn(`[${requestId}] Workflow ${workflowId} not found for autolayout`)
-      return NextResponse.json({ error: 'Workflow not found' }, { status: 404 })
-    }
-
-    const canUpdate =
-      accessContext?.isOwner ||
-      (workflowData.workspaceId
-        ? accessContext?.workspacePermission === 'write' ||
-          accessContext?.workspacePermission === 'admin'
-        : false)
-
-    if (!canUpdate) {
-      logger.warn(
-        `[${requestId}] User ${userId} denied permission to autolayout workflow ${workflowId}`
-      )
-      return NextResponse.json({ error: 'Access denied' }, { status: 403 })
-    }
 
     let currentWorkflowData: { blocks: Record<string, any>; edges: any[] } | null
 

--- a/apps/tradinggoose/app/api/workflows/[id]/log-webhook/[webhookId]/route.ts
+++ b/apps/tradinggoose/app/api/workflows/[id]/log-webhook/[webhookId]/route.ts
@@ -1,11 +1,11 @@
 import { db } from '@tradinggoose/db'
-import { permissions, workflow, workflowLogWebhook } from '@tradinggoose/db/schema'
+import { workflowLogWebhook } from '@tradinggoose/db/schema'
 import { and, eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
-import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
 import { encryptSecret } from '@/lib/utils-server'
+import { validateWorkflowPermissions } from '@/lib/workflows/utils'
 import { cancelActiveWebhookDeliveries } from '../delivery-cancellation'
 
 const logger = createLogger('WorkflowLogWebhookUpdate')
@@ -39,32 +39,15 @@ export async function PUT(
   { params }: { params: Promise<{ id: string; webhookId: string }> }
 ) {
   try {
-    const session = await getSession()
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
     const { id: workflowId, webhookId } = await params
-    const userId = session.user.id
-
-    // Check if user has access to the workflow
-    const hasAccess = await db
-      .select({ id: workflow.id })
-      .from(workflow)
-      .innerJoin(
-        permissions,
-        and(
-          eq(permissions.entityType, 'workspace'),
-          eq(permissions.entityId, workflow.workspaceId),
-          eq(permissions.userId, userId)
-        )
+    const { error, session } = await validateWorkflowPermissions(workflowId, workflowId, 'read')
+    if (error || !session?.user?.id) {
+      return NextResponse.json(
+        { error: error?.message ?? 'Unauthorized' },
+        { status: error?.status ?? 401 }
       )
-      .where(eq(workflow.id, workflowId))
-      .limit(1)
-
-    if (hasAccess.length === 0) {
-      return NextResponse.json({ error: 'Workflow not found' }, { status: 404 })
     }
+    const userId = session.user.id
 
     // Check if webhook exists and belongs to this workflow
     const existingWebhook = await db
@@ -169,32 +152,15 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string; webhookId: string }> }
 ) {
   try {
-    const session = await getSession()
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
     const { id: workflowId, webhookId } = await params
-    const userId = session.user.id
-
-    // Check if user has access to the workflow
-    const hasAccess = await db
-      .select({ id: workflow.id })
-      .from(workflow)
-      .innerJoin(
-        permissions,
-        and(
-          eq(permissions.entityType, 'workspace'),
-          eq(permissions.entityId, workflow.workspaceId),
-          eq(permissions.userId, userId)
-        )
+    const { error, session } = await validateWorkflowPermissions(workflowId, workflowId, 'read')
+    if (error || !session?.user?.id) {
+      return NextResponse.json(
+        { error: error?.message ?? 'Unauthorized' },
+        { status: error?.status ?? 401 }
       )
-      .where(eq(workflow.id, workflowId))
-      .limit(1)
-
-    if (hasAccess.length === 0) {
-      return NextResponse.json({ error: 'Workflow not found' }, { status: 404 })
     }
+    const userId = session.user.id
 
     await cancelActiveWebhookDeliveries(workflowId, webhookId)
 

--- a/apps/tradinggoose/app/api/workflows/[id]/log-webhook/route.ts
+++ b/apps/tradinggoose/app/api/workflows/[id]/log-webhook/route.ts
@@ -1,12 +1,12 @@
 import { db } from '@tradinggoose/db'
-import { permissions, workflow, workflowLogWebhook } from '@tradinggoose/db/schema'
+import { workflowLogWebhook } from '@tradinggoose/db/schema'
 import { and, eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { v4 as uuidv4 } from 'uuid'
 import { z } from 'zod'
-import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
 import { encryptSecret } from '@/lib/utils-server'
+import { validateWorkflowPermissions } from '@/lib/workflows/utils'
 import { cancelActiveWebhookDeliveries } from './delivery-cancellation'
 
 const logger = createLogger('WorkflowLogWebhookAPI')
@@ -31,30 +31,10 @@ const CreateWebhookSchema = z.object({
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await getSession()
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
     const { id: workflowId } = await params
-    const userId = session.user.id
-
-    const hasAccess = await db
-      .select({ id: workflow.id, userId: workflow.userId, workspaceId: workflow.workspaceId })
-      .from(workflow)
-      .innerJoin(
-        permissions,
-        and(
-          eq(permissions.entityType, 'workspace'),
-          eq(permissions.entityId, workflow.workspaceId),
-          eq(permissions.userId, userId)
-        )
-      )
-      .where(eq(workflow.id, workflowId))
-      .limit(1)
-
-    if (hasAccess.length === 0) {
-      return NextResponse.json({ error: 'Workflow not found' }, { status: 404 })
+    const { error } = await validateWorkflowPermissions(workflowId, workflowId, 'read')
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
     }
 
     const webhooks = await db
@@ -83,33 +63,11 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await getSession()
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
     const { id: workflowId } = await params
-    const userId = session.user.id
-
-    const hasAccess = await db
-      .select({ id: workflow.id, userId: workflow.userId, workspaceId: workflow.workspaceId })
-      .from(workflow)
-      .innerJoin(
-        permissions,
-        and(
-          eq(permissions.entityType, 'workspace'),
-          eq(permissions.entityId, workflow.workspaceId),
-          eq(permissions.userId, userId)
-        )
-      )
-      .where(eq(workflow.id, workflowId))
-      .limit(1)
-
-    if (hasAccess.length === 0) {
-      return NextResponse.json({ error: 'Workflow not found' }, { status: 404 })
+    const { error } = await validateWorkflowPermissions(workflowId, workflowId, 'read')
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
     }
-
-    const workflowRecord = hasAccess[0]
 
     const body = await request.json()
     const validationResult = CreateWebhookSchema.safeParse(body)
@@ -194,13 +152,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const session = await getSession()
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
     const { id: workflowId } = await params
-    const userId = session.user.id
     const { searchParams } = new URL(request.url)
     const webhookId = searchParams.get('webhookId')
 
@@ -208,22 +160,9 @@ export async function DELETE(
       return NextResponse.json({ error: 'webhookId is required' }, { status: 400 })
     }
 
-    const hasAccess = await db
-      .select({ id: workflow.id })
-      .from(workflow)
-      .innerJoin(
-        permissions,
-        and(
-          eq(permissions.entityType, 'workspace'),
-          eq(permissions.entityId, workflow.workspaceId),
-          eq(permissions.userId, userId)
-        )
-      )
-      .where(eq(workflow.id, workflowId))
-      .limit(1)
-
-    if (hasAccess.length === 0) {
-      return NextResponse.json({ error: 'Workflow not found' }, { status: 404 })
+    const { error } = await validateWorkflowPermissions(workflowId, workflowId, 'read')
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
     }
 
     await cancelActiveWebhookDeliveries(workflowId, webhookId)

--- a/apps/tradinggoose/app/api/workflows/[id]/log-webhook/test/route.ts
+++ b/apps/tradinggoose/app/api/workflows/[id]/log-webhook/test/route.ts
@@ -1,12 +1,12 @@
 import { createHmac } from 'crypto'
 import { db } from '@tradinggoose/db'
-import { permissions, workflow, workflowLogWebhook } from '@tradinggoose/db/schema'
+import { workflowLogWebhook } from '@tradinggoose/db/schema'
 import { and, eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { v4 as uuidv4 } from 'uuid'
-import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
 import { decryptSecret } from '@/lib/utils-server'
+import { validateWorkflowPermissions } from '@/lib/workflows/utils'
 
 const logger = createLogger('WorkflowLogWebhookTestAPI')
 
@@ -19,13 +19,7 @@ function generateSignature(secret: string, timestamp: number, body: string): str
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const session = await getSession()
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
     const { id: workflowId } = await params
-    const userId = session.user.id
     const { searchParams } = new URL(request.url)
     const webhookId = searchParams.get('webhookId')
 
@@ -33,22 +27,9 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       return NextResponse.json({ error: 'webhookId is required' }, { status: 400 })
     }
 
-    const hasAccess = await db
-      .select({ id: workflow.id })
-      .from(workflow)
-      .innerJoin(
-        permissions,
-        and(
-          eq(permissions.entityType, 'workspace'),
-          eq(permissions.entityId, workflow.workspaceId),
-          eq(permissions.userId, userId)
-        )
-      )
-      .where(eq(workflow.id, workflowId))
-      .limit(1)
-
-    if (hasAccess.length === 0) {
-      return NextResponse.json({ error: 'Workflow not found' }, { status: 404 })
+    const { error } = await validateWorkflowPermissions(workflowId, workflowId, 'read')
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
     }
 
     const [webhook] = await db

--- a/apps/tradinggoose/app/api/workflows/[id]/state/route.test.ts
+++ b/apps/tradinggoose/app/api/workflows/[id]/state/route.test.ts
@@ -85,8 +85,9 @@ describe('Workflow State API Route', () => {
     }))
 
     vi.doMock('@/lib/workflows/utils', () => ({
-      readWorkflowAccessContext: vi.fn().mockResolvedValue({
-        isOwner: true,
+      validateWorkflowPermissions: vi.fn().mockResolvedValue({
+        error: null,
+        session: { user: { id: 'user-id' } },
         workflow: {
           id: 'workflow-id',
           workspaceId: 'workspace-id',

--- a/apps/tradinggoose/app/api/workflows/[id]/state/route.ts
+++ b/apps/tradinggoose/app/api/workflows/[id]/state/route.ts
@@ -3,7 +3,6 @@ import { workflow } from '@tradinggoose/db/schema'
 import { eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
-import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
 import { generateRequestId } from '@/lib/utils'
 import { extractAndPersistCustomTools } from '@/lib/workflows/custom-tools-persistence'
@@ -12,7 +11,7 @@ import {
   saveWorkflowToNormalizedTables,
   toISOStringOrUndefined,
 } from '@/lib/workflows/db-helpers'
-import { readWorkflowAccessContext } from '@/lib/workflows/utils'
+import { validateWorkflowPermissions } from '@/lib/workflows/utils'
 import { sanitizeAgentToolsInBlocks } from '@/lib/workflows/validation'
 import { tryApplyWorkflowState } from '@/lib/yjs/server/apply-workflow-state'
 import type { WorkflowSnapshot } from '@/lib/yjs/workflow-session'
@@ -131,42 +130,22 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   const { id: workflowId } = await params
 
   try {
-    // Get the session
-    const session = await getSession()
-    if (!session?.user?.id) {
-      logger.warn(`[${requestId}] Unauthorized state update attempt for workflow ${workflowId}`)
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    const {
+      error,
+      session,
+      workflow: workflowData,
+    } = await validateWorkflowPermissions(workflowId, requestId, 'write')
+    if (error || !session?.user?.id || !workflowData) {
+      return NextResponse.json(
+        { error: error?.message ?? 'Unauthorized' },
+        { status: error?.status ?? 401 }
+      )
     }
-
     const userId = session.user.id
 
     // Parse and validate request body
     const body = await request.json()
     const state = WorkflowStateSchema.parse(body)
-
-    // Fetch the workflow to check ownership/access
-    const accessContext = await readWorkflowAccessContext(workflowId, userId)
-    const workflowData = accessContext?.workflow
-
-    if (!workflowData) {
-      logger.warn(`[${requestId}] Workflow ${workflowId} not found for state update`)
-      return NextResponse.json({ error: 'Workflow not found' }, { status: 404 })
-    }
-
-    // Check if user has permission to update this workflow
-    const canUpdate =
-      accessContext?.isOwner ||
-      (workflowData.workspaceId
-        ? accessContext?.workspacePermission === 'write' ||
-          accessContext?.workspacePermission === 'admin'
-        : false)
-
-    if (!canUpdate) {
-      logger.warn(
-        `[${requestId}] User ${userId} denied permission to update workflow state ${workflowId}`
-      )
-      return NextResponse.json({ error: 'Access denied' }, { status: 403 })
-    }
 
     // Sanitize custom tools in agent blocks before saving
     const { blocks: sanitizedBlocks, warnings } = sanitizeAgentToolsInBlocks(state.blocks as any)

--- a/apps/tradinggoose/app/api/workspaces/[id]/permissions/route.test.ts
+++ b/apps/tradinggoose/app/api/workspaces/[id]/permissions/route.test.ts
@@ -42,6 +42,7 @@ describe('Workspace permissions PATCH route', () => {
       },
       workspace: {
         id: 'workspace.id',
+        ownerId: 'workspace.ownerId',
         billingOwnerType: 'workspace.billingOwnerType',
         billingOwnerUserId: 'workspace.billingOwnerUserId',
       },
@@ -96,6 +97,7 @@ describe('Workspace permissions PATCH route', () => {
       [{ id: 'permission-1' }],
       [
         {
+          ownerId: 'owner-1',
           billingOwnerType: 'user',
           billingOwnerUserId: 'user-2',
         },
@@ -126,7 +128,7 @@ describe('Workspace permissions PATCH route', () => {
     mockGetUsersWithPermissions.mockResolvedValue([])
     selectResults.push(
       [{ id: 'permission-1' }],
-      [{ billingOwnerType: 'user', billingOwnerUserId: 'user-2' }]
+      [{ ownerId: 'owner-1', billingOwnerType: 'user', billingOwnerUserId: 'user-2' }]
     )
 
     const { PATCH } = await import('./route')
@@ -141,6 +143,35 @@ describe('Workspace permissions PATCH route', () => {
     expect(response.status).toBe(400)
     expect(await response.json()).toEqual({
       error: 'Invalid permissions update payload',
+    })
+    expect(transactionMock).not.toHaveBeenCalled()
+    expect(mockAssertWorkspaceBillingOwnerRetainsAdminAccess).not.toHaveBeenCalled()
+  })
+
+  it('rejects updates to the canonical workspace owner permission', async () => {
+    mockHasWorkspaceAdminAccess.mockResolvedValue(true)
+    selectResults.push([
+      {
+        ownerId: 'owner-1',
+        billingOwnerType: 'organization',
+        billingOwnerUserId: null,
+      },
+    ])
+
+    const { PATCH } = await import('./route')
+    const response = await PATCH(
+      new NextRequest('http://localhost/api/workspaces/workspace-1/permissions', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          updates: [{ userId: 'owner-1', permissions: 'write' }],
+        }),
+      }),
+      { params: Promise.resolve({ id: 'workspace-1' }) }
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'Workspace owner permissions are managed by workspace ownership',
     })
     expect(transactionMock).not.toHaveBeenCalled()
     expect(mockAssertWorkspaceBillingOwnerRetainsAdminAccess).not.toHaveBeenCalled()

--- a/apps/tradinggoose/app/api/workspaces/[id]/permissions/route.test.ts
+++ b/apps/tradinggoose/app/api/workspaces/[id]/permissions/route.test.ts
@@ -14,6 +14,8 @@ describe('Workspace permissions PATCH route', () => {
       })),
     })),
   }))
+  const mockAssertActiveWorkspaceAccess = vi.fn()
+  const mockGetUserEntityPermissions = vi.fn()
   const mockHasWorkspaceAdminAccess = vi.fn()
   const mockGetUsersWithPermissions = vi.fn()
   const mockAssertWorkspaceBillingOwnerRetainsAdminAccess = vi.fn()
@@ -65,6 +67,8 @@ describe('Workspace permissions PATCH route', () => {
     }))
 
     vi.doMock('@/lib/permissions/utils', () => ({
+      assertActiveWorkspaceAccess: mockAssertActiveWorkspaceAccess,
+      getUserEntityPermissions: mockGetUserEntityPermissions,
       getUsersWithPermissions: mockGetUsersWithPermissions,
       hasWorkspaceAdminAccess: mockHasWorkspaceAdminAccess,
     }))
@@ -73,6 +77,9 @@ describe('Workspace permissions PATCH route', () => {
       assertWorkspaceBillingOwnerRetainsAdminAccess:
         mockAssertWorkspaceBillingOwnerRetainsAdminAccess,
     }))
+
+    mockAssertActiveWorkspaceAccess.mockResolvedValue({})
+    mockGetUserEntityPermissions.mockResolvedValue('admin')
   })
 
   afterEach(() => {
@@ -137,5 +144,25 @@ describe('Workspace permissions PATCH route', () => {
     })
     expect(transactionMock).not.toHaveBeenCalled()
     expect(mockAssertWorkspaceBillingOwnerRetainsAdminAccess).not.toHaveBeenCalled()
+  })
+
+  it('resolves the current user permission independently from the member list', async () => {
+    mockGetUsersWithPermissions.mockResolvedValue([])
+    mockGetUserEntityPermissions.mockResolvedValue('admin')
+
+    const { GET } = await import('./route')
+    const response = await GET(
+      new NextRequest('http://localhost/api/workspaces/workspace-1/permissions'),
+      { params: Promise.resolve({ id: 'workspace-1' }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      users: [],
+      total: 0,
+      currentUserPermission: 'admin',
+    })
+    expect(mockAssertActiveWorkspaceAccess).toHaveBeenCalledWith('workspace-1', 'user-1')
+    expect(mockGetUserEntityPermissions).toHaveBeenCalledWith('user-1', 'workspace', 'workspace-1')
   })
 })

--- a/apps/tradinggoose/app/api/workspaces/[id]/permissions/route.ts
+++ b/apps/tradinggoose/app/api/workspaces/[id]/permissions/route.ts
@@ -129,6 +129,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
 
     const workspaceRow = await db
       .select({
+        ownerId: workspace.ownerId,
         billingOwnerType: workspace.billingOwnerType,
         billingOwnerUserId: workspace.billingOwnerUserId,
       })
@@ -138,6 +139,13 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
 
     if (workspaceRow.length === 0) {
       return NextResponse.json({ error: 'Workspace not found or access denied' }, { status: 404 })
+    }
+
+    if (body.updates.some((update) => update.userId === workspaceRow[0].ownerId)) {
+      return NextResponse.json(
+        { error: 'Workspace owner permissions are managed by workspace ownership' },
+        { status: 400 }
+      )
     }
 
     try {

--- a/apps/tradinggoose/app/api/workspaces/[id]/permissions/route.ts
+++ b/apps/tradinggoose/app/api/workspaces/[id]/permissions/route.ts
@@ -33,6 +33,13 @@ interface UpdatePermissionsRequest {
   }>
 }
 
+function getCurrentUserPermission(
+  users: Array<{ userId: string; permissionType: PermissionType }>,
+  userId: string
+) {
+  return users.find((user) => user.userId === userId)?.permissionType ?? null
+}
+
 /**
  * GET /api/workspaces/[id]/permissions
  *
@@ -62,10 +69,16 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     }
 
     const result = await getUsersWithPermissions(workspaceId)
+    const currentUserPermission = getCurrentUserPermission(result, session.user.id)
+
+    if (!currentUserPermission) {
+      throw new Error('Authenticated workspace user missing permission state')
+    }
 
     return NextResponse.json({
       users: result,
       total: result.length,
+      currentUserPermission,
     })
   } catch (error) {
     logger.error('Error fetching workspace permissions:', error)
@@ -167,11 +180,17 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     })
 
     const updatedUsers = await getUsersWithPermissions(workspaceId)
+    const currentUserPermission = getCurrentUserPermission(updatedUsers, session.user.id)
+
+    if (!currentUserPermission) {
+      throw new Error('Authenticated workspace user missing permission state')
+    }
 
     return NextResponse.json({
       message: 'Permissions updated successfully',
       users: updatedUsers,
       total: updatedUsers.length,
+      currentUserPermission,
     })
   } catch (error) {
     logger.error('Error updating workspace permissions:', error)

--- a/apps/tradinggoose/app/api/workspaces/[id]/permissions/route.ts
+++ b/apps/tradinggoose/app/api/workspaces/[id]/permissions/route.ts
@@ -7,6 +7,7 @@ import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
 import {
   assertActiveWorkspaceAccess,
+  getUserEntityPermissions,
   getUsersWithPermissions,
   hasWorkspaceAdminAccess,
 } from '@/lib/permissions/utils'
@@ -31,13 +32,6 @@ interface UpdatePermissionsRequest {
     userId: string
     permissions: PermissionType
   }>
-}
-
-function getCurrentUserPermission(
-  users: Array<{ userId: string; permissionType: PermissionType }>,
-  userId: string
-) {
-  return users.find((user) => user.userId === userId)?.permissionType ?? null
 }
 
 /**
@@ -69,10 +63,14 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     }
 
     const result = await getUsersWithPermissions(workspaceId)
-    const currentUserPermission = getCurrentUserPermission(result, session.user.id)
+    const currentUserPermission = await getUserEntityPermissions(
+      session.user.id,
+      'workspace',
+      workspaceId
+    )
 
     if (!currentUserPermission) {
-      throw new Error('Authenticated workspace user missing permission state')
+      return NextResponse.json({ error: 'Workspace permission state unavailable' }, { status: 403 })
     }
 
     return NextResponse.json({
@@ -180,10 +178,14 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     })
 
     const updatedUsers = await getUsersWithPermissions(workspaceId)
-    const currentUserPermission = getCurrentUserPermission(updatedUsers, session.user.id)
+    const currentUserPermission = await getUserEntityPermissions(
+      session.user.id,
+      'workspace',
+      workspaceId
+    )
 
     if (!currentUserPermission) {
-      throw new Error('Authenticated workspace user missing permission state')
+      return NextResponse.json({ error: 'Workspace permission state unavailable' }, { status: 403 })
     }
 
     return NextResponse.json({

--- a/apps/tradinggoose/app/api/workspaces/invitations/[invitationId]/route.test.ts
+++ b/apps/tradinggoose/app/api/workspaces/invitations/[invitationId]/route.test.ts
@@ -37,6 +37,7 @@ describe('Workspace Invitation [invitationId] API Route', () => {
   let mockDbResults: any[] = []
   let mockGetSession: any
   let mockHasWorkspaceAdminAccess: any
+  let mockCheckWorkspaceAccess: any
   let mockTransaction: any
 
   beforeEach(async () => {
@@ -57,7 +58,9 @@ describe('Workspace Invitation [invitationId] API Route', () => {
     }))
 
     mockHasWorkspaceAdminAccess = vi.fn()
+    mockCheckWorkspaceAccess = vi.fn().mockResolvedValue({ hasAccess: false })
     vi.doMock('@/lib/permissions/utils', () => ({
+      checkWorkspaceAccess: mockCheckWorkspaceAccess,
       hasWorkspaceAdminAccess: mockHasWorkspaceAdminAccess,
     }))
 
@@ -185,7 +188,6 @@ describe('Workspace Invitation [invitationId] API Route', () => {
       mockDbResults.push([mockInvitation])
       mockDbResults.push([mockWorkspace])
       mockDbResults.push([{ ...mockUser, email: 'invited@example.com' }])
-      mockDbResults.push([])
 
       mockTransaction.mockImplementation(async (callback: any) => {
         await callback({
@@ -392,6 +394,7 @@ describe('Workspace Invitation [invitationId] API Route', () => {
         getSession: vi.fn().mockResolvedValue({ user: mockUser }),
       }))
       vi.doMock('@/lib/permissions/utils', () => ({
+        checkWorkspaceAccess: vi.fn(),
         hasWorkspaceAdminAccess: vi.fn(),
       }))
       vi.doMock('@/lib/env', () => {

--- a/apps/tradinggoose/app/api/workspaces/invitations/[invitationId]/route.ts
+++ b/apps/tradinggoose/app/api/workspaces/invitations/[invitationId]/route.ts
@@ -7,12 +7,12 @@ import {
   workspace,
   workspaceInvitation,
 } from '@tradinggoose/db/schema'
-import { and, eq } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { getEmailSubject, renderWorkspaceInvitationEmail } from '@/components/emails/render-email'
 import { getSession } from '@/lib/auth'
 import { resolveEmailLocale } from '@/lib/email/locale'
-import { hasWorkspaceAdminAccess } from '@/lib/permissions/utils'
+import { checkWorkspaceAccess, hasWorkspaceAdminAccess } from '@/lib/permissions/utils'
 import { getBaseUrl } from '@/lib/urls/utils'
 import { defaultLocale, localizeUrl, stripLocaleFromPathname } from '@/i18n/utils'
 
@@ -115,19 +115,8 @@ export async function GET(
         return NextResponse.redirect(redirectUrl(`/invite/${invitation.id}?error=email-mismatch`))
       }
 
-      const existingPermission = await db
-        .select()
-        .from(permissions)
-        .where(
-          and(
-            eq(permissions.entityId, invitation.workspaceId),
-            eq(permissions.entityType, 'workspace'),
-            eq(permissions.userId, session.user.id)
-          )
-        )
-        .then((rows) => rows[0])
-
-      if (existingPermission) {
+      const existingAccess = await checkWorkspaceAccess(invitation.workspaceId, session.user.id)
+      if (existingAccess.hasAccess) {
         await db
           .update(workspaceInvitation)
           .set({

--- a/apps/tradinggoose/app/api/workspaces/invitations/route.test.ts
+++ b/apps/tradinggoose/app/api/workspaces/invitations/route.test.ts
@@ -11,6 +11,7 @@ describe('Workspace Invitations API Route', () => {
   let mockInsertValues: any
   let mockSendEmail: any
   let mockHasWorkspaceAdminAccess: any
+  let mockCheckWorkspaceAccess: any
 
   beforeEach(() => {
     vi.resetModules()
@@ -31,6 +32,7 @@ describe('Workspace Invitations API Route', () => {
 
     mockInsertValues = vi.fn().mockResolvedValue(undefined)
     mockHasWorkspaceAdminAccess = vi.fn().mockResolvedValue(true)
+    mockCheckWorkspaceAccess = vi.fn().mockResolvedValue({ hasAccess: false })
     const mockDbChain = {
       select: vi.fn().mockReturnThis(),
       from: vi.fn().mockReturnThis(),
@@ -101,6 +103,7 @@ describe('Workspace Invitations API Route', () => {
         permissionJoin: 'permission-join',
         accessFilter: 'access-filter',
       })),
+      checkWorkspaceAccess: mockCheckWorkspaceAccess,
       hasWorkspaceAdminAccess: mockHasWorkspaceAdminAccess,
     }))
 
@@ -250,10 +253,10 @@ describe('Workspace Invitations API Route', () => {
 
     it('should return 400 when user already has workspace access', async () => {
       mockGetSession.mockResolvedValue({ user: { id: 'user-123' } })
+      mockCheckWorkspaceAccess.mockResolvedValue({ hasAccess: true })
       mockDbResults = [
         [mockWorkspace], // Workspace exists
         [mockUser], // User exists
-        [{ permissionType: 'read' }], // User already has access
       ]
 
       const { POST } = await import('@/app/api/workspaces/invitations/route')

--- a/apps/tradinggoose/app/api/workspaces/invitations/route.test.ts
+++ b/apps/tradinggoose/app/api/workspaces/invitations/route.test.ts
@@ -10,6 +10,7 @@ describe('Workspace Invitations API Route', () => {
   let mockGetSession: any
   let mockInsertValues: any
   let mockSendEmail: any
+  let mockHasWorkspaceAdminAccess: any
 
   beforeEach(() => {
     vi.resetModules()
@@ -29,11 +30,13 @@ describe('Workspace Invitations API Route', () => {
     }))
 
     mockInsertValues = vi.fn().mockResolvedValue(undefined)
+    mockHasWorkspaceAdminAccess = vi.fn().mockResolvedValue(true)
     const mockDbChain = {
       select: vi.fn().mockReturnThis(),
       from: vi.fn().mockReturnThis(),
       where: vi.fn().mockReturnThis(),
       innerJoin: vi.fn().mockReturnThis(),
+      leftJoin: vi.fn().mockReturnThis(),
       limit: vi.fn().mockReturnThis(),
       then: vi.fn().mockImplementation((callback: any) => {
         const result = mockDbResults.shift() || []
@@ -91,6 +94,14 @@ describe('Workspace Invitations API Route', () => {
 
     vi.doMock('@/lib/urls/utils', () => ({
       getBaseUrl: vi.fn().mockReturnValue('https://test.tradinggoose.ai'),
+    }))
+
+    vi.doMock('@/lib/permissions/utils', () => ({
+      buildWorkspaceAccessScope: vi.fn(() => ({
+        permissionJoin: 'permission-join',
+        accessFilter: 'access-filter',
+      })),
+      hasWorkspaceAdminAccess: mockHasWorkspaceAdminAccess,
     }))
 
     vi.doMock('drizzle-orm', () => ({
@@ -205,7 +216,7 @@ describe('Workspace Invitations API Route', () => {
 
     it('should return 403 when user does not have admin permissions', async () => {
       mockGetSession.mockResolvedValue({ user: { id: 'user-123' } })
-      mockDbResults = [[]] // No admin permissions found
+      mockHasWorkspaceAdminAccess.mockResolvedValue(false)
 
       const { POST } = await import('@/app/api/workspaces/invitations/route')
       const req = createMockRequest('POST', {
@@ -222,7 +233,6 @@ describe('Workspace Invitations API Route', () => {
     it('should return 404 when workspace is not found', async () => {
       mockGetSession.mockResolvedValue({ user: { id: 'user-123' } })
       mockDbResults = [
-        [{ permissionType: 'admin' }], // User has admin permissions
         [], // Workspace not found
       ]
 
@@ -241,7 +251,6 @@ describe('Workspace Invitations API Route', () => {
     it('should return 400 when user already has workspace access', async () => {
       mockGetSession.mockResolvedValue({ user: { id: 'user-123' } })
       mockDbResults = [
-        [{ permissionType: 'admin' }], // User has admin permissions
         [mockWorkspace], // Workspace exists
         [mockUser], // User exists
         [{ permissionType: 'read' }], // User already has access
@@ -265,7 +274,6 @@ describe('Workspace Invitations API Route', () => {
     it('should return 400 when invitation already exists', async () => {
       mockGetSession.mockResolvedValue({ user: { id: 'user-123' } })
       mockDbResults = [
-        [{ permissionType: 'admin' }], // User has admin permissions
         [mockWorkspace], // Workspace exists
         [], // User doesn't exist
         [mockInvitation], // Invitation exists
@@ -291,7 +299,6 @@ describe('Workspace Invitations API Route', () => {
         user: { id: 'user-123', name: 'Test User', email: 'sender@example.com' },
       })
       mockDbResults = [
-        [{ permissionType: 'admin' }], // User has admin permissions
         [mockWorkspace], // Workspace exists
         [], // User doesn't exist
         [], // No existing invitation

--- a/apps/tradinggoose/app/api/workspaces/invitations/route.ts
+++ b/apps/tradinggoose/app/api/workspaces/invitations/route.ts
@@ -15,6 +15,7 @@ import { getSession } from '@/lib/auth'
 import { resolveEmailLocale } from '@/lib/email/locale'
 import { sendEmail } from '@/lib/email/mailer'
 import { createLogger } from '@/lib/logs/console/logger'
+import { buildWorkspaceAccessScope, hasWorkspaceAdminAccess } from '@/lib/permissions/utils'
 import { getBaseUrl } from '@/lib/urls/utils'
 import { localizeUrl } from '@/i18n/utils'
 
@@ -33,18 +34,12 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    // Get all workspaces where the user has permissions
+    const workspaceAccess = buildWorkspaceAccessScope(session.user.id, workspace.id)
     const userWorkspaces = await db
       .select({ id: workspace.id })
       .from(workspace)
-      .innerJoin(
-        permissions,
-        and(
-          eq(permissions.entityId, workspace.id),
-          eq(permissions.entityType, 'workspace'),
-          eq(permissions.userId, session.user.id)
-        )
-      )
+      .leftJoin(permissions, workspaceAccess.permissionJoin)
+      .where(workspaceAccess.accessFilter)
 
     if (userWorkspaces.length === 0) {
       return NextResponse.json({ invitations: [] })
@@ -90,21 +85,8 @@ export async function POST(req: NextRequest) {
       )
     }
 
-    // Check if user has admin permissions for this workspace
-    const userPermission = await db
-      .select()
-      .from(permissions)
-      .where(
-        and(
-          eq(permissions.entityId, workspaceId),
-          eq(permissions.entityType, 'workspace'),
-          eq(permissions.userId, session.user.id),
-          eq(permissions.permissionType, 'admin')
-        )
-      )
-      .then((rows) => rows[0])
-
-    if (!userPermission) {
+    const hasAdminAccess = await hasWorkspaceAdminAccess(session.user.id, workspaceId)
+    if (!hasAdminAccess) {
       return NextResponse.json(
         { error: 'You need admin permissions to invite users' },
         { status: 403 }

--- a/apps/tradinggoose/app/api/workspaces/invitations/route.ts
+++ b/apps/tradinggoose/app/api/workspaces/invitations/route.ts
@@ -15,7 +15,11 @@ import { getSession } from '@/lib/auth'
 import { resolveEmailLocale } from '@/lib/email/locale'
 import { sendEmail } from '@/lib/email/mailer'
 import { createLogger } from '@/lib/logs/console/logger'
-import { buildWorkspaceAccessScope, hasWorkspaceAdminAccess } from '@/lib/permissions/utils'
+import {
+  buildWorkspaceAccessScope,
+  checkWorkspaceAccess,
+  hasWorkspaceAdminAccess,
+} from '@/lib/permissions/utils'
 import { getBaseUrl } from '@/lib/urls/utils'
 import { localizeUrl } from '@/i18n/utils'
 
@@ -113,20 +117,8 @@ export async function POST(req: NextRequest) {
       .then((rows) => rows[0])
 
     if (existingUser) {
-      // Check if the user already has permissions for this workspace
-      const existingPermission = await db
-        .select()
-        .from(permissions)
-        .where(
-          and(
-            eq(permissions.entityId, workspaceId),
-            eq(permissions.entityType, 'workspace'),
-            eq(permissions.userId, existingUser.id)
-          )
-        )
-        .then((rows) => rows[0])
-
-      if (existingPermission) {
+      const existingAccess = await checkWorkspaceAccess(workspaceId, existingUser.id)
+      if (existingAccess.hasAccess) {
         return NextResponse.json(
           {
             error: `${email} already has access to this workspace`,

--- a/apps/tradinggoose/app/api/workspaces/members/[id]/route.test.ts
+++ b/apps/tradinggoose/app/api/workspaces/members/[id]/route.test.ts
@@ -17,12 +17,23 @@ async function deleteMember(userId: string) {
 
 describe('Workspace member DELETE route', () => {
   const selectResults: any[][] = []
-  const deleteMock = vi.fn()
+  const deleteWhereMock = vi.fn()
+  const deleteMock = vi.fn(() => ({
+    where: deleteWhereMock,
+  }))
   const selectMock = vi.fn(() => ({
     from: vi.fn(() => ({
-      where: vi.fn(() => ({
-        limit: vi.fn(() => selectResults.shift() ?? []),
-      })),
+      where: vi.fn(() => {
+        const rows = selectResults.shift() ?? []
+
+        return {
+          limit: vi.fn(() => rows),
+          then: (
+            onFulfilled: (value: any[]) => unknown,
+            onRejected?: (reason: unknown) => unknown
+          ) => Promise.resolve(rows).then(onFulfilled, onRejected),
+        }
+      }),
     })),
   }))
   const mockHasWorkspaceAdminAccess = vi.fn()
@@ -141,5 +152,23 @@ describe('Workspace member DELETE route', () => {
     expect(await response.json()).toEqual({ error: 'Insufficient permissions' })
     expect(deleteMock).not.toHaveBeenCalled()
     expect(mockHasWorkspaceAdminAccess).toHaveBeenCalledWith('user-1', 'workspace-1')
+  })
+
+  it('allows a non-owner admin to leave when the canonical owner remains admin', async () => {
+    selectResults.push([
+      {
+        ownerId: 'owner-1',
+        billingOwnerType: 'user',
+        billingOwnerUserId: 'owner-1',
+      },
+    ])
+    selectResults.push([{ userId: 'user-1', permissionType: 'admin' }])
+
+    const response = await deleteMember('user-1')
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ success: true })
+    expect(deleteMock).toHaveBeenCalledWith(expect.anything())
+    expect(deleteWhereMock).toHaveBeenCalled()
   })
 })

--- a/apps/tradinggoose/app/api/workspaces/members/[id]/route.test.ts
+++ b/apps/tradinggoose/app/api/workspaces/members/[id]/route.test.ts
@@ -4,6 +4,17 @@
 import { NextRequest } from 'next/server'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+async function deleteMember(userId: string) {
+  const { DELETE } = await import('./route')
+  return DELETE(
+    new NextRequest(`http://localhost/api/workspaces/members/${userId}`, {
+      method: 'DELETE',
+      body: JSON.stringify({ workspaceId: 'workspace-1' }),
+    }),
+    { params: Promise.resolve({ id: userId }) }
+  )
+}
+
 describe('Workspace member DELETE route', () => {
   const selectResults: any[][] = []
   const deleteMock = vi.fn()
@@ -71,6 +82,8 @@ describe('Workspace member DELETE route', () => {
         }
       ),
     }))
+
+    mockHasWorkspaceAdminAccess.mockResolvedValue(true)
   })
 
   afterEach(() => {
@@ -85,22 +98,14 @@ describe('Workspace member DELETE route', () => {
         billingOwnerUserId: 'user-2',
       },
     ])
-
-    const { DELETE } = await import('./route')
-    const response = await DELETE(
-      new NextRequest('http://localhost/api/workspaces/members/user-2', {
-        method: 'DELETE',
-        body: JSON.stringify({ workspaceId: 'workspace-1' }),
-      }),
-      { params: Promise.resolve({ id: 'user-2' }) }
-    )
+    const response = await deleteMember('user-2')
 
     expect(response.status).toBe(400)
     expect(await response.json()).toEqual({
       error: 'Cannot remove the workspace billing owner. Please reassign billing first.',
     })
     expect(deleteMock).not.toHaveBeenCalled()
-    expect(mockHasWorkspaceAdminAccess).not.toHaveBeenCalled()
+    expect(mockHasWorkspaceAdminAccess).toHaveBeenCalledWith('user-1', 'workspace-1')
   })
 
   it('blocks removing the canonical workspace owner', async () => {
@@ -112,18 +117,29 @@ describe('Workspace member DELETE route', () => {
       },
     ])
 
-    const { DELETE } = await import('./route')
-    const response = await DELETE(
-      new NextRequest('http://localhost/api/workspaces/members/user-2', {
-        method: 'DELETE',
-        body: JSON.stringify({ workspaceId: 'workspace-1' }),
-      }),
-      { params: Promise.resolve({ id: 'user-2' }) }
-    )
+    const response = await deleteMember('user-2')
 
     expect(response.status).toBe(400)
     expect(await response.json()).toEqual({ error: 'Cannot remove the workspace owner' })
     expect(deleteMock).not.toHaveBeenCalled()
-    expect(mockHasWorkspaceAdminAccess).not.toHaveBeenCalled()
+    expect(mockHasWorkspaceAdminAccess).toHaveBeenCalledWith('user-1', 'workspace-1')
+  })
+
+  it('does not disclose canonical owner state to callers without admin access', async () => {
+    mockHasWorkspaceAdminAccess.mockResolvedValue(false)
+    selectResults.push([
+      {
+        ownerId: 'user-2',
+        billingOwnerType: 'user',
+        billingOwnerUserId: 'user-1',
+      },
+    ])
+
+    const response = await deleteMember('user-2')
+
+    expect(response.status).toBe(403)
+    expect(await response.json()).toEqual({ error: 'Insufficient permissions' })
+    expect(deleteMock).not.toHaveBeenCalled()
+    expect(mockHasWorkspaceAdminAccess).toHaveBeenCalledWith('user-1', 'workspace-1')
   })
 })

--- a/apps/tradinggoose/app/api/workspaces/members/[id]/route.test.ts
+++ b/apps/tradinggoose/app/api/workspaces/members/[id]/route.test.ts
@@ -34,6 +34,7 @@ describe('Workspace member DELETE route', () => {
       },
       workspace: {
         id: 'workspace.id',
+        ownerId: 'workspace.ownerId',
         billingOwnerType: 'workspace.billingOwnerType',
         billingOwnerUserId: 'workspace.billingOwnerUserId',
       },
@@ -79,6 +80,7 @@ describe('Workspace member DELETE route', () => {
   it('blocks removing the workspace billing owner until billing is reassigned', async () => {
     selectResults.push([
       {
+        ownerId: 'user-1',
         billingOwnerType: 'user',
         billingOwnerUserId: 'user-2',
       },
@@ -97,6 +99,30 @@ describe('Workspace member DELETE route', () => {
     expect(await response.json()).toEqual({
       error: 'Cannot remove the workspace billing owner. Please reassign billing first.',
     })
+    expect(deleteMock).not.toHaveBeenCalled()
+    expect(mockHasWorkspaceAdminAccess).not.toHaveBeenCalled()
+  })
+
+  it('blocks removing the canonical workspace owner', async () => {
+    selectResults.push([
+      {
+        ownerId: 'user-2',
+        billingOwnerType: 'user',
+        billingOwnerUserId: 'user-1',
+      },
+    ])
+
+    const { DELETE } = await import('./route')
+    const response = await DELETE(
+      new NextRequest('http://localhost/api/workspaces/members/user-2', {
+        method: 'DELETE',
+        body: JSON.stringify({ workspaceId: 'workspace-1' }),
+      }),
+      { params: Promise.resolve({ id: 'user-2' }) }
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Cannot remove the workspace owner' })
     expect(deleteMock).not.toHaveBeenCalled()
     expect(mockHasWorkspaceAdminAccess).not.toHaveBeenCalled()
   })

--- a/apps/tradinggoose/app/api/workspaces/members/[id]/route.ts
+++ b/apps/tradinggoose/app/api/workspaces/members/[id]/route.ts
@@ -31,6 +31,7 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
 
     const workspaceRow = await db
       .select({
+        ownerId: workspace.ownerId,
         billingOwnerType: workspace.billingOwnerType,
         billingOwnerUserId: workspace.billingOwnerUserId,
       })
@@ -40,6 +41,10 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
 
     if (workspaceRow.length === 0) {
       return NextResponse.json({ error: 'Workspace not found' }, { status: 404 })
+    }
+
+    if (workspaceRow[0].ownerId === userId) {
+      return NextResponse.json({ error: 'Cannot remove the workspace owner' }, { status: 400 })
     }
 
     try {

--- a/apps/tradinggoose/app/api/workspaces/members/[id]/route.ts
+++ b/apps/tradinggoose/app/api/workspaces/members/[id]/route.ts
@@ -84,28 +84,6 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
       return NextResponse.json({ error: 'User not found in workspace' }, { status: 404 })
     }
 
-    // Prevent removing yourself if you're the last admin
-    if (isSelf && userPermission.permissionType === 'admin') {
-      const otherAdmins = await db
-        .select()
-        .from(permissions)
-        .where(
-          and(
-            eq(permissions.entityType, 'workspace'),
-            eq(permissions.entityId, workspaceId),
-            eq(permissions.permissionType, 'admin')
-          )
-        )
-        .then((rows) => rows.filter((row) => row.userId !== session.user.id))
-
-      if (otherAdmins.length === 0) {
-        return NextResponse.json(
-          { error: 'Cannot remove the last admin from a workspace' },
-          { status: 400 }
-        )
-      }
-    }
-
     // Delete the user's permissions for this workspace
     await db
       .delete(permissions)

--- a/apps/tradinggoose/app/api/workspaces/members/[id]/route.ts
+++ b/apps/tradinggoose/app/api/workspaces/members/[id]/route.ts
@@ -43,6 +43,13 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
       return NextResponse.json({ error: 'Workspace not found' }, { status: 404 })
     }
 
+    const hasAdminAccess = await hasWorkspaceAdminAccess(session.user.id, workspaceId)
+    const isSelf = userId === session.user.id
+
+    if (!hasAdminAccess && !isSelf) {
+      return NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 })
+    }
+
     if (workspaceRow[0].ownerId === userId) {
       return NextResponse.json({ error: 'Cannot remove the workspace owner' }, { status: 400 })
     }
@@ -75,14 +82,6 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
 
     if (!userPermission) {
       return NextResponse.json({ error: 'User not found in workspace' }, { status: 404 })
-    }
-
-    // Check if current user has admin access to this workspace
-    const hasAdminAccess = await hasWorkspaceAdminAccess(session.user.id, workspaceId)
-    const isSelf = userId === session.user.id
-
-    if (!hasAdminAccess && !isSelf) {
-      return NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 })
     }
 
     // Prevent removing yourself if you're the last admin

--- a/apps/tradinggoose/app/api/workspaces/members/route.ts
+++ b/apps/tradinggoose/app/api/workspaces/members/route.ts
@@ -1,9 +1,9 @@
 import { db } from '@tradinggoose/db'
 import { permissions, type permissionTypeEnum, user } from '@tradinggoose/db/schema'
-import { and, eq } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { getSession } from '@/lib/auth'
-import { hasWorkspaceAdminAccess } from '@/lib/permissions/utils'
+import { checkWorkspaceAccess, hasWorkspaceAdminAccess } from '@/lib/permissions/utils'
 
 type PermissionType = (typeof permissionTypeEnum.enumValues)[number]
 
@@ -52,21 +52,10 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 })
     }
 
-    // Check if user already has permissions for this workspace
-    const existingPermissions = await db
-      .select()
-      .from(permissions)
-      .where(
-        and(
-          eq(permissions.userId, targetUser.id),
-          eq(permissions.entityType, 'workspace'),
-          eq(permissions.entityId, workspaceId)
-        )
-      )
-
-    if (existingPermissions.length > 0) {
+    const existingAccess = await checkWorkspaceAccess(workspaceId, targetUser.id)
+    if (existingAccess.hasAccess) {
       return NextResponse.json(
-        { error: 'User already has permissions for this workspace' },
+        { error: 'User already has access to this workspace' },
         { status: 400 }
       )
     }

--- a/apps/tradinggoose/app/api/workspaces/members/route.ts
+++ b/apps/tradinggoose/app/api/workspaces/members/route.ts
@@ -3,7 +3,7 @@ import { permissions, type permissionTypeEnum, user } from '@tradinggoose/db/sch
 import { and, eq } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { getSession } from '@/lib/auth'
-import { hasAdminPermission } from '@/lib/permissions/utils'
+import { hasWorkspaceAdminAccess } from '@/lib/permissions/utils'
 
 type PermissionType = (typeof permissionTypeEnum.enumValues)[number]
 
@@ -35,7 +35,7 @@ export async function POST(req: Request) {
     }
 
     // Check if current user has admin permission for the workspace
-    const hasAdmin = await hasAdminPermission(session.user.id, workspaceId)
+    const hasAdmin = await hasWorkspaceAdminAccess(session.user.id, workspaceId)
 
     if (!hasAdmin) {
       return NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 })

--- a/apps/tradinggoose/app/api/workspaces/route.test.ts
+++ b/apps/tradinggoose/app/api/workspaces/route.test.ts
@@ -265,8 +265,12 @@ describe('Workspaces API Route', () => {
       () => mockSaveWorkflowToNormalizedTables.mockRejectedValue(new Error('database unavailable')),
     ],
     [
-      'Yjs seeding throws',
-      () => mockTryApplyWorkflowState.mockRejectedValue(new Error('socket unavailable')),
+      'Yjs seeding fails',
+      () =>
+        mockTryApplyWorkflowState.mockResolvedValue({
+          success: false,
+          error: new Error('socket unavailable'),
+        }),
     ],
   ])('removes a newly created workspace when default workflow %s', async (_case, fail) => {
     fail()

--- a/apps/tradinggoose/app/api/workspaces/route.test.ts
+++ b/apps/tradinggoose/app/api/workspaces/route.test.ts
@@ -135,6 +135,16 @@ describe('Workspaces API Route', () => {
     vi.clearAllMocks()
   })
 
+  async function postWorkspace() {
+    const { POST } = await import('@/app/api/workspaces/route')
+    return POST(
+      new Request('http://localhost/api/workspaces', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'New Workspace' }),
+      })
+    )
+  }
+
   it('returns an empty list without creating a default workspace when autoCreate=false', async () => {
     const { GET } = await import('@/app/api/workspaces/route')
 
@@ -217,24 +227,52 @@ describe('Workspaces API Route', () => {
     expect(transactionMock).not.toHaveBeenCalled()
   })
 
-  it('removes a newly created workspace when default workflow persistence fails', async () => {
-    mockSaveWorkflowToNormalizedTables.mockResolvedValue({
-      success: false,
-      error: 'Failed to persist normalized workflow state',
-    })
+  it('auto-creates a default workspace with the canonical workspace shape', async () => {
+    const { GET } = await import('@/app/api/workspaces/route')
 
-    const { POST } = await import('@/app/api/workspaces/route')
-    const response = await POST(
-      new Request('http://localhost/api/workspaces', {
-        method: 'POST',
-        body: JSON.stringify({ name: 'New Workspace' }),
-      })
-    )
+    const response = await GET(new NextRequest('http://localhost/api/workspaces'))
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.workspaces).toEqual([
+      expect.objectContaining({
+        name: "Bruz's Workspace",
+        role: 'owner',
+        permissions: 'admin',
+        billingOwner: {
+          type: 'user',
+          userId: 'user-1',
+        },
+      }),
+    ])
+    expect(transactionMock).toHaveBeenCalled()
+    expect(updateMock).toHaveBeenCalled()
+  })
+
+  it.each([
+    [
+      'persistence fails',
+      () =>
+        mockSaveWorkflowToNormalizedTables.mockResolvedValue({
+          success: false,
+          error: 'Failed to persist normalized workflow state',
+        }),
+    ],
+    [
+      'persistence throws',
+      () => mockSaveWorkflowToNormalizedTables.mockRejectedValue(new Error('database unavailable')),
+    ],
+    [
+      'Yjs seeding throws',
+      () => mockTryApplyWorkflowState.mockRejectedValue(new Error('socket unavailable')),
+    ],
+  ])('removes a newly created workspace when default workflow %s', async (_case, fail) => {
+    fail()
+    const response = await postWorkspace()
 
     expect(response.status).toBe(500)
     expect(await response.json()).toEqual({ error: 'Failed to create workspace' })
     expect(deleteMock).toHaveBeenCalled()
     expect(deleteWhereMock).toHaveBeenCalled()
-    expect(mockTryApplyWorkflowState).not.toHaveBeenCalled()
   })
 })

--- a/apps/tradinggoose/app/api/workspaces/route.test.ts
+++ b/apps/tradinggoose/app/api/workspaces/route.test.ts
@@ -11,7 +11,7 @@ describe('Workspaces API Route', () => {
   const updateMock = vi.fn()
   let userWorkspaces: Array<{
     workspace: Record<string, unknown>
-    permissionType: 'admin' | 'write' | 'read'
+    permissionType: 'admin' | 'write' | 'read' | null
   }> = []
 
   beforeEach(() => {
@@ -27,6 +27,11 @@ describe('Workspaces API Route', () => {
       db: {
         select: vi.fn(() => ({
           from: vi.fn(() => ({
+            leftJoin: vi.fn(() => ({
+              where: vi.fn(() => ({
+                orderBy: vi.fn(() => userWorkspaces),
+              })),
+            })),
             innerJoin: vi.fn(() => ({
               where: vi.fn(() => ({
                 orderBy: vi.fn(() => userWorkspaces),
@@ -53,6 +58,7 @@ describe('Workspaces API Route', () => {
       },
       workspace: {
         id: 'workspace.id',
+        ownerId: 'workspace.ownerId',
         createdAt: 'workspace.createdAt',
       },
     }))
@@ -159,6 +165,39 @@ describe('Workspaces API Route', () => {
       permissions: 'admin',
     })
     expect(updateMock).not.toHaveBeenCalled()
+    expect(transactionMock).not.toHaveBeenCalled()
+  })
+
+  it('lists owned workspaces without requiring an owner permission row', async () => {
+    userWorkspaces = [
+      {
+        workspace: {
+          id: 'workspace-owned',
+          name: 'Owned Workspace',
+          ownerId: 'user-1',
+          billingOwnerType: 'user',
+          billingOwnerUserId: 'user-1',
+          billingOwnerOrganizationId: null,
+          createdAt: new Date('2026-04-10T00:00:00.000Z'),
+          updatedAt: new Date('2026-04-10T00:00:00.000Z'),
+        },
+        permissionType: null,
+      },
+    ]
+
+    const { GET } = await import('@/app/api/workspaces/route')
+
+    const response = await GET(new NextRequest('http://localhost/api/workspaces?autoCreate=false'))
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.workspaces).toEqual([
+      expect.objectContaining({
+        id: 'workspace-owned',
+        role: 'owner',
+        permissions: 'admin',
+      }),
+    ])
     expect(transactionMock).not.toHaveBeenCalled()
   })
 })

--- a/apps/tradinggoose/app/api/workspaces/route.test.ts
+++ b/apps/tradinggoose/app/api/workspaces/route.test.ts
@@ -6,9 +6,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('Workspaces API Route', () => {
   const transactionMock = vi.fn()
+  const txInsertValuesMock = vi.fn()
+  const txInsertMock = vi.fn(() => ({
+    values: txInsertValuesMock,
+  }))
+  const deleteWhereMock = vi.fn()
+  const deleteMock = vi.fn(() => ({
+    where: deleteWhereMock,
+  }))
   const updateWhereMock = vi.fn()
   const updateSetMock = vi.fn()
   const updateMock = vi.fn()
+  const mockSaveWorkflowToNormalizedTables = vi.fn()
+  const mockTryApplyWorkflowState = vi.fn()
   let userWorkspaces: Array<{
     workspace: Record<string, unknown>
     permissionType: 'admin' | 'write' | 'read' | null
@@ -19,12 +29,18 @@ describe('Workspaces API Route', () => {
     vi.clearAllMocks()
     userWorkspaces = []
 
+    txInsertValuesMock.mockResolvedValue(undefined)
+    transactionMock.mockImplementation(async (callback) => callback({ insert: txInsertMock }))
+    deleteWhereMock.mockResolvedValue(undefined)
     updateWhereMock.mockResolvedValue([])
     updateSetMock.mockReturnValue({ where: updateWhereMock })
     updateMock.mockReturnValue({ set: updateSetMock })
+    mockSaveWorkflowToNormalizedTables.mockResolvedValue({ success: true })
+    mockTryApplyWorkflowState.mockResolvedValue({ success: true })
 
     vi.doMock('@tradinggoose/db', () => ({
       db: {
+        delete: deleteMock,
         select: vi.fn(() => ({
           from: vi.fn(() => ({
             leftJoin: vi.fn(() => ({
@@ -91,11 +107,11 @@ describe('Workspaces API Route', () => {
     }))
 
     vi.doMock('@/lib/workflows/db-helpers', () => ({
-      saveWorkflowToNormalizedTables: vi.fn().mockResolvedValue({ success: true }),
+      saveWorkflowToNormalizedTables: mockSaveWorkflowToNormalizedTables,
     }))
 
     vi.doMock('@/lib/yjs/server/apply-workflow-state', () => ({
-      tryApplyWorkflowState: vi.fn().mockResolvedValue(undefined),
+      tryApplyWorkflowState: mockTryApplyWorkflowState,
     }))
 
     vi.doMock('@/lib/yjs/workflow-session', () => ({
@@ -199,5 +215,26 @@ describe('Workspaces API Route', () => {
       }),
     ])
     expect(transactionMock).not.toHaveBeenCalled()
+  })
+
+  it('removes a newly created workspace when default workflow persistence fails', async () => {
+    mockSaveWorkflowToNormalizedTables.mockResolvedValue({
+      success: false,
+      error: 'Failed to persist normalized workflow state',
+    })
+
+    const { POST } = await import('@/app/api/workspaces/route')
+    const response = await POST(
+      new Request('http://localhost/api/workspaces', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'New Workspace' }),
+      })
+    )
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toEqual({ error: 'Failed to create workspace' })
+    expect(deleteMock).toHaveBeenCalled()
+    expect(deleteWhereMock).toHaveBeenCalled()
+    expect(mockTryApplyWorkflowState).not.toHaveBeenCalled()
   })
 })

--- a/apps/tradinggoose/app/api/workspaces/route.test.ts
+++ b/apps/tradinggoose/app/api/workspaces/route.test.ts
@@ -11,7 +11,7 @@ describe('Workspaces API Route', () => {
     values: txInsertValuesMock,
   }))
   const deleteWhereMock = vi.fn()
-  const deleteMock = vi.fn(() => ({
+  const deleteMock = vi.fn((_table: unknown) => ({
     where: deleteWhereMock,
   }))
   const updateWhereMock = vi.fn()
@@ -30,7 +30,9 @@ describe('Workspaces API Route', () => {
     userWorkspaces = []
 
     txInsertValuesMock.mockResolvedValue(undefined)
-    transactionMock.mockImplementation(async (callback) => callback({ insert: txInsertMock }))
+    transactionMock.mockImplementation(async (callback) =>
+      callback({ insert: txInsertMock, delete: deleteMock })
+    )
     deleteWhereMock.mockResolvedValue(undefined)
     updateWhereMock.mockResolvedValue([])
     updateSetMock.mockReturnValue({ where: updateWhereMock })
@@ -272,7 +274,10 @@ describe('Workspaces API Route', () => {
 
     expect(response.status).toBe(500)
     expect(await response.json()).toEqual({ error: 'Failed to create workspace' })
-    expect(deleteMock).toHaveBeenCalled()
-    expect(deleteWhereMock).toHaveBeenCalled()
+    expect(deleteMock.mock.calls.map(([table]) => table)).toEqual([
+      expect.objectContaining({ workspaceId: 'workflow.workspaceId' }),
+      expect.objectContaining({ ownerId: 'workspace.ownerId' }),
+    ])
+    expect(deleteWhereMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/tradinggoose/app/api/workspaces/route.ts
+++ b/apps/tradinggoose/app/api/workspaces/route.ts
@@ -1,15 +1,8 @@
-import { db } from '@tradinggoose/db'
-import { permissions, workflow, workspace } from '@tradinggoose/db/schema'
-import { and, desc, eq, isNull } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getSession } from '@/lib/auth'
 import { createLogger } from '@/lib/logs/console/logger'
-import { saveWorkflowToNormalizedTables } from '@/lib/workflows/db-helpers'
-import { buildDefaultWorkflowArtifacts } from '@/lib/workflows/defaults'
-import { toWorkspaceApiRecord } from '@/lib/workspaces/billing-owner'
-import { tryApplyWorkflowState } from '@/lib/yjs/server/apply-workflow-state'
-import { createWorkflowSnapshot } from '@/lib/yjs/workflow-session'
+import { createWorkspace, getUserWorkspaces } from '@/lib/workspaces/service'
 
 const logger = createLogger('Workspaces')
 const createWorkspaceSchema = z.object({
@@ -25,46 +18,13 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  // Get all workspaces where the user has permissions
-  const userWorkspaces = await db
-    .select({
-      workspace: workspace,
-      permissionType: permissions.permissionType,
-    })
-    .from(permissions)
-    .innerJoin(workspace, eq(permissions.entityId, workspace.id))
-    .where(and(eq(permissions.userId, session.user.id), eq(permissions.entityType, 'workspace')))
-    .orderBy(desc(workspace.createdAt))
+  const workspaces = await getUserWorkspaces({
+    userId: session.user.id,
+    userName: session.user.name,
+    autoCreate: allowWorkspaceBootstrap,
+  })
 
-  if (userWorkspaces.length === 0) {
-    if (!allowWorkspaceBootstrap) {
-      return NextResponse.json({ workspaces: [] })
-    }
-
-    // Create a default workspace for the user
-    const defaultWorkspace = await createDefaultWorkspace(session.user.id, session.user.name)
-
-    // Migrate existing workflows to the default workspace
-    await migrateExistingWorkflows(session.user.id, defaultWorkspace.id)
-
-    return NextResponse.json({ workspaces: [defaultWorkspace] })
-  }
-
-  if (allowWorkspaceBootstrap) {
-    // If user has workspaces but might have orphaned workflows, migrate them
-    await ensureWorkflowsHaveWorkspace(session.user.id, userWorkspaces[0].workspace.id)
-  }
-
-  // Format the response with permission information
-  const workspacesWithPermissions = userWorkspaces.map(
-    ({ workspace: workspaceDetails, permissionType }) => ({
-      ...toWorkspaceApiRecord(workspaceDetails),
-      role: permissionType === 'admin' ? 'owner' : 'member', // Map admin to owner for compatibility
-      permissions: permissionType,
-    })
-  )
-
-  return NextResponse.json({ workspaces: workspacesWithPermissions })
+  return NextResponse.json({ workspaces })
 }
 
 // POST /api/workspaces - Create a new workspace
@@ -84,167 +44,5 @@ export async function POST(req: Request) {
   } catch (error) {
     logger.error('Error creating workspace:', error)
     return NextResponse.json({ error: 'Failed to create workspace' }, { status: 500 })
-  }
-}
-
-// Helper function to create a default workspace
-async function createDefaultWorkspace(userId: string, userName?: string | null) {
-  const firstName = userName?.split(' ')[0] || null
-  const workspaceName = firstName ? `${firstName}'s Workspace` : 'My Workspace'
-  return createWorkspace(userId, workspaceName)
-}
-
-// Helper function to create a workspace
-async function createWorkspace(userId: string, name: string) {
-  const workspaceId = crypto.randomUUID()
-  const workflowId = crypto.randomUUID()
-  const now = new Date()
-
-  // Create the workspace and initial workflow in a transaction
-  try {
-    await db.transaction(async (tx) => {
-      // Create the workspace
-      await tx.insert(workspace).values({
-        id: workspaceId,
-        name,
-        ownerId: userId,
-        billingOwnerType: 'user',
-        billingOwnerUserId: userId,
-        billingOwnerOrganizationId: null,
-        allowPersonalApiKeys: true,
-        createdAt: now,
-        updatedAt: now,
-      })
-
-      // Create admin permissions for the workspace owner
-      await tx.insert(permissions).values({
-        id: crypto.randomUUID(),
-        entityType: 'workspace' as const,
-        entityId: workspaceId,
-        userId: userId,
-        permissionType: 'admin' as const,
-        createdAt: now,
-        updatedAt: now,
-      })
-
-      // Create initial workflow for the workspace (empty canvas)
-      // Create the workflow
-      await tx.insert(workflow).values({
-        id: workflowId,
-        userId,
-        workspaceId,
-        folderId: null,
-        name: 'default-agent',
-        description: 'Your first workflow - start building here!',
-        color: '#3972F6',
-        lastSynced: now,
-        createdAt: now,
-        updatedAt: now,
-        isDeployed: false,
-        collaborators: [],
-        runCount: 0,
-        variables: {},
-        isPublished: false,
-        marketplaceData: null,
-      })
-
-      // No blocks are inserted - empty canvas
-
-      logger.info(
-        `Created workspace ${workspaceId} with initial workflow ${workflowId} for user ${userId}`
-      )
-    })
-
-    const { workflowState } = buildDefaultWorkflowArtifacts()
-    const lastSaved = now.toISOString()
-
-    // Seed the Yjs doc and persist to normalized tables in parallel
-    const [, seedResult] = await Promise.all([
-      tryApplyWorkflowState(
-        workflowId,
-        createWorkflowSnapshot({
-          blocks: workflowState.blocks,
-          edges: workflowState.edges,
-          loops: workflowState.loops,
-          parallels: workflowState.parallels,
-          lastSaved,
-          isDeployed: false,
-        }),
-        undefined,
-        'default-agent'
-      ),
-      saveWorkflowToNormalizedTables(workflowId, workflowState),
-    ])
-
-    if (!seedResult.success) {
-      throw new Error(seedResult.error || 'Failed to seed default workflow state')
-    }
-  } catch (error) {
-    logger.error(`Failed to create workspace ${workspaceId} with initial workflow:`, error)
-    throw error
-  }
-
-  // Return the workspace data directly instead of querying again
-  return {
-    ...toWorkspaceApiRecord({
-      id: workspaceId,
-      name,
-      ownerId: userId,
-      billingOwnerType: 'user',
-      billingOwnerUserId: userId,
-      billingOwnerOrganizationId: null,
-      allowPersonalApiKeys: true,
-      createdAt: now,
-      updatedAt: now,
-    }),
-    role: 'owner',
-  }
-}
-
-// Helper function to migrate existing workflows to a workspace
-async function migrateExistingWorkflows(userId: string, workspaceId: string) {
-  // Find all workflows that have no workspace ID
-  const orphanedWorkflows = await db
-    .select({ id: workflow.id })
-    .from(workflow)
-    .where(and(eq(workflow.userId, userId), isNull(workflow.workspaceId)))
-
-  if (orphanedWorkflows.length === 0) {
-    return // No orphaned workflows to migrate
-  }
-
-  logger.info(
-    `Migrating ${orphanedWorkflows.length} workflows to workspace ${workspaceId} for user ${userId}`
-  )
-
-  // Bulk update all orphaned workflows at once
-  await db
-    .update(workflow)
-    .set({
-      workspaceId: workspaceId,
-      updatedAt: new Date(),
-    })
-    .where(and(eq(workflow.userId, userId), isNull(workflow.workspaceId)))
-}
-
-// Helper function to ensure all workflows have a workspace
-async function ensureWorkflowsHaveWorkspace(userId: string, defaultWorkspaceId: string) {
-  // First check if there are any orphaned workflows
-  const orphanedWorkflows = await db
-    .select()
-    .from(workflow)
-    .where(and(eq(workflow.userId, userId), isNull(workflow.workspaceId)))
-
-  if (orphanedWorkflows.length > 0) {
-    // Directly update any workflows that don't have a workspace ID in a single query
-    await db
-      .update(workflow)
-      .set({
-        workspaceId: defaultWorkspaceId,
-        updatedAt: new Date(),
-      })
-      .where(and(eq(workflow.userId, userId), isNull(workflow.workspaceId)))
-
-    logger.info(`Fixed ${orphanedWorkflows.length} orphaned workflows for user ${userId}`)
   }
 }

--- a/apps/tradinggoose/app/workspace/[workspaceId]/providers/workspace-permissions-provider.test.tsx
+++ b/apps/tradinggoose/app/workspace/[workspaceId]/providers/workspace-permissions-provider.test.tsx
@@ -20,7 +20,6 @@ vi.mock('next/navigation', () => ({
 }))
 
 vi.mock('@/i18n/navigation', () => ({
-  usePathname: () => '/workspace/ws-1/dashboard',
   useRouter: () => ({
     replace: mockReplace,
   }),
@@ -52,7 +51,6 @@ describe('WorkspacePermissionsProvider', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    window.history.replaceState({}, '', '/workspace/ws-1/dashboard?layoutId=layout-1')
 
     mockUseWorkspacePermissions.mockReturnValue({
       permissions: null,
@@ -90,40 +88,6 @@ describe('WorkspacePermissionsProvider', () => {
 
   afterAll(() => {
     reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment
-  })
-
-  it('redirects missing sessions to login with the current callback target', async () => {
-    mockUseWorkspacePermissions.mockReturnValue({
-      permissions: null,
-      loading: false,
-      error: 'Workspace not found or access denied',
-      updatePermissions: mockUpdatePermissions,
-      refetch: mockRefetchPermissions,
-    })
-
-    mockUseUserPermissions.mockReturnValue({
-      canRead: false,
-      canEdit: false,
-      canAdmin: false,
-      userPermissions: 'read',
-      isLoading: false,
-      error: 'Authentication required',
-    })
-
-    const { WorkspacePermissionsProvider } = await import('./workspace-permissions-provider')
-
-    await act(async () => {
-      root?.render(
-        <WorkspacePermissionsProvider workspaceId='ws-1'>
-          <div>workspace</div>
-        </WorkspacePermissionsProvider>
-      )
-    })
-
-    expect(mockReplace).toHaveBeenCalledWith(
-      '/login?reauth=1&callbackUrl=%2Fworkspace%2Fws-1%2Fdashboard%3FlayoutId%3Dlayout-1'
-    )
-    expect(container?.textContent).toBe('')
   })
 
   it('redirects authenticated users without access back to the workspace index', async () => {

--- a/apps/tradinggoose/app/workspace/[workspaceId]/providers/workspace-permissions-provider.tsx
+++ b/apps/tradinggoose/app/workspace/[workspaceId]/providers/workspace-permissions-provider.tsx
@@ -9,11 +9,10 @@ import {
   useWorkspacePermissions,
   type WorkspacePermissions,
 } from '@/hooks/use-workspace-permissions'
-import { usePathname, useRouter } from '@/i18n/navigation'
+import { useRouter } from '@/i18n/navigation'
 
 const logger = createLogger('WorkspacePermissionsProvider')
 const ACCESS_DENIED_PATTERNS = ['access denied', 'workspace not found', 'user not found']
-const AUTH_ERROR_PATTERNS = ['authentication required', 'failed to get session']
 
 interface WorkspacePermissionsContextType {
   workspacePermissions: WorkspacePermissions | null
@@ -53,7 +52,6 @@ export function WorkspacePermissionsProvider({
 }: WorkspacePermissionsProviderProps) {
   const params = useParams()
   const router = useRouter()
-  const pathname = usePathname()
   const workspaceId = workspaceIdProp ?? (params?.workspaceId as string | undefined) ?? null
 
   const [isOfflineMode, setIsOfflineMode] = useState(false)
@@ -119,33 +117,15 @@ export function WorkspacePermissionsProvider({
   const isAccessDeniedError = normalizedError
     ? ACCESS_DENIED_PATTERNS.some((pattern) => normalizedError.includes(pattern))
     : false
-  const isAuthError = normalizedError
-    ? AUTH_ERROR_PATTERNS.some((pattern) => normalizedError.includes(pattern))
-    : false
   const shouldTriggerRedirect = Boolean(
     workspaceId &&
       !permissionsLoading &&
       !userPermissions.isLoading &&
-      (isAuthError || isAccessDeniedError || !userPermissions.canRead)
+      (isAccessDeniedError || !userPermissions.canRead)
   )
 
   useEffect(() => {
     if (!shouldTriggerRedirect || hasRedirected) {
-      return
-    }
-
-    if (isAuthError) {
-      const callbackTarget =
-        typeof window === 'undefined'
-          ? `/workspace/${workspaceId}/dashboard`
-          : `${pathname ?? `/workspace/${workspaceId}/dashboard`}${window.location.search}`
-
-      setHasRedirected(true)
-      logger.warn('Redirecting unauthenticated user from protected workspace route', {
-        workspaceId,
-        error: combinedError ?? 'missing session',
-      })
-      router.replace(`/login?reauth=1&callbackUrl=${encodeURIComponent(callbackTarget)}`)
       return
     }
 
@@ -155,7 +135,7 @@ export function WorkspacePermissionsProvider({
       error: combinedError ?? 'missing read permissions',
     })
     router.replace('/workspace')
-  }, [combinedError, hasRedirected, isAuthError, pathname, router, shouldTriggerRedirect, workspaceId])
+  }, [combinedError, hasRedirected, router, shouldTriggerRedirect, workspaceId])
 
   const shouldBlockRender = hasRedirected || shouldTriggerRedirect
 

--- a/apps/tradinggoose/global-navbar/components/workspace-dialogs.tsx
+++ b/apps/tradinggoose/global-navbar/components/workspace-dialogs.tsx
@@ -41,6 +41,7 @@ interface WorkspaceInviteModalProps {
   onOpenChange: (open: boolean) => void
   workspaceName?: string
   workspaceId?: string
+  workspaceOwnerId?: string
 }
 
 interface EmailTagProps {
@@ -73,6 +74,7 @@ interface PermissionsTableProps {
   permissionsLoading: boolean
   pendingInvitations: UserPermissions[]
   isPendingInvitationsLoading: boolean
+  workspaceOwnerId?: string
   resendingInvitationIds?: Record<string, boolean>
   resentInvitationIds?: Record<string, boolean>
   resendCooldowns?: Record<string, number>
@@ -191,6 +193,7 @@ const PermissionsTable = ({
   permissionsLoading,
   pendingInvitations,
   isPendingInvitationsLoading,
+  workspaceOwnerId,
   onResendInvitation,
   resendingInvitationIds,
   resentInvitationIds,
@@ -285,6 +288,7 @@ const PermissionsTable = ({
         <div>
           {allUsers.map((user) => {
             const isCurrentUser = user.isCurrentUser === true
+            const isWorkspaceOwner = user.userId === workspaceOwnerId
             const isExistingUser = filteredExistingUsers.some((eu) => eu.email === user.email)
             const isPendingInvitation = user.isPendingInvitation === true
             const userIdentifier = user.userId || user.email
@@ -300,6 +304,7 @@ const PermissionsTable = ({
             const canShowRemoveButton =
               isWorkspaceMember &&
               !isCurrentUser &&
+              !isWorkspaceOwner &&
               !isPendingInvitation &&
               currentUserIsAdmin &&
               user.userId
@@ -348,6 +353,7 @@ const PermissionsTable = ({
                     disabled={
                       disabled ||
                       !currentUserIsAdmin ||
+                      isWorkspaceOwner ||
                       isPendingInvitation ||
                       (isCurrentUser && user.permissionType === 'admin')
                     }
@@ -443,6 +449,7 @@ export function WorkspaceInviteModal({
   onOpenChange,
   workspaceName,
   workspaceId,
+  workspaceOwnerId,
 }: WorkspaceInviteModalProps) {
   const locale = useLocale() as LocaleCode
   const formRef = useRef<HTMLFormElement>(null)
@@ -1117,6 +1124,7 @@ export function WorkspaceInviteModal({
               permissionsLoading={permissionsLoading}
               pendingInvitations={pendingInvitations}
               isPendingInvitationsLoading={isPendingInvitationsLoading}
+              workspaceOwnerId={workspaceOwnerId}
               resendingInvitationIds={resendingInvitationIds}
               resentInvitationIds={resentInvitationIds}
               resendCooldowns={resendCooldowns}
@@ -1285,6 +1293,7 @@ export function WorkspaceDialogs({
             onOpenChange={onInviteDialogChange}
             workspaceName={inviteWorkspace?.name}
             workspaceId={inviteWorkspace?.id}
+            workspaceOwnerId={inviteWorkspace.ownerId}
           />
         </WorkspacePermissionsProvider>
       ) : null}

--- a/apps/tradinggoose/global-navbar/components/workspace-dialogs.tsx
+++ b/apps/tradinggoose/global-navbar/components/workspace-dialogs.tsx
@@ -2,8 +2,8 @@
 
 import React, { type KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Loader2, RotateCw, X } from 'lucide-react'
-import { useLocale } from 'next-intl'
 import { useParams } from 'next/navigation'
+import { useLocale } from 'next-intl'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -24,14 +24,14 @@ import { createLogger } from '@/lib/logs/console/logger'
 import type { PermissionType } from '@/lib/permissions/utils'
 import { cn } from '@/lib/utils'
 import {
-  WorkspacePermissionsProvider,
   useUserPermissionsContext,
   useWorkspacePermissionsContext,
+  WorkspacePermissionsProvider,
 } from '@/app/workspace/[workspaceId]/providers/workspace-permissions-provider'
-import { useOptionalWorkflowRoute } from '@/widgets/widgets/editor_workflow/context/workflow-route-context'
 import type { WorkspacePermissions } from '@/hooks/use-workspace-permissions'
+import type { LocaleCode } from '@/i18n/utils'
 import { API_ENDPOINTS } from '@/stores/constants'
-import { type LocaleCode } from '@/i18n/utils'
+import { useOptionalWorkflowRoute } from '@/widgets/widgets/editor_workflow/context/workflow-route-context'
 import type { Workspace } from '../types'
 
 const logger = createLogger('WorkspaceInviteModal')
@@ -134,9 +134,7 @@ const PermissionSelector = React.memo<{
   )
 
   return (
-    <div
-      className={cn('inline-flex rounded-lg border border-input bg-background', className)}
-    >
+    <div className={cn('inline-flex rounded-lg border border-input bg-background', className)}>
       {permissionOptions.map((option, index) => (
         <button
           key={option.value}
@@ -222,10 +220,10 @@ const PermissionsTable = ({
     () =>
       session?.user?.email
         ? existingUsers.find((user) => user.isCurrentUser) || {
-          email: session.user.email,
-          permissionType: 'admin',
-          isCurrentUser: true,
-        }
+            email: session.user.email,
+            permissionType: 'admin',
+            isCurrentUser: true,
+          }
         : null,
     [session?.user?.email, existingUsers]
   )
@@ -320,8 +318,8 @@ const PermissionsTable = ({
                     {isPendingInvitation && (
                       <span className='inline-flex items-center gap-1 rounded-sm bg-gray-100 px-2 py-1 font-medium text-gray-700 text-xs dark:bg-gray-800 dark:text-gray-300'>
                         {resendingInvitationIds &&
-                          user.invitationId &&
-                          resendingInvitationIds[user.invitationId] ? (
+                        user.invitationId &&
+                        resendingInvitationIds[user.invitationId] ? (
                           <>
                             <Loader2 className='h-3.5 w-3.5 animate-spin' />
                             <span>Sending...</span>
@@ -399,36 +397,36 @@ const PermissionsTable = ({
                         currentUserIsAdmin &&
                         user.invitationId &&
                         onRemoveInvitation)) && (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button
-                              variant='ghost'
-                              size='icon'
-                              onClick={() => {
-                                if (canShowRemoveButton && onRemoveMember) {
-                                  onRemoveMember(user.userId!, user.email)
-                                } else if (
-                                  isPendingInvitation &&
-                                  user.invitationId &&
-                                  onRemoveInvitation
-                                ) {
-                                  onRemoveInvitation(user.invitationId, user.email)
-                                }
-                              }}
-                              disabled={disabled || isSaving}
-                              className='h-4 w-4 p-0 text-muted-foreground transition-colors hover:bg-transparent hover:text-foreground'
-                            >
-                              <X className='h-3.5 w-3.5' />
-                              <span className='sr-only'>
-                                {isPendingInvitation ? 'Revoke invite' : 'Remove member'}
-                              </span>
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p>{isPendingInvitation ? 'Revoke invite' : 'Remove member'}</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      )}
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant='ghost'
+                            size='icon'
+                            onClick={() => {
+                              if (canShowRemoveButton && onRemoveMember) {
+                                onRemoveMember(user.userId!, user.email)
+                              } else if (
+                                isPendingInvitation &&
+                                user.invitationId &&
+                                onRemoveInvitation
+                              ) {
+                                onRemoveInvitation(user.invitationId, user.email)
+                              }
+                            }}
+                            disabled={disabled || isSaving}
+                            className='h-4 w-4 p-0 text-muted-foreground transition-colors hover:bg-transparent hover:text-foreground'
+                          >
+                            <X className='h-3.5 w-3.5' />
+                            <span className='sr-only'>
+                              {isPendingInvitation ? 'Revoke invite' : 'Remove member'}
+                            </span>
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>{isPendingInvitation ? 'Revoke invite' : 'Remove member'}</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
                   </div>
                 </div>
               </div>
@@ -655,8 +653,12 @@ export function WorkspaceInviteModal({
         throw new Error(data.error || 'Failed to update permissions')
       }
 
-      if (data.users && data.total !== undefined) {
-        updatePermissions({ users: data.users, total: data.total })
+      if (data.users && data.total !== undefined && data.currentUserPermission) {
+        updatePermissions({
+          users: data.users,
+          total: data.total,
+          currentUserPermission: data.currentUserPermission,
+        })
       }
 
       setExistingUserPermissionChanges({})
@@ -732,6 +734,7 @@ export function WorkspaceInviteModal({
           (user) => user.userId !== memberToRemove.userId
         )
         updatePermissions({
+          ...workspacePermissions,
           users: updatedUsers,
           total: workspacePermissions.total - 1,
         })
@@ -1047,9 +1050,7 @@ export function WorkspaceInviteModal({
       <AlertDialogContent className='flex max-h-[80vh] flex-col gap-0 sm:max-w-[560px]'>
         <TooltipProvider>
           <AlertDialogHeader>
-            <AlertDialogTitle>
-              Invite members to {workspaceName || 'Workspace'}
-            </AlertDialogTitle>
+            <AlertDialogTitle>Invite members to {workspaceName || 'Workspace'}</AlertDialogTitle>
           </AlertDialogHeader>
 
           <form ref={formRef} onSubmit={handleSubmit} className='mt-5'>
@@ -1156,7 +1157,11 @@ export function WorkspaceInviteModal({
               type='button'
               onClick={() => formRef.current?.requestSubmit()}
               disabled={
-                !userPerms.canAdmin || isSubmitting || isSaving || !resolvedWorkspaceId || !hasNewInvites
+                !userPerms.canAdmin ||
+                isSubmitting ||
+                isSaving ||
+                !resolvedWorkspaceId ||
+                !hasNewInvites
               }
               className={cn(
                 'ml-auto flex h-9 items-center justify-center gap-2 rounded-sm px-4 py-2 font-medium transition-all duration-200',

--- a/apps/tradinggoose/global-navbar/types.ts
+++ b/apps/tradinggoose/global-navbar/types.ts
@@ -17,7 +17,7 @@ export interface Workspace {
   name: string
   ownerId: string
   billingOwner?: { type: 'user'; userId: string } | { type: 'organization'; organizationId: string }
-  role?: string
+  role: 'owner' | 'member'
   membershipId?: string
-  permissions?: 'admin' | 'write' | 'read' | null
+  permissions: 'admin' | 'write' | 'read'
 }

--- a/apps/tradinggoose/global-navbar/use-workspace-switcher.test.ts
+++ b/apps/tradinggoose/global-navbar/use-workspace-switcher.test.ts
@@ -5,6 +5,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockPush = vi.fn()
+const mockReplace = vi.fn()
 let mockSwitchToWorkspace = vi.fn()
 let fetchMock: ReturnType<typeof vi.fn>
 let originalFetch: typeof globalThis.fetch
@@ -29,6 +30,7 @@ afterAll(() => {
 vi.mock('@/i18n/navigation', () => ({
   useRouter: () => ({
     push: mockPush,
+    replace: mockReplace,
   }),
 }))
 
@@ -44,6 +46,7 @@ vi.mock('@/stores/workflows/registry/store', () => ({
 describe('useWorkspaceSwitcher', () => {
   beforeEach(() => {
     mockPush.mockReset()
+    mockReplace.mockReset()
     mockSwitchToWorkspace = vi.fn()
     latestValue = null
 
@@ -100,6 +103,7 @@ describe('useWorkspaceSwitcher', () => {
     expect(latestValue.canManageWorkspaces).toBe(true)
     expect(latestValue.activeWorkspace?.id).toBe('ws-1')
     expect(fetchMock.mock.calls.map(([url]) => String(url))).toContain('/api/workspaces')
+    expect(mockReplace).not.toHaveBeenCalled()
 
     await act(async () => {
       latestValue.setWorkspaceMenuOpen(true)
@@ -114,5 +118,25 @@ describe('useWorkspaceSwitcher', () => {
     expect(latestValue.editingWorkspaceId).toBe('ws-1')
     expect(latestValue.inviteDialogOpen).toBe(true)
     expect(latestValue.deleteDialogOpen).toBe(true)
+  })
+
+  it('redirects the workspace root to the first workspace after mounted bootstrap', async () => {
+    const { useWorkspaceSwitcher } = await import('@/global-navbar/use-workspace-switcher')
+
+    function Harness() {
+      latestValue = useWorkspaceSwitcher({
+        enabled: true,
+        section: 'dashboard',
+      })
+      return null
+    }
+
+    await act(async () => {
+      root?.render(React.createElement(Harness))
+      await flush()
+    })
+
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toContain('/api/workspaces')
+    expect(mockReplace).toHaveBeenCalledWith('/workspace/ws-1/dashboard')
   })
 })

--- a/apps/tradinggoose/global-navbar/use-workspace-switcher.test.ts
+++ b/apps/tradinggoose/global-navbar/use-workspace-switcher.test.ts
@@ -120,7 +120,7 @@ describe('useWorkspaceSwitcher', () => {
     expect(latestValue.deleteDialogOpen).toBe(true)
   })
 
-  it('redirects the workspace root to the first workspace after mounted bootstrap', async () => {
+  it('does not redirect during the workspace bootstrap fetch (server owns the root redirect)', async () => {
     const { useWorkspaceSwitcher } = await import('@/global-navbar/use-workspace-switcher')
 
     function Harness() {
@@ -137,6 +137,8 @@ describe('useWorkspaceSwitcher', () => {
     })
 
     expect(fetchMock.mock.calls.map(([url]) => String(url))).toContain('/api/workspaces')
-    expect(mockReplace).toHaveBeenCalledWith('/workspace/ws-1/dashboard')
+    expect(latestValue.activeWorkspace?.id).toBe('ws-1')
+    expect(mockReplace).not.toHaveBeenCalled()
+    expect(mockPush).not.toHaveBeenCalled()
   })
 })

--- a/apps/tradinggoose/global-navbar/use-workspace-switcher.ts
+++ b/apps/tradinggoose/global-navbar/use-workspace-switcher.ts
@@ -18,7 +18,7 @@ export function useWorkspaceSwitcher({
   workspaceId,
   section,
 }: UseWorkspaceSwitcherOptions) {
-  const router = useRouter()
+  const { push, replace } = useRouter()
   const switchToWorkspace = useWorkflowRegistry((state) => state.switchToWorkspace)
   const canManageWorkspaces = true
   const [workspaces, setWorkspaces] = React.useState<Workspace[]>([])
@@ -64,11 +64,17 @@ export function useWorkspaceSwitcher({
 
       setWorkspaces(items)
 
+      const firstWorkspace = items[0] ?? null
+
       if (workspaceId) {
-        const match = items.find((workspace) => workspace.id === workspaceId)
-        setActiveWorkspace(match ?? items[0] ?? null)
+        setActiveWorkspace(
+          items.find((workspace) => workspace.id === workspaceId) ?? firstWorkspace
+        )
       } else {
-        setActiveWorkspace((current) => current ?? items[0] ?? null)
+        setActiveWorkspace((current) => current ?? firstWorkspace)
+        if (section && firstWorkspace) {
+          replace(getWorkspaceSwitchPath(firstWorkspace.id, section))
+        }
       }
     } catch (error) {
       console.error('Error fetching workspaces:', error)
@@ -77,7 +83,7 @@ export function useWorkspaceSwitcher({
     } finally {
       setIsWorkspacesLoading(false)
     }
-  }, [enabled, workspaceId])
+  }, [enabled, replace, section, workspaceId])
 
   React.useEffect(() => {
     void fetchWorkspaces()
@@ -100,9 +106,9 @@ export function useWorkspaceSwitcher({
         }
       }
 
-      router.push(getWorkspaceSwitchPath(workspace.id, section))
+      push(getWorkspaceSwitchPath(workspace.id, section))
     },
-    [router, section, switchToWorkspace, workspaceId]
+    [push, section, switchToWorkspace, workspaceId]
   )
 
   const handleCreateWorkspace = React.useCallback(async () => {

--- a/apps/tradinggoose/global-navbar/use-workspace-switcher.ts
+++ b/apps/tradinggoose/global-navbar/use-workspace-switcher.ts
@@ -55,12 +55,8 @@ export function useWorkspaceSwitcher({
         return
       }
 
-      const data = await response.json()
-      const items = ((data.workspaces ?? []) as Workspace[]).map((workspace) => ({
-        ...workspace,
-        permissions: workspace.permissions ?? 'admin',
-        role: workspace.role ?? (workspace.permissions === 'admin' ? 'owner' : 'member'),
-      }))
+      const data = (await response.json()) as { workspaces?: Workspace[] }
+      const items = data.workspaces ?? []
 
       setWorkspaces(items)
 
@@ -131,15 +127,11 @@ export function useWorkspaceSwitcher({
         throw new Error(error?.error ?? 'Failed to create workspace')
       }
 
-      const data = await response.json()
+      const data = (await response.json()) as { workspace?: Workspace }
       await fetchWorkspaces()
 
       if (data.workspace) {
-        await handleSwitchWorkspace({
-          ...data.workspace,
-          permissions: data.workspace.permissions ?? 'admin',
-          role: data.workspace.role ?? 'owner',
-        } satisfies Workspace)
+        await handleSwitchWorkspace(data.workspace)
       }
     } catch (error) {
       console.error('Error creating workspace:', error)

--- a/apps/tradinggoose/global-navbar/use-workspace-switcher.ts
+++ b/apps/tradinggoose/global-navbar/use-workspace-switcher.ts
@@ -18,7 +18,7 @@ export function useWorkspaceSwitcher({
   workspaceId,
   section,
 }: UseWorkspaceSwitcherOptions) {
-  const { push, replace } = useRouter()
+  const { push } = useRouter()
   const switchToWorkspace = useWorkflowRegistry((state) => state.switchToWorkspace)
   const canManageWorkspaces = true
   const [workspaces, setWorkspaces] = React.useState<Workspace[]>([])
@@ -72,9 +72,6 @@ export function useWorkspaceSwitcher({
         )
       } else {
         setActiveWorkspace((current) => current ?? firstWorkspace)
-        if (section && firstWorkspace) {
-          replace(getWorkspaceSwitchPath(firstWorkspace.id, section))
-        }
       }
     } catch (error) {
       console.error('Error fetching workspaces:', error)
@@ -83,7 +80,7 @@ export function useWorkspaceSwitcher({
     } finally {
       setIsWorkspacesLoading(false)
     }
-  }, [enabled, replace, section, workspaceId])
+  }, [enabled, workspaceId])
 
   React.useEffect(() => {
     void fetchWorkspaces()

--- a/apps/tradinggoose/hooks/queries/workspace.ts
+++ b/apps/tradinggoose/hooks/queries/workspace.ts
@@ -81,6 +81,7 @@ export interface WorkspaceSettingsResponse {
   } | null
   permissions: {
     users: WorkspaceSettingsUser[]
+    currentUserPermission: 'admin' | 'write' | 'read'
   } | null
 }
 
@@ -176,15 +177,7 @@ async function fetchAdminWorkspaces(userId: string | undefined): Promise<AdminWo
     if (!result) continue
 
     const { workspace, permissionData } = result
-    let hasAdminAccess = false
-
-    if (permissionData.users) {
-      const currentUserPermission = permissionData.users.find(
-        (user: { id: string; userId?: string; permissionType: string }) =>
-          user.id === userId || user.userId === userId
-      )
-      hasAdminAccess = currentUserPermission?.permissionType === 'admin'
-    }
+    const hasAdminAccess = permissionData.currentUserPermission === 'admin'
 
     const isOwner = workspace.isOwner || workspace.ownerId === userId
 

--- a/apps/tradinggoose/hooks/use-user-permissions.test.tsx
+++ b/apps/tradinggoose/hooks/use-user-permissions.test.tsx
@@ -1,10 +1,9 @@
 /** @vitest-environment jsdom */
 
-import React, { act } from 'react'
+import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
-const mockUseSession = vi.fn()
 const reactActEnvironment = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean
 }
@@ -13,18 +12,6 @@ const previousActEnvironment = reactActEnvironment.IS_REACT_ACT_ENVIRONMENT
 let container: HTMLDivElement | null = null
 let root: Root | null = null
 let latestValue: unknown = null
-
-vi.mock('@/lib/auth-client', () => ({
-  useSession: () => mockUseSession(),
-}))
-
-vi.mock('@/lib/logs/console/logger', () => ({
-  createLogger: () => ({
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  }),
-}))
 
 beforeAll(() => {
   reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true
@@ -37,12 +24,6 @@ afterAll(() => {
 describe('useUserPermissions', () => {
   beforeEach(() => {
     latestValue = null
-    mockUseSession.mockReset()
-    mockUseSession.mockReturnValue({
-      data: null,
-      isPending: true,
-      error: null,
-    })
 
     container = document.createElement('div')
     document.body.appendChild(container)
@@ -61,26 +42,11 @@ describe('useUserPermissions', () => {
     container = null
   })
 
-  it('keeps permissions loading while the auth session is still pending', async () => {
+  it('keeps permissions loading while workspace permissions are still pending', async () => {
     const { useUserPermissions } = await import('@/hooks/use-user-permissions')
 
     function Harness() {
-      latestValue = useUserPermissions(
-        {
-          users: [
-            {
-              userId: 'user-1',
-              email: 'member@example.com',
-              name: 'Member',
-              image: null,
-              permissionType: 'admin',
-            },
-          ],
-          total: 1,
-        },
-        false,
-        null
-      )
+      latestValue = useUserPermissions(null, true, null)
       return null
     }
 
@@ -97,18 +63,7 @@ describe('useUserPermissions', () => {
     })
   })
 
-  it('returns resolved permissions once the auth session is available', async () => {
-    mockUseSession.mockReturnValue({
-      data: {
-        user: {
-          id: 'user-1',
-          email: 'member@example.com',
-        },
-      },
-      isPending: false,
-      error: null,
-    })
-
+  it('returns server-derived current user permissions', async () => {
     const { useUserPermissions } = await import('@/hooks/use-user-permissions')
 
     function Harness() {
@@ -124,6 +79,7 @@ describe('useUserPermissions', () => {
             },
           ],
           total: 1,
+          currentUserPermission: 'write',
         },
         false,
         null

--- a/apps/tradinggoose/hooks/use-user-permissions.ts
+++ b/apps/tradinggoose/hooks/use-user-permissions.ts
@@ -1,9 +1,5 @@
 import { useMemo } from 'react'
-import { useSession } from '@/lib/auth-client'
-import { createLogger } from '@/lib/logs/console/logger'
 import type { PermissionType, WorkspacePermissions } from '@/hooks/use-workspace-permissions'
-
-const logger = createLogger('useUserPermissions')
 
 export interface WorkspaceUserPermissions {
   // Core permission checks
@@ -31,78 +27,53 @@ export function useUserPermissions(
   permissionsLoading = false,
   permissionsError: string | null = null
 ): WorkspaceUserPermissions {
-  const {
-    data: session,
-    isPending: isSessionPending,
-    error: sessionError,
-  } = useSession()
-
   const userPermissions = useMemo((): WorkspaceUserPermissions => {
-    const sessionEmail = session?.user?.email
-    const sessionErrorMessage = sessionError?.message ?? null
-    const resolvedError = permissionsError ?? sessionErrorMessage
-
-    if (permissionsLoading || isSessionPending) {
+    if (permissionsLoading) {
       return {
         canRead: false,
         canEdit: false,
         canAdmin: false,
         userPermissions: 'read',
         isLoading: true,
-        error: resolvedError,
+        error: permissionsError,
       }
     }
 
-    if (!sessionEmail) {
+    if (permissionsError) {
       return {
         canRead: false,
         canEdit: false,
         canAdmin: false,
         userPermissions: 'read',
         isLoading: false,
-        error: sessionErrorMessage ?? 'Authentication required',
+        error: permissionsError,
       }
     }
 
-    // Find current user in workspace permissions (case-insensitive)
-    const currentUser = workspacePermissions?.users?.find(
-      (user) => user.email.toLowerCase() === sessionEmail.toLowerCase()
-    )
-
-    // If user not found in workspace, they have no permissions
-    if (!currentUser) {
-      logger.warn('User not found in workspace permissions', {
-        userEmail: sessionEmail,
-        hasPermissions: !!workspacePermissions,
-        userCount: workspacePermissions?.users?.length || 0,
-      })
-
+    const userPerms = workspacePermissions?.currentUserPermission
+    if (!userPerms) {
       return {
         canRead: false,
         canEdit: false,
         canAdmin: false,
         userPermissions: 'read',
         isLoading: false,
-        error: resolvedError || 'User not found in workspace',
+        error: 'User not found in workspace',
       }
     }
 
-    const userPerms = currentUser.permissionType || 'read'
-
-    // Core permission checks
     const canAdmin = userPerms === 'admin'
     const canEdit = userPerms === 'write' || userPerms === 'admin'
-    const canRead = true // If user is found in workspace permissions, they have read access
 
     return {
-      canRead,
+      canRead: true,
       canEdit,
       canAdmin,
       userPermissions: userPerms,
       isLoading: false,
-      error: resolvedError,
+      error: null,
     }
-  }, [session, workspacePermissions, permissionsLoading, permissionsError, isSessionPending, sessionError])
+  }, [workspacePermissions?.currentUserPermission, permissionsLoading, permissionsError])
 
   return userPermissions
 }

--- a/apps/tradinggoose/hooks/use-workspace-permissions.test.tsx
+++ b/apps/tradinggoose/hooks/use-workspace-permissions.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useWorkspacePermissions } from './use-workspace-permissions'
 
 const mockHandleAuthError = vi.hoisted(() => vi.fn())
+let latestValue: ReturnType<typeof useWorkspacePermissions> | null = null
 
 vi.mock('@/lib/auth/auth-error-handler', () => ({
   handleAuthError: mockHandleAuthError,
@@ -19,7 +20,7 @@ vi.mock('@/i18n/navigation', () => ({
 }))
 
 function WorkspacePermissionsProbe() {
-  useWorkspacePermissions('workspace-401')
+  latestValue = useWorkspacePermissions('workspace-401')
   return null
 }
 
@@ -32,6 +33,7 @@ describe('useWorkspacePermissions', () => {
 
   beforeEach(() => {
     reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+    latestValue = null
     mockHandleAuthError.mockResolvedValue(undefined)
     vi.stubGlobal(
       'fetch',
@@ -62,5 +64,10 @@ describe('useWorkspacePermissions', () => {
       'workspace-permissions',
       '/workspace/workspace-1/dashboard'
     )
+    expect(latestValue).toMatchObject({
+      loading: true,
+      error: null,
+      permissions: null,
+    })
   })
 })

--- a/apps/tradinggoose/hooks/use-workspace-permissions.test.tsx
+++ b/apps/tradinggoose/hooks/use-workspace-permissions.test.tsx
@@ -92,6 +92,33 @@ describe('useWorkspacePermissions', () => {
     })
   })
 
+  it('routes resolved missing sessions through auth recovery without completing permission load', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    mockUseSession.mockReturnValue({
+      data: null,
+      isPending: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    await act(async () => {
+      root.render(<WorkspacePermissionsProbe />)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(mockHandleAuthError).toHaveBeenCalledWith(
+      'workspace-permissions',
+      '/workspace/workspace-1/dashboard'
+    )
+    expect(latestValue).toMatchObject({
+      loading: true,
+      error: null,
+      permissions: null,
+    })
+  })
+
   it('does not reuse a cached workspace permission record after the active user changes', async () => {
     workspaceId = 'workspace-1'
     const fetchMock = vi

--- a/apps/tradinggoose/hooks/use-workspace-permissions.test.tsx
+++ b/apps/tradinggoose/hooks/use-workspace-permissions.test.tsx
@@ -5,14 +5,23 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { useWorkspacePermissions } from './use-workspace-permissions'
+import {
+  resetWorkspacePermissionsStore,
+  useWorkspacePermissions,
+} from './use-workspace-permissions'
 
 const mockHandleAuthError = vi.hoisted(() => vi.fn())
+const mockUseSession = vi.hoisted(() => vi.fn())
 let latestValue: ReturnType<typeof useWorkspacePermissions> | null = null
+let workspaceId = 'workspace-401'
 
 vi.mock('@/lib/auth/auth-error-handler', () => ({
   handleAuthError: mockHandleAuthError,
   isAuthErrorStatus: (status?: number | null) => status === 401,
+}))
+
+vi.mock('@/lib/auth-client', () => ({
+  useSession: mockUseSession,
 }))
 
 vi.mock('@/i18n/navigation', () => ({
@@ -20,7 +29,7 @@ vi.mock('@/i18n/navigation', () => ({
 }))
 
 function WorkspacePermissionsProbe() {
-  latestValue = useWorkspacePermissions('workspace-401')
+  latestValue = useWorkspacePermissions(workspaceId)
   return null
 }
 
@@ -34,7 +43,18 @@ describe('useWorkspacePermissions', () => {
   beforeEach(() => {
     reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true
     latestValue = null
+    workspaceId = 'workspace-401'
     mockHandleAuthError.mockResolvedValue(undefined)
+    mockUseSession.mockReturnValue({
+      data: {
+        user: {
+          id: 'user-1',
+        },
+      },
+      isPending: false,
+      error: null,
+      refetch: vi.fn(),
+    })
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue(new Response(null, { status: 401, statusText: 'Unauthorized' }))
@@ -51,6 +71,7 @@ describe('useWorkspacePermissions', () => {
     container.remove()
     vi.unstubAllGlobals()
     vi.clearAllMocks()
+    resetWorkspacePermissionsStore()
     reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = false
   })
 
@@ -69,5 +90,53 @@ describe('useWorkspacePermissions', () => {
       error: null,
       permissions: null,
     })
+  })
+
+  it('does not reuse a cached workspace permission record after the active user changes', async () => {
+    workspaceId = 'workspace-1'
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({
+          users: [],
+          total: 0,
+          currentUserPermission: 'admin',
+        })
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          users: [],
+          total: 0,
+          currentUserPermission: 'read',
+        })
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await act(async () => {
+      root.render(<WorkspacePermissionsProbe />)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(latestValue?.permissions?.currentUserPermission).toBe('admin')
+
+    mockUseSession.mockReturnValue({
+      data: {
+        user: {
+          id: 'user-2',
+        },
+      },
+      isPending: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    await act(async () => {
+      root.render(<WorkspacePermissionsProbe />)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(latestValue?.permissions?.currentUserPermission).toBe('read')
   })
 })

--- a/apps/tradinggoose/hooks/use-workspace-permissions.ts
+++ b/apps/tradinggoose/hooks/use-workspace-permissions.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect } from 'react'
 import type { permissionTypeEnum } from '@tradinggoose/db/schema'
 import { createWithEqualityFn as create } from 'zustand/traditional'
 import { handleAuthError, isAuthErrorStatus } from '@/lib/auth/auth-error-handler'
+import { useSession } from '@/lib/auth-client'
 import { createLogger } from '@/lib/logs/console/logger'
 import { usePathname } from '@/i18n/navigation'
 import { API_ENDPOINTS } from '@/stores/constants'
@@ -49,9 +50,10 @@ type WorkspacePermissionsRecord = {
 interface WorkspacePermissionsStoreState {
   records: Record<string, WorkspacePermissionsRecord>
   inFlight: Partial<Record<string, Promise<void>>>
-  setRecord: (workspaceId: string, partial: Partial<WorkspacePermissionsRecord>) => void
-  clearRecord: (workspaceId: string) => void
+  setRecord: (recordKey: string, partial: Partial<WorkspacePermissionsRecord>) => void
+  clearRecord: (recordKey: string) => void
   fetchPermissions: (
+    recordKey: string,
     workspaceId: string,
     options: { callbackPathname: string; force?: boolean }
   ) => Promise<void>
@@ -66,35 +68,35 @@ const createDefaultRecord = (): WorkspacePermissionsRecord => ({
 const useWorkspacePermissionsStore = create<WorkspacePermissionsStoreState>((set, get) => ({
   records: {},
   inFlight: {},
-  setRecord: (workspaceId, partial) =>
+  setRecord: (recordKey, partial) =>
     set((state) => {
-      const prev = state.records[workspaceId] ?? createDefaultRecord()
+      const prev = state.records[recordKey] ?? createDefaultRecord()
       return {
         records: {
           ...state.records,
-          [workspaceId]: {
+          [recordKey]: {
             ...prev,
             ...partial,
           },
         },
       }
     }),
-  clearRecord: (workspaceId) =>
+  clearRecord: (recordKey) =>
     set((state) => {
       const records = { ...state.records }
-      delete records[workspaceId]
+      delete records[recordKey]
       return { records }
     }),
-  fetchPermissions: async (workspaceId, options) => {
+  fetchPermissions: async (recordKey, workspaceId, options) => {
     const { callbackPathname, force = false } = options
     const { records, inFlight, setRecord, clearRecord } = get()
 
     if (!force) {
-      if (inFlight[workspaceId]) {
-        return inFlight[workspaceId]
+      if (inFlight[recordKey]) {
+        return inFlight[recordKey]
       }
 
-      const existing = records[workspaceId]
+      const existing = records[recordKey]
       if (existing?.permissions && !existing?.error) {
         return
       }
@@ -102,7 +104,7 @@ const useWorkspacePermissionsStore = create<WorkspacePermissionsStoreState>((set
 
     const fetchPromise = (async () => {
       try {
-        setRecord(workspaceId, { loading: true, error: null })
+        setRecord(recordKey, { loading: true, error: null })
 
         const response = await fetch(API_ENDPOINTS.WORKSPACE_PERMISSIONS(workspaceId))
 
@@ -112,7 +114,7 @@ const useWorkspacePermissionsStore = create<WorkspacePermissionsStoreState>((set
           }
           if (isAuthErrorStatus(response.status)) {
             await handleAuthError('workspace-permissions', callbackPathname)
-            clearRecord(workspaceId)
+            clearRecord(recordKey)
             return
           }
           throw new Error(`Failed to fetch permissions: ${response.statusText}`)
@@ -126,7 +128,7 @@ const useWorkspacePermissionsStore = create<WorkspacePermissionsStoreState>((set
           users: data.users.map((u) => ({ email: u.email, permissions: u.permissionType })),
         })
 
-        setRecord(workspaceId, {
+        setRecord(recordKey, {
           permissions: data,
           loading: false,
           error: null,
@@ -137,14 +139,14 @@ const useWorkspacePermissionsStore = create<WorkspacePermissionsStoreState>((set
           workspaceId,
           error: errorMessage,
         })
-        setRecord(workspaceId, {
+        setRecord(recordKey, {
           loading: false,
           error: errorMessage,
         })
       } finally {
         set((state) => {
           const next = { ...state.inFlight }
-          delete next[workspaceId]
+          delete next[recordKey]
           return { inFlight: next }
         })
       }
@@ -153,7 +155,7 @@ const useWorkspacePermissionsStore = create<WorkspacePermissionsStoreState>((set
     set((state) => ({
       inFlight: {
         ...state.inFlight,
-        [workspaceId]: fetchPromise,
+        [recordKey]: fetchPromise,
       },
     }))
 
@@ -161,41 +163,52 @@ const useWorkspacePermissionsStore = create<WorkspacePermissionsStoreState>((set
   },
 }))
 
+function getRecordKey(workspaceId: string, userId: string) {
+  return `${userId}:${workspaceId}`
+}
+
+export function resetWorkspacePermissionsStore() {
+  useWorkspacePermissionsStore.setState({ records: {}, inFlight: {} })
+}
+
 export function useWorkspacePermissions(workspaceId: string | null): UseWorkspacePermissionsReturn {
   const callbackPathname = usePathname()
+  const session = useSession()
+  const userId = session.data?.user?.id ?? null
+  const recordKey = workspaceId && userId ? getRecordKey(workspaceId, userId) : null
   const record = useWorkspacePermissionsStore((state) =>
-    workspaceId ? state.records[workspaceId] : undefined
+    recordKey ? state.records[recordKey] : undefined
   )
   const fetchPermissions = useWorkspacePermissionsStore((state) => state.fetchPermissions)
   const setRecord = useWorkspacePermissionsStore((state) => state.setRecord)
 
   useEffect(() => {
-    if (!workspaceId) {
+    if (!workspaceId || !recordKey) {
       return () => {}
     }
-    fetchPermissions(workspaceId, { callbackPathname }).catch((error) => {
+    fetchPermissions(recordKey, workspaceId, { callbackPathname }).catch((error) => {
       logger.error('Failed to load workspace permissions', { workspaceId, error })
     })
-  }, [workspaceId, callbackPathname, fetchPermissions])
+  }, [workspaceId, recordKey, callbackPathname, fetchPermissions])
 
   const refetch = useCallback(async () => {
-    if (!workspaceId) return
-    await fetchPermissions(workspaceId, { callbackPathname, force: true })
-  }, [workspaceId, callbackPathname, fetchPermissions])
+    if (!workspaceId || !recordKey) return
+    await fetchPermissions(recordKey, workspaceId, { callbackPathname, force: true })
+  }, [workspaceId, recordKey, callbackPathname, fetchPermissions])
 
   const updatePermissions = useCallback(
     (newPermissions: WorkspacePermissions) => {
-      if (!workspaceId) return
-      setRecord(workspaceId, {
+      if (!recordKey) return
+      setRecord(recordKey, {
         permissions: newPermissions,
         loading: false,
         error: null,
       })
     },
-    [workspaceId, setRecord]
+    [recordKey, setRecord]
   )
 
-  const isInitialLoad = Boolean(workspaceId) && !record
+  const isInitialLoad = Boolean(workspaceId) && (session.isPending || Boolean(recordKey && !record))
 
   return {
     permissions: record?.permissions ?? null,

--- a/apps/tradinggoose/hooks/use-workspace-permissions.ts
+++ b/apps/tradinggoose/hooks/use-workspace-permissions.ts
@@ -183,13 +183,26 @@ export function useWorkspacePermissions(workspaceId: string | null): UseWorkspac
   const setRecord = useWorkspacePermissionsStore((state) => state.setRecord)
 
   useEffect(() => {
-    if (!workspaceId || !recordKey) {
+    if (!workspaceId || session.isPending) {
       return () => {}
     }
-    fetchPermissions(recordKey, workspaceId, { callbackPathname }).catch((error) => {
-      logger.error('Failed to load workspace permissions', { workspaceId, error })
-    })
-  }, [workspaceId, recordKey, callbackPathname, fetchPermissions])
+
+    if (!userId) {
+      handleAuthError('workspace-permissions', callbackPathname).catch((error) =>
+        logger.error('Failed to route missing workspace session through auth recovery', {
+          workspaceId,
+          error,
+        })
+      )
+      return () => {}
+    }
+
+    fetchPermissions(getRecordKey(workspaceId, userId), workspaceId, { callbackPathname }).catch(
+      (error) => {
+        logger.error('Failed to load workspace permissions', { workspaceId, error })
+      }
+    )
+  }, [workspaceId, session.isPending, userId, callbackPathname, fetchPermissions])
 
   const refetch = useCallback(async () => {
     if (!workspaceId || !recordKey) return
@@ -208,7 +221,8 @@ export function useWorkspacePermissions(workspaceId: string | null): UseWorkspac
     [recordKey, setRecord]
   )
 
-  const isInitialLoad = Boolean(workspaceId) && (session.isPending || Boolean(recordKey && !record))
+  const isInitialLoad =
+    Boolean(workspaceId) && (session.isPending || !userId || Boolean(recordKey && !record))
 
   return {
     permissions: record?.permissions ?? null,

--- a/apps/tradinggoose/hooks/use-workspace-permissions.ts
+++ b/apps/tradinggoose/hooks/use-workspace-permissions.ts
@@ -23,6 +23,7 @@ export interface WorkspaceUser {
 export interface WorkspacePermissions {
   users: WorkspaceUser[]
   total: number
+  currentUserPermission: PermissionType
 }
 
 interface UseWorkspacePermissionsReturn {
@@ -49,6 +50,7 @@ interface WorkspacePermissionsStoreState {
   records: Record<string, WorkspacePermissionsRecord>
   inFlight: Partial<Record<string, Promise<void>>>
   setRecord: (workspaceId: string, partial: Partial<WorkspacePermissionsRecord>) => void
+  clearRecord: (workspaceId: string) => void
   fetchPermissions: (
     workspaceId: string,
     options: { callbackPathname: string; force?: boolean }
@@ -77,9 +79,15 @@ const useWorkspacePermissionsStore = create<WorkspacePermissionsStoreState>((set
         },
       }
     }),
+  clearRecord: (workspaceId) =>
+    set((state) => {
+      const records = { ...state.records }
+      delete records[workspaceId]
+      return { records }
+    }),
   fetchPermissions: async (workspaceId, options) => {
     const { callbackPathname, force = false } = options
-    const { records, inFlight, setRecord } = get()
+    const { records, inFlight, setRecord, clearRecord } = get()
 
     if (!force) {
       if (inFlight[workspaceId]) {
@@ -104,7 +112,8 @@ const useWorkspacePermissionsStore = create<WorkspacePermissionsStoreState>((set
           }
           if (isAuthErrorStatus(response.status)) {
             await handleAuthError('workspace-permissions', callbackPathname)
-            throw new Error('Authentication required')
+            clearRecord(workspaceId)
+            return
           }
           throw new Error(`Failed to fetch permissions: ${response.statusText}`)
         }

--- a/apps/tradinggoose/i18n/utils.ts
+++ b/apps/tradinggoose/i18n/utils.ts
@@ -27,6 +27,15 @@ export function normalizeLocaleCode(locale: LocaleInput): LocaleCode {
   return locale && isLocaleCode(locale) ? locale : defaultLocale
 }
 
+export function requireCanonicalCallbackPath(headers: Headers, routeName: string) {
+  const callbackUrl = headers.get(CANONICAL_CALLBACK_PATH_HEADER)
+  if (!callbackUrl) {
+    throw new Error(`Missing canonical callback path for ${routeName} reauth redirect`)
+  }
+
+  return callbackUrl
+}
+
 export function getLocaleDisplayName(locale: LocaleCode) {
   return LOCALE_DISPLAY_NAMES[locale]
 }

--- a/apps/tradinggoose/lib/admin/access.ts
+++ b/apps/tradinggoose/lib/admin/access.ts
@@ -38,8 +38,8 @@ export async function claimFirstSystemAdmin(userId: string) {
   })
 }
 
-export async function getSystemAdminAccess() {
-  const session = await getSession()
+export async function getSystemAdminAccess(headersOverride?: Headers) {
+  const session = await getSession(headersOverride)
   const user = session?.user ?? null
   const userId = user?.id ?? null
 

--- a/apps/tradinggoose/lib/copilot/review-sessions/permissions.test.ts
+++ b/apps/tradinggoose/lib/copilot/review-sessions/permissions.test.ts
@@ -63,7 +63,9 @@ import {
   loadReviewSessionForUser,
   loadReviewSessionForUserByConversationId,
   verifyReviewTargetAccess,
+  verifyWorkflowAccess,
 } from '@/lib/copilot/review-sessions/permissions'
+import { readWorkflowAccessContext } from '@/lib/workflows/utils'
 import { resolveEntityWorkspaceId } from '@/lib/yjs/server/entity-loaders'
 
 type MockChain = {
@@ -77,6 +79,7 @@ type MockChain = {
 
 const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> }
 const mockResolveEntityWorkspaceId = vi.mocked(resolveEntityWorkspaceId)
+const mockReadWorkflowAccessContext = vi.mocked(readWorkflowAccessContext)
 
 function createMockChain(finalResult: any): MockChain {
   const chain: any = {}
@@ -271,5 +274,28 @@ describe('review session permissions', () => {
     const result = await loadReviewSessionForUser('review-session-1', 'collaborator-1')
 
     expect(result).toBeNull()
+  })
+
+  it('treats canonical workspace owners as workflow admins without permission rows', async () => {
+    mockReadWorkflowAccessContext.mockResolvedValueOnce({
+      workflow: {
+        id: 'workflow-1',
+        userId: 'member-1',
+        workspaceId: 'workspace-1',
+      } as NonNullable<Awaited<ReturnType<typeof readWorkflowAccessContext>>>['workflow'],
+      workspaceOwnerId: 'owner-1',
+      workspacePermission: null,
+      isOwner: false,
+      isWorkspaceOwner: true,
+    })
+
+    const result = await verifyWorkflowAccess('owner-1', 'workflow-1', 'write')
+
+    expect(result).toEqual({
+      hasAccess: true,
+      userPermission: 'admin',
+      workspaceId: 'workspace-1',
+      isOwner: false,
+    })
   })
 })

--- a/apps/tradinggoose/lib/copilot/review-sessions/permissions.ts
+++ b/apps/tradinggoose/lib/copilot/review-sessions/permissions.ts
@@ -247,7 +247,9 @@ export async function verifyWorkflowAccess(
 
     return buildAccessResult({
       isOwner: accessContext.isOwner,
-      userPermission: accessContext.workspacePermission ?? null,
+      userPermission: accessContext.isWorkspaceOwner
+        ? 'admin'
+        : (accessContext.workspacePermission ?? null),
       workspaceId: accessContext.workflow.workspaceId ?? null,
       accessMode,
     })

--- a/apps/tradinggoose/lib/knowledge/service.ts
+++ b/apps/tradinggoose/lib/knowledge/service.ts
@@ -5,9 +5,8 @@ import {
   embedding,
   knowledgeBase,
   knowledgeBaseTagDefinitions,
-  permissions,
 } from '@tradinggoose/db/schema'
-import { and, count, eq, inArray, isNotNull, isNull } from 'drizzle-orm'
+import { and, count, eq, inArray, isNull } from 'drizzle-orm'
 import { checkStorageQuota, incrementStorageUsage } from '@/lib/billing/storage'
 import { enqueueDocumentProcessingJobs } from '@/lib/knowledge/documents/service'
 import {
@@ -20,7 +19,7 @@ import type {
   KnowledgeBaseWithCounts,
 } from '@/lib/knowledge/types'
 import { createLogger } from '@/lib/logs/console/logger'
-import { getUserEntityPermissions } from '@/lib/permissions/utils'
+import { checkWorkspaceAccess, getUserEntityPermissions } from '@/lib/permissions/utils'
 
 const logger = createLogger('KnowledgeBaseService')
 
@@ -31,6 +30,11 @@ export async function getKnowledgeBases(
   userId: string,
   workspaceId: string
 ): Promise<KnowledgeBaseWithCounts[]> {
+  const workspaceAccess = await checkWorkspaceAccess(workspaceId, userId)
+  if (!workspaceAccess.hasAccess) {
+    return []
+  }
+
   const knowledgeBasesWithCounts = await db
     .select({
       id: knowledgeBase.id,
@@ -50,21 +54,7 @@ export async function getKnowledgeBases(
       document,
       and(eq(document.knowledgeBaseId, knowledgeBase.id), isNull(document.deletedAt))
     )
-    .leftJoin(
-      permissions,
-      and(
-        eq(permissions.entityType, 'workspace'),
-        eq(permissions.entityId, knowledgeBase.workspaceId),
-        eq(permissions.userId, userId)
-      )
-    )
-    .where(
-      and(
-        isNull(knowledgeBase.deletedAt),
-        eq(knowledgeBase.workspaceId, workspaceId),
-        isNotNull(permissions.userId)
-      )
-    )
+    .where(and(isNull(knowledgeBase.deletedAt), eq(knowledgeBase.workspaceId, workspaceId)))
     .groupBy(knowledgeBase.id)
     .orderBy(knowledgeBase.createdAt)
 

--- a/apps/tradinggoose/lib/permissions/utils.test.ts
+++ b/apps/tradinggoose/lib/permissions/utils.test.ts
@@ -27,7 +27,6 @@ vi.mock('@tradinggoose/db/schema', () => ({
     id: 'user_id',
     email: 'user_email',
     name: 'user_name',
-    image: 'user_image',
   },
   workspace: {
     id: 'workspace_id',
@@ -54,7 +53,6 @@ import {
   getUserEntityPermissions,
   getUsersWithPermissions,
   getWorkspaceById,
-  getWorkspaceMemberProfiles,
   hasAdminPermission,
   hasWorkspaceAdminAccess,
   workspaceExists,
@@ -334,20 +332,6 @@ describe('Permission Utils', () => {
     })
   })
 
-  describe('getWorkspaceMemberProfiles', () => {
-    it('should return minimal member profiles for a workspace', async () => {
-      const members = [
-        { userId: 'user-1', name: 'Alice', image: 'alice.png' },
-        { userId: 'user-2', name: 'Bob', image: null },
-      ]
-      mockDb.select.mockReturnValue(createMockChain(members))
-
-      const result = await getWorkspaceMemberProfiles('workspace123')
-
-      expect(result).toEqual(members)
-    })
-  })
-
   describe('hasAdminPermission', () => {
     it('should return true when user has admin permission for workspace', async () => {
       const chain = createMockChain([{ id: 'perm1' }])
@@ -405,13 +389,37 @@ describe('Permission Utils', () => {
   })
 
   describe('getUsersWithPermissions', () => {
-    it('should return empty array when no users have permissions for workspace', async () => {
+    it('should return empty array when the workspace owner is unavailable', async () => {
+      const ownerChain = createMockChain([])
       const usersChain = createMockChain([])
-      mockDb.select.mockReturnValue(usersChain)
+      mockDb.select.mockReturnValueOnce(ownerChain).mockReturnValueOnce(usersChain)
 
       const result = await getUsersWithPermissions('workspace123')
 
       expect(result).toEqual([])
+    })
+
+    it('should include the workspace owner as admin without a permission row', async () => {
+      const ownerChain = createMockChain([
+        {
+          userId: 'owner-1',
+          email: 'owner@example.com',
+          name: 'Owner User',
+        },
+      ])
+      const usersChain = createMockChain([])
+      mockDb.select.mockReturnValueOnce(ownerChain).mockReturnValueOnce(usersChain)
+
+      const result = await getUsersWithPermissions('workspace123')
+
+      expect(result).toEqual([
+        {
+          userId: 'owner-1',
+          email: 'owner@example.com',
+          name: 'Owner User',
+          permissionType: 'admin',
+        },
+      ])
     })
 
     it('should return users with their permissions for workspace', async () => {
@@ -424,8 +432,9 @@ describe('Permission Utils', () => {
         },
       ]
 
+      const ownerChain = createMockChain([])
       const usersChain = createMockChain(mockUsersResults)
-      mockDb.select.mockReturnValue(usersChain)
+      mockDb.select.mockReturnValueOnce(ownerChain).mockReturnValueOnce(usersChain)
 
       const result = await getUsersWithPermissions('workspace456')
 
@@ -461,15 +470,16 @@ describe('Permission Utils', () => {
         },
       ]
 
+      const ownerChain = createMockChain([])
       const usersChain = createMockChain(mockUsersResults)
-      mockDb.select.mockReturnValue(usersChain)
+      mockDb.select.mockReturnValueOnce(ownerChain).mockReturnValueOnce(usersChain)
 
       const result = await getUsersWithPermissions('workspace456')
 
       expect(result).toHaveLength(3)
-      expect(result[0].permissionType).toBe('admin')
-      expect(result[1].permissionType).toBe('write')
-      expect(result[2].permissionType).toBe('read')
+      expect(result.find((row) => row.userId === 'user1')?.permissionType).toBe('admin')
+      expect(result.find((row) => row.userId === 'user2')?.permissionType).toBe('write')
+      expect(result.find((row) => row.userId === 'user3')?.permissionType).toBe('read')
     })
 
     it('should handle users with empty names', async () => {
@@ -482,8 +492,9 @@ describe('Permission Utils', () => {
         },
       ]
 
+      const ownerChain = createMockChain([])
       const usersChain = createMockChain(mockUsersResults)
-      mockDb.select.mockReturnValue(usersChain)
+      mockDb.select.mockReturnValueOnce(ownerChain).mockReturnValueOnce(usersChain)
 
       const result = await getUsersWithPermissions('workspace123')
 

--- a/apps/tradinggoose/lib/permissions/utils.test.ts
+++ b/apps/tradinggoose/lib/permissions/utils.test.ts
@@ -55,7 +55,6 @@ import {
   getWorkspaceById,
   hasAdminPermission,
   hasWorkspaceAdminAccess,
-  workspaceExists,
 } from '@/lib/permissions/utils'
 
 const mockDb = db as any
@@ -195,16 +194,18 @@ describe('Permission Utils', () => {
 
       expect(result).toBeNull()
     })
+
+    it('should return admin for workspace owners without permission rows', async () => {
+      mockDb.select.mockReturnValueOnce(createMockChain([{ ownerId: 'owner-1' }]))
+
+      const result = await getUserEntityPermissions('owner-1', 'workspace', 'workspace456')
+
+      expect(result).toBe('admin')
+      expect(mockDb.select).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('workspace helpers', () => {
-    it('should report when a workspace exists', async () => {
-      const chain = createMockChain([{ id: 'workspace123' }])
-      mockDb.select.mockReturnValue(chain)
-
-      await expect(workspaceExists('workspace123')).resolves.toBe(true)
-    })
-
     it('should return the workspace row by id', async () => {
       const workspaceRow = {
         id: 'workspace123',

--- a/apps/tradinggoose/lib/permissions/utils.test.ts
+++ b/apps/tradinggoose/lib/permissions/utils.test.ts
@@ -53,7 +53,6 @@ import {
   getUserEntityPermissions,
   getUsersWithPermissions,
   getWorkspaceById,
-  hasAdminPermission,
   hasWorkspaceAdminAccess,
 } from '@/lib/permissions/utils'
 
@@ -333,62 +332,6 @@ describe('Permission Utils', () => {
     })
   })
 
-  describe('hasAdminPermission', () => {
-    it('should return true when user has admin permission for workspace', async () => {
-      const chain = createMockChain([{ id: 'perm1' }])
-      mockDb.select.mockReturnValue(chain)
-
-      const result = await hasAdminPermission('admin-user', 'workspace123')
-
-      expect(result).toBe(true)
-    })
-
-    it('should return false when user has no admin permission for workspace', async () => {
-      const chain = createMockChain([])
-      mockDb.select.mockReturnValue(chain)
-
-      const result = await hasAdminPermission('regular-user', 'workspace123')
-
-      expect(result).toBe(false)
-    })
-
-    it('should return false when user has write permission but not admin', async () => {
-      const chain = createMockChain([])
-      mockDb.select.mockReturnValue(chain)
-
-      const result = await hasAdminPermission('write-user', 'workspace123')
-
-      expect(result).toBe(false)
-    })
-
-    it('should return false when user has read permission but not admin', async () => {
-      const chain = createMockChain([])
-      mockDb.select.mockReturnValue(chain)
-
-      const result = await hasAdminPermission('read-user', 'workspace123')
-
-      expect(result).toBe(false)
-    })
-
-    it('should handle non-existent workspace', async () => {
-      const chain = createMockChain([])
-      mockDb.select.mockReturnValue(chain)
-
-      const result = await hasAdminPermission('user123', 'non-existent-workspace')
-
-      expect(result).toBe(false)
-    })
-
-    it('should handle empty user ID', async () => {
-      const chain = createMockChain([])
-      mockDb.select.mockReturnValue(chain)
-
-      const result = await hasAdminPermission('', 'workspace123')
-
-      expect(result).toBe(false)
-    })
-  })
-
   describe('getUsersWithPermissions', () => {
     it('should return empty array when the workspace owner is unavailable', async () => {
       const ownerChain = createMockChain([])
@@ -520,7 +463,7 @@ describe('Permission Utils', () => {
         if (callCount === 1) {
           return createMockChain([{ ownerId: 'other-user' }])
         }
-        return createMockChain([{ id: 'perm1' }])
+        return createMockChain([{ permissionType: 'admin' }])
       })
 
       const result = await hasWorkspaceAdminAccess('user123', 'workspace456')
@@ -544,7 +487,7 @@ describe('Permission Utils', () => {
         if (callCount === 1) {
           return createMockChain([{ ownerId: 'other-user' }])
         }
-        return createMockChain([])
+        return createMockChain([{ permissionType: 'write' }])
       })
 
       const result = await hasWorkspaceAdminAccess('user123', 'workspace456')
@@ -559,7 +502,7 @@ describe('Permission Utils', () => {
         if (callCount === 1) {
           return createMockChain([{ ownerId: 'other-user' }])
         }
-        return createMockChain([])
+        return createMockChain([{ permissionType: 'read' }])
       })
 
       const result = await hasWorkspaceAdminAccess('user123', 'workspace456')

--- a/apps/tradinggoose/lib/permissions/utils.ts
+++ b/apps/tradinggoose/lib/permissions/utils.ts
@@ -13,12 +13,6 @@ export interface WorkspaceAccess {
   workspace: WorkspaceRecord | null
 }
 
-export interface WorkspaceMemberProfile {
-  userId: string
-  name: string
-  image: string | null
-}
-
 async function selectWorkspaceById(workspaceId: string): Promise<WorkspaceRecord | null> {
   const [row] = await db.select().from(workspace).where(eq(workspace.id, workspaceId)).limit(1)
   return row ?? null
@@ -180,6 +174,17 @@ export async function getUsersWithPermissions(workspaceId: string): Promise<
     permissionType: PermissionType
   }>
 > {
+  const [owner] = await db
+    .select({
+      userId: user.id,
+      email: user.email,
+      name: user.name,
+    })
+    .from(workspace)
+    .innerJoin(user, eq(workspace.ownerId, user.id))
+    .where(eq(workspace.id, workspaceId))
+    .limit(1)
+
   const usersWithPermissions = await db
     .select({
       userId: user.id,
@@ -193,12 +198,35 @@ export async function getUsersWithPermissions(workspaceId: string): Promise<
     .where(and(eq(permissions.entityType, 'workspace'), eq(permissions.entityId, workspaceId)))
     .orderBy(user.email)
 
-  return usersWithPermissions.map((row) => ({
-    userId: row.userId,
-    email: row.email,
-    name: row.name,
-    permissionType: row.permissionType,
-  }))
+  const usersById = new Map<
+    string,
+    {
+      userId: string
+      email: string
+      name: string
+      permissionType: PermissionType
+    }
+  >()
+
+  if (owner) {
+    usersById.set(owner.userId, {
+      ...owner,
+      permissionType: 'admin',
+    })
+  }
+
+  for (const row of usersWithPermissions) {
+    if (!usersById.has(row.userId)) {
+      usersById.set(row.userId, {
+        userId: row.userId,
+        email: row.email,
+        name: row.name,
+        permissionType: row.permissionType,
+      })
+    }
+  }
+
+  return [...usersById.values()].sort((a, b) => a.email.localeCompare(b.email))
 }
 
 /**
@@ -278,21 +306,4 @@ export async function getManageableWorkspaces(userId: string): Promise<
   ]
 
   return combined
-}
-
-export async function getWorkspaceMemberProfiles(
-  workspaceId: string
-): Promise<WorkspaceMemberProfile[]> {
-  const rows = await db
-    .select({
-      userId: user.id,
-      name: user.name,
-      image: user.image,
-    })
-    .from(permissions)
-    .innerJoin(user, eq(permissions.userId, user.id))
-    .innerJoin(workspace, eq(permissions.entityId, workspace.id))
-    .where(and(eq(permissions.entityType, 'workspace'), eq(permissions.entityId, workspaceId)))
-
-  return rows
 }

--- a/apps/tradinggoose/lib/permissions/utils.ts
+++ b/apps/tradinggoose/lib/permissions/utils.ts
@@ -18,16 +18,6 @@ async function selectWorkspaceById(workspaceId: string): Promise<WorkspaceRecord
   return row ?? null
 }
 
-export async function workspaceExists(workspaceId: string): Promise<boolean> {
-  const [row] = await db
-    .select({ id: workspace.id })
-    .from(workspace)
-    .where(eq(workspace.id, workspaceId))
-    .limit(1)
-
-  return !!row
-}
-
 export async function getWorkspaceById(workspaceId: string): Promise<WorkspaceRecord | null> {
   return await selectWorkspaceById(workspaceId)
 }
@@ -105,9 +95,13 @@ export async function getUserEntityPermissions(
   entityId: string
 ): Promise<PermissionType | null> {
   if (entityType === 'workspace') {
-    const activeWorkspace = await workspaceExists(entityId)
+    const activeWorkspace = await selectWorkspaceById(entityId)
     if (!activeWorkspace) {
       return null
+    }
+
+    if (activeWorkspace.ownerId === userId) {
+      return 'admin'
     }
   }
 

--- a/apps/tradinggoose/lib/permissions/utils.ts
+++ b/apps/tradinggoose/lib/permissions/utils.ts
@@ -131,30 +131,6 @@ export async function getUserEntityPermissions(
 }
 
 /**
- * Check if a user has admin permission for a specific workspace
- *
- * @param userId - The ID of the user to check
- * @param workspaceId - The ID of the workspace to check
- * @returns Promise<boolean> - True if the user has admin permission for the workspace, false otherwise
- */
-export async function hasAdminPermission(userId: string, workspaceId: string): Promise<boolean> {
-  const result = await db
-    .select({ id: permissions.id })
-    .from(permissions)
-    .where(
-      and(
-        eq(permissions.userId, userId),
-        eq(permissions.entityType, 'workspace'),
-        eq(permissions.entityId, workspaceId),
-        eq(permissions.permissionType, 'admin')
-      )
-    )
-    .limit(1)
-
-  return result.length > 0
-}
-
-/**
  * Retrieves a list of users with their associated permissions for a given workspace.
  *
  * @param workspaceId - The ID of the workspace to retrieve user permissions for.
@@ -234,17 +210,7 @@ export async function hasWorkspaceAdminAccess(
   userId: string,
   workspaceId: string
 ): Promise<boolean> {
-  const ws = await selectWorkspaceById(workspaceId)
-
-  if (!ws) {
-    return false
-  }
-
-  if (ws.ownerId === userId) {
-    return true
-  }
-
-  return await hasAdminPermission(userId, workspaceId)
+  return (await getUserEntityPermissions(userId, 'workspace', workspaceId)) === 'admin'
 }
 
 /**

--- a/apps/tradinggoose/lib/workflows/utils.ts
+++ b/apps/tradinggoose/lib/workflows/utils.ts
@@ -569,9 +569,9 @@ export async function validateWorkflowPermissions(
     }
   }
 
-  const { workflow, workspacePermission, isOwner } = accessContext
+  const { workflow, workspacePermission, isOwner, isWorkspaceOwner } = accessContext
 
-  if (isOwner) {
+  if (isOwner || isWorkspaceOwner) {
     return {
       error: null,
       session,

--- a/apps/tradinggoose/lib/workspaces/service.ts
+++ b/apps/tradinggoose/lib/workspaces/service.ts
@@ -8,6 +8,8 @@ import { toWorkspaceApiRecord } from '@/lib/workspaces/billing-owner'
 import { tryApplyWorkflowState } from '@/lib/yjs/server/apply-workflow-state'
 import { createWorkflowSnapshot } from '@/lib/yjs/workflow-session'
 
+type WorkspaceRecord = typeof workspace.$inferSelect
+
 export async function getUserWorkspaces({
   userId,
   userName,
@@ -60,19 +62,20 @@ export async function createWorkspace(userId: string, name: string) {
   const workspaceId = crypto.randomUUID()
   const workflowId = crypto.randomUUID()
   const now = new Date()
+  const workspaceDetails = {
+    id: workspaceId,
+    name,
+    ownerId: userId,
+    billingOwnerType: 'user',
+    billingOwnerUserId: userId,
+    billingOwnerOrganizationId: null,
+    allowPersonalApiKeys: true,
+    createdAt: now,
+    updatedAt: now,
+  } satisfies WorkspaceRecord
 
   await db.transaction(async (tx) => {
-    await tx.insert(workspace).values({
-      id: workspaceId,
-      name,
-      ownerId: userId,
-      billingOwnerType: 'user',
-      billingOwnerUserId: userId,
-      billingOwnerOrganizationId: null,
-      allowPersonalApiKeys: true,
-      createdAt: now,
-      updatedAt: now,
-    })
+    await tx.insert(workspace).values(workspaceDetails)
 
     await tx.insert(workflow).values({
       id: workflowId,
@@ -97,39 +100,34 @@ export async function createWorkspace(userId: string, name: string) {
   const { workflowState } = buildDefaultWorkflowArtifacts()
   const lastSaved = now.toISOString()
 
-  const saveResult = await saveWorkflowToNormalizedTables(workflowId, workflowState)
-  if (!saveResult.success) {
+  try {
+    const saveResult = await saveWorkflowToNormalizedTables(workflowId, workflowState)
+    if (!saveResult.success) {
+      throw new Error(saveResult.error || 'Failed to persist default workflow state')
+    }
+
+    await tryApplyWorkflowState(
+      workflowId,
+      createWorkflowSnapshot({
+        blocks: saveResult.normalizedState?.blocks ?? workflowState.blocks,
+        edges: saveResult.normalizedState?.edges ?? workflowState.edges,
+        loops: saveResult.normalizedState?.loops ?? workflowState.loops,
+        parallels: saveResult.normalizedState?.parallels ?? workflowState.parallels,
+        lastSaved,
+        isDeployed: false,
+      }),
+      undefined,
+      'default-agent'
+    )
+  } catch (error) {
     await db.delete(workspace).where(eq(workspace.id, workspaceId))
-    throw new Error(saveResult.error || 'Failed to persist default workflow state')
+    throw error
   }
 
-  await tryApplyWorkflowState(
-    workflowId,
-    createWorkflowSnapshot({
-      blocks: saveResult.normalizedState?.blocks ?? workflowState.blocks,
-      edges: saveResult.normalizedState?.edges ?? workflowState.edges,
-      loops: saveResult.normalizedState?.loops ?? workflowState.loops,
-      parallels: saveResult.normalizedState?.parallels ?? workflowState.parallels,
-      lastSaved,
-      isDeployed: false,
-    }),
-    undefined,
-    'default-agent'
-  )
-
   return {
-    ...toWorkspaceApiRecord({
-      id: workspaceId,
-      name,
-      ownerId: userId,
-      billingOwnerType: 'user',
-      billingOwnerUserId: userId,
-      billingOwnerOrganizationId: null,
-      allowPersonalApiKeys: true,
-      createdAt: now,
-      updatedAt: now,
-    }),
+    ...toWorkspaceApiRecord(workspaceDetails),
     role: 'owner',
+    permissions: 'admin',
   }
 }
 

--- a/apps/tradinggoose/lib/workspaces/service.ts
+++ b/apps/tradinggoose/lib/workspaces/service.ts
@@ -106,7 +106,7 @@ export async function createWorkspace(userId: string, name: string) {
       throw new Error(saveResult.error || 'Failed to persist default workflow state')
     }
 
-    await tryApplyWorkflowState(
+    const seedResult = await tryApplyWorkflowState(
       workflowId,
       createWorkflowSnapshot({
         blocks: saveResult.normalizedState?.blocks ?? workflowState.blocks,
@@ -119,6 +119,11 @@ export async function createWorkspace(userId: string, name: string) {
       undefined,
       'default-agent'
     )
+    if (!seedResult.success) {
+      throw seedResult.error instanceof Error
+        ? seedResult.error
+        : new Error('Failed to seed default workflow state')
+    }
   } catch (error) {
     await db.transaction(async (tx) => {
       await tx.delete(workflow).where(eq(workflow.id, workflowId))

--- a/apps/tradinggoose/lib/workspaces/service.ts
+++ b/apps/tradinggoose/lib/workspaces/service.ts
@@ -74,16 +74,6 @@ export async function createWorkspace(userId: string, name: string) {
       updatedAt: now,
     })
 
-    await tx.insert(permissions).values({
-      id: crypto.randomUUID(),
-      entityType: 'workspace' as const,
-      entityId: workspaceId,
-      userId,
-      permissionType: 'admin' as const,
-      createdAt: now,
-      updatedAt: now,
-    })
-
     await tx.insert(workflow).values({
       id: workflowId,
       userId,

--- a/apps/tradinggoose/lib/workspaces/service.ts
+++ b/apps/tradinggoose/lib/workspaces/service.ts
@@ -1,0 +1,161 @@
+import { db } from '@tradinggoose/db'
+import { permissions, workflow, workspace } from '@tradinggoose/db/schema'
+import { and, desc, eq, isNull } from 'drizzle-orm'
+import { saveWorkflowToNormalizedTables } from '@/lib/workflows/db-helpers'
+import { buildDefaultWorkflowArtifacts } from '@/lib/workflows/defaults'
+import { toWorkspaceApiRecord } from '@/lib/workspaces/billing-owner'
+import { tryApplyWorkflowState } from '@/lib/yjs/server/apply-workflow-state'
+import { createWorkflowSnapshot } from '@/lib/yjs/workflow-session'
+
+export async function getUserWorkspaces({
+  userId,
+  userName,
+  autoCreate = true,
+}: {
+  userId: string
+  userName?: string | null
+  autoCreate?: boolean
+}) {
+  const userWorkspaces = await db
+    .select({
+      workspace: workspace,
+      permissionType: permissions.permissionType,
+    })
+    .from(permissions)
+    .innerJoin(workspace, eq(permissions.entityId, workspace.id))
+    .where(and(eq(permissions.userId, userId), eq(permissions.entityType, 'workspace')))
+    .orderBy(desc(workspace.createdAt))
+
+  if (userWorkspaces.length === 0) {
+    if (!autoCreate) {
+      return []
+    }
+
+    const defaultWorkspace = await createDefaultWorkspace(userId, userName)
+    await migrateExistingWorkflows(userId, defaultWorkspace.id)
+    return [defaultWorkspace]
+  }
+
+  if (autoCreate) {
+    await ensureWorkflowsHaveWorkspace(userId, userWorkspaces[0].workspace.id)
+  }
+
+  return userWorkspaces.map(({ workspace: workspaceDetails, permissionType }) => ({
+    ...toWorkspaceApiRecord(workspaceDetails),
+    role: permissionType === 'admin' ? 'owner' : 'member',
+    permissions: permissionType,
+  }))
+}
+
+export async function createWorkspace(userId: string, name: string) {
+  const workspaceId = crypto.randomUUID()
+  const workflowId = crypto.randomUUID()
+  const now = new Date()
+
+  await db.transaction(async (tx) => {
+    await tx.insert(workspace).values({
+      id: workspaceId,
+      name,
+      ownerId: userId,
+      billingOwnerType: 'user',
+      billingOwnerUserId: userId,
+      billingOwnerOrganizationId: null,
+      allowPersonalApiKeys: true,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    await tx.insert(permissions).values({
+      id: crypto.randomUUID(),
+      entityType: 'workspace' as const,
+      entityId: workspaceId,
+      userId,
+      permissionType: 'admin' as const,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    await tx.insert(workflow).values({
+      id: workflowId,
+      userId,
+      workspaceId,
+      folderId: null,
+      name: 'default-agent',
+      description: 'Your first workflow - start building here!',
+      color: '#3972F6',
+      lastSynced: now,
+      createdAt: now,
+      updatedAt: now,
+      isDeployed: false,
+      collaborators: [],
+      runCount: 0,
+      variables: {},
+      isPublished: false,
+      marketplaceData: null,
+    })
+  })
+
+  const { workflowState } = buildDefaultWorkflowArtifacts()
+  const lastSaved = now.toISOString()
+
+  const [, seedResult] = await Promise.all([
+    tryApplyWorkflowState(
+      workflowId,
+      createWorkflowSnapshot({
+        blocks: workflowState.blocks,
+        edges: workflowState.edges,
+        loops: workflowState.loops,
+        parallels: workflowState.parallels,
+        lastSaved,
+        isDeployed: false,
+      }),
+      undefined,
+      'default-agent'
+    ),
+    saveWorkflowToNormalizedTables(workflowId, workflowState),
+  ])
+
+  if (!seedResult.success) {
+    throw new Error(seedResult.error || 'Failed to seed default workflow state')
+  }
+
+  return {
+    ...toWorkspaceApiRecord({
+      id: workspaceId,
+      name,
+      ownerId: userId,
+      billingOwnerType: 'user',
+      billingOwnerUserId: userId,
+      billingOwnerOrganizationId: null,
+      allowPersonalApiKeys: true,
+      createdAt: now,
+      updatedAt: now,
+    }),
+    role: 'owner',
+  }
+}
+
+async function createDefaultWorkspace(userId: string, userName?: string | null) {
+  const firstName = userName?.split(' ')[0] || null
+  return createWorkspace(userId, firstName ? `${firstName}'s Workspace` : 'My Workspace')
+}
+
+async function migrateExistingWorkflows(userId: string, workspaceId: string) {
+  await db
+    .update(workflow)
+    .set({
+      workspaceId,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(workflow.userId, userId), isNull(workflow.workspaceId)))
+}
+
+async function ensureWorkflowsHaveWorkspace(userId: string, defaultWorkspaceId: string) {
+  await db
+    .update(workflow)
+    .set({
+      workspaceId: defaultWorkspaceId,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(workflow.userId, userId), isNull(workflow.workspaceId)))
+}

--- a/apps/tradinggoose/lib/workspaces/service.ts
+++ b/apps/tradinggoose/lib/workspaces/service.ts
@@ -1,6 +1,7 @@
 import { db } from '@tradinggoose/db'
 import { permissions, workflow, workspace } from '@tradinggoose/db/schema'
 import { and, desc, eq, isNull } from 'drizzle-orm'
+import { buildWorkspaceAccessScope } from '@/lib/permissions/utils'
 import { saveWorkflowToNormalizedTables } from '@/lib/workflows/db-helpers'
 import { buildDefaultWorkflowArtifacts } from '@/lib/workflows/defaults'
 import { toWorkspaceApiRecord } from '@/lib/workspaces/billing-owner'
@@ -16,14 +17,15 @@ export async function getUserWorkspaces({
   userName?: string | null
   autoCreate?: boolean
 }) {
+  const workspaceAccess = buildWorkspaceAccessScope(userId, workspace.id)
   const userWorkspaces = await db
     .select({
       workspace: workspace,
       permissionType: permissions.permissionType,
     })
-    .from(permissions)
-    .innerJoin(workspace, eq(permissions.entityId, workspace.id))
-    .where(and(eq(permissions.userId, userId), eq(permissions.entityType, 'workspace')))
+    .from(workspace)
+    .leftJoin(permissions, workspaceAccess.permissionJoin)
+    .where(workspaceAccess.accessFilter)
     .orderBy(desc(workspace.createdAt))
 
   if (userWorkspaces.length === 0) {
@@ -40,11 +42,18 @@ export async function getUserWorkspaces({
     await ensureWorkflowsHaveWorkspace(userId, userWorkspaces[0].workspace.id)
   }
 
-  return userWorkspaces.map(({ workspace: workspaceDetails, permissionType }) => ({
-    ...toWorkspaceApiRecord(workspaceDetails),
-    role: permissionType === 'admin' ? 'owner' : 'member',
-    permissions: permissionType,
-  }))
+  return userWorkspaces.map(({ workspace: workspaceDetails, permissionType }) => {
+    const resolvedPermissionType = workspaceDetails.ownerId === userId ? 'admin' : permissionType
+    if (!resolvedPermissionType) {
+      throw new Error(`Expected workspace permission for ${workspaceDetails.id}`)
+    }
+
+    return {
+      ...toWorkspaceApiRecord(workspaceDetails),
+      role: resolvedPermissionType === 'admin' ? 'owner' : 'member',
+      permissions: resolvedPermissionType,
+    }
+  })
 }
 
 export async function createWorkspace(userId: string, name: string) {

--- a/apps/tradinggoose/lib/workspaces/service.ts
+++ b/apps/tradinggoose/lib/workspaces/service.ts
@@ -107,26 +107,25 @@ export async function createWorkspace(userId: string, name: string) {
   const { workflowState } = buildDefaultWorkflowArtifacts()
   const lastSaved = now.toISOString()
 
-  const [, seedResult] = await Promise.all([
-    tryApplyWorkflowState(
-      workflowId,
-      createWorkflowSnapshot({
-        blocks: workflowState.blocks,
-        edges: workflowState.edges,
-        loops: workflowState.loops,
-        parallels: workflowState.parallels,
-        lastSaved,
-        isDeployed: false,
-      }),
-      undefined,
-      'default-agent'
-    ),
-    saveWorkflowToNormalizedTables(workflowId, workflowState),
-  ])
-
-  if (!seedResult.success) {
-    throw new Error(seedResult.error || 'Failed to seed default workflow state')
+  const saveResult = await saveWorkflowToNormalizedTables(workflowId, workflowState)
+  if (!saveResult.success) {
+    await db.delete(workspace).where(eq(workspace.id, workspaceId))
+    throw new Error(saveResult.error || 'Failed to persist default workflow state')
   }
+
+  await tryApplyWorkflowState(
+    workflowId,
+    createWorkflowSnapshot({
+      blocks: saveResult.normalizedState?.blocks ?? workflowState.blocks,
+      edges: saveResult.normalizedState?.edges ?? workflowState.edges,
+      loops: saveResult.normalizedState?.loops ?? workflowState.loops,
+      parallels: saveResult.normalizedState?.parallels ?? workflowState.parallels,
+      lastSaved,
+      isDeployed: false,
+    }),
+    undefined,
+    'default-agent'
+  )
 
   return {
     ...toWorkspaceApiRecord({

--- a/apps/tradinggoose/lib/workspaces/service.ts
+++ b/apps/tradinggoose/lib/workspaces/service.ts
@@ -120,7 +120,10 @@ export async function createWorkspace(userId: string, name: string) {
       'default-agent'
     )
   } catch (error) {
-    await db.delete(workspace).where(eq(workspace.id, workspaceId))
+    await db.transaction(async (tx) => {
+      await tx.delete(workflow).where(eq(workflow.id, workflowId))
+      await tx.delete(workspace).where(eq(workspace.id, workspaceId))
+    })
     throw error
   }
 

--- a/apps/tradinggoose/proxy.test.ts
+++ b/apps/tradinggoose/proxy.test.ts
@@ -1,9 +1,6 @@
 import { NextRequest } from 'next/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const PLAIN_SESSION_COOKIE = 'better-auth.session_token=session-cookie'
-const SECURE_SESSION_COOKIE = '__Secure-better-auth.session_token=session-cookie'
-
 vi.mock('./lib/logs/console/logger', () => ({
   createLogger: () => ({
     warn: vi.fn(),
@@ -40,15 +37,19 @@ describe('proxy auth routing', () => {
     process.env.NEXT_PUBLIC_APP_URL = 'https://www.tradinggoose.ai'
   })
 
-  it('uses the request host for localhost auth redirects instead of hosted-mode rewrites', async () => {
+  it('uses the request host for protected route locale redirects', async () => {
     const { proxy } = await import('./proxy')
     const response = await proxy(
-      new NextRequest('http://localhost:3000/workspace/ws-1/dashboard?layoutId=layout-1')
+      new NextRequest('http://localhost:3000/workspace/ws-1/dashboard?layoutId=layout-1', {
+        headers: {
+          'user-agent': 'vitest',
+        },
+      })
     )
 
     expect(response.status).toBe(307)
     expect(response.headers.get('location')).toBe(
-      'http://localhost:3000/en/login?callbackUrl=%2Fworkspace%2Fws-1%2Fdashboard%3FlayoutId%3Dlayout-1'
+      'http://localhost:3000/en/workspace/ws-1/dashboard?layoutId=layout-1'
     )
     expect(response.headers.get('x-middleware-rewrite')).toBeNull()
     expect(response.cookies.get('NEXT_LOCALE')?.value).toBe('en')
@@ -98,7 +99,7 @@ describe('proxy auth routing', () => {
     expect(response.cookies.get('NEXT_LOCALE')?.value).toBe('zh')
   })
 
-  it('redirects anonymous unprefixed protected routes using Accept-Language', async () => {
+  it('localizes unprefixed protected routes using Accept-Language', async () => {
     const { proxy } = await import('./proxy')
     const response = await proxy(
       new NextRequest('http://localhost:3000/workspace/ws-1/dashboard', {
@@ -111,30 +112,16 @@ describe('proxy auth routing', () => {
 
     expect(response.status).toBe(307)
     expect(response.headers.get('location')).toBe(
-      'http://localhost:3000/es/login?callbackUrl=%2Fworkspace%2Fws-1%2Fdashboard'
+      'http://localhost:3000/es/workspace/ws-1/dashboard'
     )
     expect(response.cookies.get('NEXT_LOCALE')?.value).toBe('es')
   })
 
-  it('redirects hosted protected routes to login when no session is present', async () => {
-    const { proxy } = await import('./proxy')
-    const response = await proxy(
-      new NextRequest('https://www.tradinggoose.ai/workspace/ws-1/dashboard')
-    )
-
-    expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toBe(
-      'https://www.tradinggoose.ai/en/login?callbackUrl=%2Fworkspace%2Fws-1%2Fdashboard'
-    )
-    expect(response.headers.get('x-middleware-rewrite')).toBeNull()
-  })
-
-  it('accepts Better Auth plain session cookies on HTTPS protected routes', async () => {
+  it('localizes hosted protected routes before the app auth boundary handles access', async () => {
     const { proxy } = await import('./proxy')
     const response = await proxy(
       new NextRequest('https://www.tradinggoose.ai/workspace/ws-1/dashboard', {
         headers: {
-          cookie: PLAIN_SESSION_COOKIE,
           'user-agent': 'vitest',
         },
       })
@@ -147,12 +134,13 @@ describe('proxy auth routing', () => {
     expect(response.headers.get('x-middleware-rewrite')).toBeNull()
   })
 
-  it('accepts Better Auth secure session cookies on HTTPS protected routes', async () => {
+  it('lets the default-locale reauth login route reach its page boundary', async () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
+
     const { proxy } = await import('./proxy')
     const response = await proxy(
-      new NextRequest('https://www.tradinggoose.ai/en/workspace', {
+      new NextRequest('http://localhost:3000/en/login?reauth=1&callbackUrl=%2Fworkspace%2Fws-1', {
         headers: {
-          cookie: SECURE_SESSION_COOKIE,
           'user-agent': 'vitest',
         },
       })
@@ -163,38 +151,20 @@ describe('proxy auth routing', () => {
     expect(response.cookies.get('NEXT_LOCALE')?.value).toBe('en')
   })
 
-  it('allows the default-locale reauth login route through without proxy-owned cookie cleanup', async () => {
-    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
-
+  it('keeps localized protected routes at the app auth boundary with a canonical callback header', async () => {
     const { proxy } = await import('./proxy')
     const response = await proxy(
-      new NextRequest(
-        'http://localhost:3000/en/login?reauth=1&callbackUrl=%2Fworkspace%2Fws-1',
-        {
-          headers: {
-            cookie: PLAIN_SESSION_COOKIE,
-            'user-agent': 'vitest',
-          },
-        }
-      )
+      new NextRequest('http://localhost:3000/es/workspace/ws-1/dashboard?layoutId=layout-1', {
+        headers: {
+          'user-agent': 'vitest',
+        },
+      })
     )
 
     expect(response.status).toBe(200)
     expect(response.headers.get('location')).toBeNull()
-    expect(response.cookies.get('NEXT_LOCALE')?.value).toBe('en')
-    expect(response.cookies.get('better-auth.session_token')).toBeUndefined()
-    expect(response.cookies.get('__Secure-better-auth.session_token')).toBeUndefined()
-  })
-
-  it('preserves locale on the login route while keeping callback targets canonical', async () => {
-    const { proxy } = await import('./proxy')
-    const response = await proxy(
-      new NextRequest('http://localhost:3000/es/workspace/ws-1/dashboard?layoutId=layout-1')
-    )
-
-    expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toBe(
-      'http://localhost:3000/es/login?callbackUrl=%2Fworkspace%2Fws-1%2Fdashboard%3FlayoutId%3Dlayout-1'
+    expect(response.headers.get('x-middleware-request-x-tradinggoose-callback-path')).toBe(
+      '/workspace/ws-1/dashboard?layoutId=layout-1'
     )
     expect(response.cookies.get('NEXT_LOCALE')?.value).toBe('es')
   })
@@ -207,14 +177,13 @@ describe('proxy auth routing', () => {
     '/es/verify',
     '/es/sso',
     '/es/error',
-  ])('lets session-cookie auth route %s reach its page boundary', async (pathname) => {
+  ])('lets auth route %s reach its page boundary', async (pathname) => {
     process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
 
     const { proxy } = await import('./proxy')
     const response = await proxy(
       new NextRequest(`http://localhost:3000${pathname}`, {
         headers: {
-          cookie: PLAIN_SESSION_COOKIE,
           'user-agent': 'vitest',
         },
       })
@@ -260,14 +229,14 @@ describe('proxy auth routing', () => {
   it.each([
     ['root', 'http://localhost:3000/?source=nav', 'http://localhost:3000/es?source=nav'],
     ['workspace', 'http://localhost:3000/workspace', 'http://localhost:3000/es/workspace'],
-  ])('redirects session-cookie %s requests to the request locale', async (_, url, location) => {
+  ])('redirects locale-cookie %s requests to the request locale', async (_, url, location) => {
     process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
 
     const { proxy } = await import('./proxy')
     const response = await proxy(
       new NextRequest(url, {
         headers: {
-          cookie: `NEXT_LOCALE=es; ${PLAIN_SESSION_COOKIE}`,
+          cookie: 'NEXT_LOCALE=es',
           'user-agent': 'vitest',
         },
       })
@@ -278,14 +247,14 @@ describe('proxy auth routing', () => {
     expect(response.cookies.get('NEXT_LOCALE')?.value).toBe('es')
   })
 
-  it('keeps session-cookie prefixed requests canonical to the URL locale', async () => {
+  it('keeps locale-cookie prefixed requests canonical to the URL locale', async () => {
     process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
 
     const { proxy } = await import('./proxy')
     const response = await proxy(
       new NextRequest('http://localhost:3000/en/workspace', {
         headers: {
-          cookie: `NEXT_LOCALE=zh; ${PLAIN_SESSION_COOKIE}`,
+          cookie: 'NEXT_LOCALE=zh',
           'user-agent': 'vitest',
         },
       })
@@ -296,7 +265,7 @@ describe('proxy auth routing', () => {
     expect(response.cookies.get('NEXT_LOCALE')?.value).toBe('en')
   })
 
-  it('rewrites session-cookie POST protected requests with the canonical callback header', async () => {
+  it('rewrites POST protected requests with the canonical callback header', async () => {
     process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
 
     const { proxy } = await import('./proxy')
@@ -304,7 +273,7 @@ describe('proxy auth routing', () => {
       new NextRequest('http://localhost:3000/workspace/ws-1/dashboard?layoutId=layout-1', {
         method: 'POST',
         headers: {
-          cookie: `NEXT_LOCALE=es; ${PLAIN_SESSION_COOKIE}`,
+          cookie: 'NEXT_LOCALE=es',
           'user-agent': 'vitest',
         },
       })
@@ -333,7 +302,6 @@ describe('proxy auth routing', () => {
         'http://localhost:3000/es/api/workspaces/invitations/invitation-1?token=abc',
         {
           headers: {
-            cookie: PLAIN_SESSION_COOKIE,
             'user-agent': 'vitest',
           },
         }

--- a/apps/tradinggoose/proxy.ts
+++ b/apps/tradinggoose/proxy.ts
@@ -1,4 +1,3 @@
-import { getSessionCookie } from 'better-auth/cookies'
 import { type NextRequest, NextResponse } from 'next/server'
 import createMiddleware from 'next-intl/middleware'
 import { appendHomepageDiscoveryLinks } from '@/lib/discovery/link-headers'
@@ -123,17 +122,6 @@ function resolveRequestLocale(request: NextRequest): LocaleCode {
   )
 }
 
-function buildLoginRedirect(request: NextRequest, route: LocaleRoute, callback?: string) {
-  const { locale } = route
-  const loginUrl = new URL(localizeUrl(request.nextUrl.origin, locale, '/login'))
-
-  if (callback) {
-    loginUrl.searchParams.set('callbackUrl', callback)
-  }
-
-  return withLocaleCookie(NextResponse.redirect(loginUrl), locale)
-}
-
 function isProtectedAppPath(pathname: string): boolean {
   const { pathname: normalizedPathname } = resolveLocaleRoute(pathname)
 
@@ -147,10 +135,7 @@ function isProtectedAppPath(pathname: string): boolean {
 
 function buildProtectedRequestHeaders(request: NextRequest, route: LocaleRoute) {
   const requestHeaders = new Headers(request.headers)
-  requestHeaders.set(
-    CANONICAL_CALLBACK_PATH_HEADER,
-    `${route.pathname}${request.nextUrl.search}`
-  )
+  requestHeaders.set(CANONICAL_CALLBACK_PATH_HEADER, `${route.pathname}${request.nextUrl.search}`)
   return requestHeaders
 }
 
@@ -279,15 +264,10 @@ function handleSecurityFiltering(request: NextRequest): NextResponse | null {
 export async function proxy(request: NextRequest) {
   const url = request.nextUrl
   const initialRoute = resolveLocaleRoute(url.pathname)
-  const hasSessionCookie = Boolean(getSessionCookie(request))
   const route = resolveCanonicalLocaleRoute(request, initialRoute)
   const { locale, pathname: normalizedPathname } = route
 
   const isProtectedPath = isProtectedAppPath(url.pathname)
-
-  if (isProtectedPath && !hasSessionCookie) {
-    return buildLoginRedirect(request, route, `${route.pathname}${url.search}`)
-  }
 
   const protectedRequestHeaders = isProtectedPath
     ? buildProtectedRequestHeaders(request, route)

--- a/apps/tradinggoose/stores/index.ts
+++ b/apps/tradinggoose/stores/index.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { createLogger } from '@/lib/logs/console/logger'
+import { resetWorkspacePermissionsStore } from '@/hooks/use-workspace-permissions'
 import { useConsoleStore } from '@/stores/console/store'
 import { getCopilotStore, useCopilotStore } from '@/stores/copilot/store'
 import { useCustomToolsStore } from '@/stores/custom-tools/store'
@@ -72,6 +73,7 @@ export const resetAllStores = () => {
   useCustomToolsStore.getState().resetAll()
   useSkillsStore.getState().resetAll()
   useIndicatorsStore.getState().resetAll()
+  resetWorkspacePermissionsStore()
   // Variables store has no tracking to reset; registry hydrates
   useSubscriptionStore.getState().reset() // Reset subscription store
 }

--- a/apps/tradinggoose/stores/organization/store.ts
+++ b/apps/tradinggoose/stores/organization/store.ts
@@ -1,5 +1,5 @@
-import { createWithEqualityFn as create } from 'zustand/traditional'
 import { devtools } from 'zustand/middleware'
+import { createWithEqualityFn as create } from 'zustand/traditional'
 import { client } from '@/lib/auth-client'
 import { createLogger } from '@/lib/logs/console/logger'
 import { stripLocaleFromPathname } from '@/i18n/utils'
@@ -297,18 +297,8 @@ export const useOrganizationStore = create<OrganizationStore>()(
               if (permissionResponse.ok) {
                 const permissionData = await permissionResponse.json()
 
-                // Check if current user has admin permission
-                // Use userId if provided, otherwise fall back to checking isOwner from workspace data
-                let hasAdminAccess = false
+                const hasAdminAccess = permissionData.currentUserPermission === 'admin'
 
-                if (userId && permissionData.users) {
-                  const currentUserPermission = permissionData.users.find(
-                    (user: any) => user.id === userId || user.userId === userId
-                  )
-                  hasAdminAccess = currentUserPermission?.permissionType === 'admin'
-                }
-
-                // Also check if user is the workspace owner
                 const isOwner = workspace.isOwner || workspace.ownerId === userId
 
                 if (hasAdminAccess || isOwner) {


### PR DESCRIPTION
## Summary
- Move protected workspace/admin auth recovery out of proxy session-cookie checks and into session-aware app route/layout boundaries.
- Convert `/workspace` entry routing to server-side workspace resolution with callback and `redirect_workflow` support.
- Extract workspace bootstrap/create logic into a shared workspace service.
- Treat canonical workspace owners as admins across permission checks, workspace APIs, member management, and UI hooks.
- Scope workspace permission cache by active user and clear it during reauth cleanup.
- Add/update tests for proxy routing, reauth redirects, owner permissions, member removal guards, and permission hooks.

## Why
Proxy-level session-cookie checks were brittle for stale auth state, localized protected routes, and callback preservation. This change lets the app’s session-aware boundaries handle reauth while keeping canonical callback paths intact, and fixes owner/admin permission gaps when a workspace owner has no explicit permission row.

## Affected Areas
- [x] `apps/tradinggoose`
- [ ] `apps/docs`
- [ ] `packages/*`
- [x] Workflows / execution
- [ ] Realtime / sockets
- [ ] Market data / charting
- [ ] Dev tooling / CI / infra
- [ ] Documentation only
- [x] Other: Auth/proxy routing and workspace permissions

## Issue Links( if any )
N/A

## Validation
```bash
cd apps/tradinggoose
bun run test -- 'app/[locale]/workspace/page.test.tsx' 'app/[locale]/admin/layout.test.tsx' 'proxy.test.ts' 'app/api/workspaces/route.test.ts' 'app/api/workspaces/members/[id]/route.test.ts' 'hooks/use-workspace-permissions.test.tsx' 'hooks/use-user-permissions.test.tsx' 'lib/permissions/utils.test.ts'
# Result: 9 test files passed, 100 tests passed.
```

## Risk / Rollout Notes
Protected workspace/admin route behavior changed. Validate signed-out access, stale-session reauth, locale-prefixed routes, `/workspace?redirect_workflow=...`, workspace invites, member removal, and workspace settings in staging.

Backout plan: revert this PR to restore proxy cookie-based protected-route handling and previous workspace permission lookup/cache behavior.

## Config / Data Changes
- Env vars added or changed: None
- Database schema or migration impact: None
- External services or provider behavior changed: None; auth routing/session recovery behavior changes are internal to the app.

## Screenshots / Video
N/A; no visible UI layout changes.

## Checklist
- [x] I kept the change focused and reviewed my own diff
- [x] I validated the change locally and documented the results above
- [x] I updated docs, examples, or copy if behavior/user-facing flows changed
- [x] I called out any env, schema, provider, or rollout impact
- [x] I did not include secrets, tokens, or private credentials in this PR