### PR TITLE
fix(layout): stabilize dashboard and widget interactions

### DIFF
--- a/apps/tradinggoose/app/api/saved-entity-error-response.ts
+++ b/apps/tradinggoose/app/api/saved-entity-error-response.ts
@@ -1,7 +1,15 @@
 import { NextResponse } from 'next/server'
+import {
+  buildCopilotServerToolErrorResponse,
+  StructuredServerToolError,
+} from '@/lib/copilot/server-tool-errors'
 import { toSavedEntityTransportError } from '@/lib/yjs/server/apply-entity-state'
 
 export function createSavedEntityErrorResponse(error: unknown): NextResponse | null {
+  if (error instanceof StructuredServerToolError) {
+    const response = buildCopilotServerToolErrorResponse(undefined, error)
+    return NextResponse.json(response.body, { status: response.status })
+  }
   const transportError = toSavedEntityTransportError(error)
   return transportError
     ? NextResponse.json(transportError.responseBody(), { status: transportError.status })

--- a/apps/tradinggoose/app/api/workspaces/[id]/dashboard-layouts/[layoutId]/structure/route.test.ts
+++ b/apps/tradinggoose/app/api/workspaces/[id]/dashboard-layouts/[layoutId]/structure/route.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment node
+ */
+
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { POST } from './route'
+
+const mocks = vi.hoisted(() => ({
+  apply: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getSession: vi.fn().mockResolvedValue({ user: { id: 'user-1' } }),
+}))
+vi.mock('@/lib/yjs/server/snapshot-bridge', () => ({
+  applyDashboardStructureMutationInSocketServer: mocks.apply,
+}))
+vi.mock('@/app/api/saved-entity-error-response', () => ({
+  createSavedEntityErrorResponse: vi.fn(() => null),
+}))
+
+const invoke = (body: BodyInit) =>
+  POST(
+    new NextRequest(
+      'http://localhost/api/workspaces/workspace-1/dashboard-layouts/layout-1/structure',
+      { method: 'POST', body }
+    ),
+    { params: Promise.resolve({ id: 'workspace-1', layoutId: 'layout-1' }) }
+  )
+
+describe('dashboard structure route', () => {
+  beforeEach(() => mocks.apply.mockReset().mockResolvedValue(undefined))
+
+  it('rejects malformed JSON before crossing the realtime boundary', async () => {
+    const response = await invoke('{')
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Invalid JSON in request body' })
+    expect(mocks.apply).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['null', null, 204],
+    [
+      JSON.stringify({ type: 'resize', groupId: 'group-1', sizes: [40, 60] }),
+      { type: 'resize', groupId: 'group-1', sizes: [40, 60] },
+      204,
+    ],
+  ])('forwards valid JSON unchanged', async (body, mutation, status) => {
+    const response = await invoke(body)
+
+    expect(response.status).toBe(status)
+    expect(mocks.apply).toHaveBeenLastCalledWith({
+      entityId: 'layout-1',
+      workspaceId: 'workspace-1',
+      ownerUserId: 'user-1',
+      mutation,
+    })
+  })
+})

--- a/apps/tradinggoose/app/api/workspaces/[id]/dashboard-layouts/[layoutId]/structure/route.ts
+++ b/apps/tradinggoose/app/api/workspaces/[id]/dashboard-layouts/[layoutId]/structure/route.ts
@@ -1,0 +1,27 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { getSession } from '@/lib/auth'
+import { applyDashboardStructureMutationInSocketServer } from '@/lib/yjs/server/snapshot-bridge'
+import { createSavedEntityErrorResponse } from '@/app/api/saved-entity-error-response'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; layoutId: string }> }
+) {
+  const userId = (await getSession(request.headers))?.user?.id
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { id: workspaceId, layoutId } = await params
+  try {
+    await applyDashboardStructureMutationInSocketServer({
+      entityId: layoutId,
+      workspaceId,
+      ownerUserId: userId,
+      mutation: await request.json().catch(() => null),
+    })
+    return new NextResponse(null, { status: 204 })
+  } catch (error) {
+    const response = createSavedEntityErrorResponse(error)
+    if (response) return response
+    throw error
+  }
+}

--- a/apps/tradinggoose/app/api/workspaces/[id]/dashboard-layouts/[layoutId]/structure/route.ts
+++ b/apps/tradinggoose/app/api/workspaces/[id]/dashboard-layouts/[layoutId]/structure/route.ts
@@ -10,13 +10,20 @@ export async function POST(
   const userId = (await getSession(request.headers))?.user?.id
   if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
+  let mutation: unknown
+  try {
+    mutation = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON in request body' }, { status: 400 })
+  }
+
   const { id: workspaceId, layoutId } = await params
   try {
     await applyDashboardStructureMutationInSocketServer({
       entityId: layoutId,
       workspaceId,
       ownerUserId: userId,
-      mutation: await request.json().catch(() => null),
+      mutation,
     })
     return new NextResponse(null, { status: 204 })
   } catch (error) {

--- a/apps/tradinggoose/app/workspace/[workspaceId]/dashboard/actions.ts
+++ b/apps/tradinggoose/app/workspace/[workspaceId]/dashboard/actions.ts
@@ -10,8 +10,6 @@ import {
 } from '@/lib/dashboard-layouts/operations'
 import { getCachedWorkspaceAccess } from '@/lib/permissions/utils'
 import { renameSavedEntityIdentity } from '@/lib/saved-entities/identity'
-import { applyDashboardStructureMutationInSocketServer } from '@/lib/yjs/server/snapshot-bridge'
-import type { DashboardLayoutStructureMutation } from '@/widgets/layout-document'
 
 export type DashboardLayoutListMutation =
   | { type: 'create' }
@@ -53,17 +51,4 @@ export async function mutateDashboardLayoutListAction(
       name: mutation.name,
     })
   return listDashboardLayouts(scope)
-}
-
-export async function mutateDashboardLayoutStructureAction(
-  workspaceId: string,
-  layoutId: string,
-  mutation: DashboardLayoutStructureMutation
-) {
-  const scope = await requireDashboardLayoutScope(workspaceId)
-  return applyDashboardStructureMutationInSocketServer({
-    entityId: layoutId,
-    ...scope,
-    mutation,
-  })
 }

--- a/apps/tradinggoose/app/workspace/[workspaceId]/dashboard/dashboard-client.tsx
+++ b/apps/tradinggoose/app/workspace/[workspaceId]/dashboard/dashboard-client.tsx
@@ -619,14 +619,6 @@ export function DashboardClient({
     <>
       <GlobalNavbarHeader left={headerLeftContent} center={headerCenterContent} />
       <div className='relative h-full min-h-0 w-full min-w-0 overflow-hidden'>
-        {layoutDocument.hasResizePersistenceError && (
-          <div
-            className='absolute top-3 right-3 z-10 rounded-md bg-destructive px-3 py-2 text-destructive-foreground text-sm shadow-sm'
-            role='alert'
-          >
-            {t('layoutState.resizePersistenceError')}
-          </div>
-        )}
         {selectedLayoutId && rawTree && layoutDocument.doc ? (
           <DashboardNode
             key={selectedLayoutId}

--- a/apps/tradinggoose/app/workspace/[workspaceId]/dashboard/use-dashboard-layout-doc.test.tsx
+++ b/apps/tradinggoose/app/workspace/[workspaceId]/dashboard/use-dashboard-layout-doc.test.tsx
@@ -187,7 +187,7 @@ describe('useDashboardLayoutDocument live fields', () => {
     expect(latest.resizeReconcileVersion).toBe(1)
 
     await act(() => latest.mutateStructure({ type: 'resize', groupId: 'group-1', sizes: [45, 55] }))
-    expect(latest.hasResizePersistenceError).toBe(false)
+    expect(latest.resizeReconcileVersion).toBe(0)
   })
 
   it('keeps list mutations projected until a matching or newer Yjs revision arrives', async () => {

--- a/apps/tradinggoose/app/workspace/[workspaceId]/dashboard/use-dashboard-layout-doc.test.tsx
+++ b/apps/tradinggoose/app/workspace/[workspaceId]/dashboard/use-dashboard-layout-doc.test.tsx
@@ -5,12 +5,9 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import * as Y from 'yjs'
-import { seedDashboardLayoutSession } from '@/lib/yjs/dashboard-layout-session'
 import type { DashboardLayoutTopologyNode } from '@/widgets/layout-document'
 import { useDashboardLayoutDocument, useDashboardLayoutList } from './use-dashboard-layout-doc'
 
-let mockLayoutDoc: Y.Doc | null = null
 let mockEntityList = {
   members: [] as Array<{
     entityId: string
@@ -23,7 +20,7 @@ let mockEntityList = {
   error: null as string | null,
 }
 const mockUseSavedEntityYjsSession = vi.hoisted(() => vi.fn())
-const mockMutateStructure = vi.hoisted(() => vi.fn())
+const mockFetch = vi.hoisted(() => vi.fn())
 const mockMutateList = vi.hoisted(() => vi.fn())
 
 const topology: DashboardLayoutTopologyNode = {
@@ -55,8 +52,9 @@ vi.mock('@/lib/yjs/use-entity-fields', () => ({
 
 vi.mock('@/app/workspace/[workspaceId]/dashboard/actions', () => ({
   mutateDashboardLayoutListAction: mockMutateList,
-  mutateDashboardLayoutStructureAction: mockMutateStructure,
 }))
+
+vi.stubGlobal('fetch', mockFetch)
 
 describe('useDashboardLayoutDocument live fields', () => {
   let container: HTMLDivElement
@@ -108,12 +106,13 @@ describe('useDashboardLayoutDocument live fields', () => {
   }
 
   beforeEach(() => {
-    mockMutateStructure.mockReset()
+    mockFetch.mockReset()
+    mockFetch.mockResolvedValue({ ok: true })
     mockMutateList.mockReset()
     mockEntityList = { members: [], hasLiveSnapshot: false, isLoading: true, error: null }
     mockUseSavedEntityYjsSession.mockClear()
     mockUseSavedEntityYjsSession.mockImplementation(() => ({
-      doc: mockLayoutDoc,
+      doc: null,
       isLoading: false,
       error: null,
     }))
@@ -124,8 +123,6 @@ describe('useDashboardLayoutDocument live fields', () => {
 
   afterEach(() => {
     act(() => root.unmount())
-    mockLayoutDoc?.destroy()
-    mockLayoutDoc = null
     container.remove()
   })
 
@@ -150,66 +147,46 @@ describe('useDashboardLayoutDocument live fields', () => {
   })
 
   it('isolates departed layout queues and recovers from resize failures', async () => {
-    mockLayoutDoc = new Y.Doc()
-    seedDashboardLayoutSession(mockLayoutDoc, { layout: topology })
+    const resize = { type: 'resize' as const, groupId: 'group-1', sizes: [35, 65] }
+    const split = {
+      type: 'split' as const,
+      panelId: 'panel-chart',
+      direction: 'horizontal' as const,
+    }
+    const replace = {
+      type: 'replace' as const,
+      panelId: 'panel-chart',
+      widgetKey: 'watchlist' as const,
+    }
     let rejectDepartedResize!: (error: Error) => void
-    mockMutateStructure.mockImplementationOnce(
-      () => new Promise<void>((_resolve, reject) => (rejectDepartedResize = reject))
+    mockFetch.mockImplementationOnce(
+      () => new Promise((_resolve, reject) => (rejectDepartedResize = reject))
     )
     act(() => root.render(<Capture workspaceId='workspace-1' layoutId='layout-1' />))
-    const departedResize = latest.mutateStructure({
-      type: 'resize',
-      groupId: 'group-1',
-      sizes: [35, 65],
-    })
+    const departedResize = latest.mutateStructure(resize)
     const departedFailure = expect(departedResize).rejects.toThrow('departed resize failed')
-    const departedSplit = latest.mutateStructure({
-      type: 'split',
-      panelId: 'panel-chart',
-      direction: 'horizontal',
-    })
+    const departedSplit = latest.mutateStructure(split)
     act(() => root.render(<Capture workspaceId='workspace-2' layoutId='layout-2' />))
-    const replacement = latest.mutateStructure({
-      type: 'replace',
-      panelId: 'panel-chart',
-      widgetKey: 'watchlist',
-    })
-    await act(async () => Promise.resolve())
-    expect(mockMutateStructure).toHaveBeenCalledTimes(2)
-    expect(mockMutateStructure).toHaveBeenNthCalledWith(1, 'workspace-1', 'layout-1', {
-      type: 'resize',
-      groupId: 'group-1',
-      sizes: [35, 65],
-    })
-    expect(mockMutateStructure).toHaveBeenNthCalledWith(2, 'workspace-2', 'layout-2', {
-      type: 'replace',
-      panelId: 'panel-chart',
-      widgetKey: 'watchlist',
-    })
-    await replacement
+    await latest.mutateStructure(replace)
+    expect(mockFetch.mock.calls.map(([url, init]) => [url, JSON.parse(init.body)])).toEqual([
+      ['/api/workspaces/workspace-1/dashboard-layouts/layout-1/structure', resize],
+      ['/api/workspaces/workspace-2/dashboard-layouts/layout-2/structure', replace],
+    ])
 
     rejectDepartedResize(new Error('departed resize failed'))
     await departedFailure
-    await vi.waitFor(() => expect(mockMutateStructure).toHaveBeenCalledTimes(3))
-    expect(mockMutateStructure).toHaveBeenLastCalledWith('workspace-1', 'layout-1', {
-      type: 'split',
-      panelId: 'panel-chart',
-      direction: 'horizontal',
-    })
     await departedSplit
+    expect(JSON.parse(mockFetch.mock.calls[2][1].body)).toEqual(split)
 
-    mockMutateStructure.mockRejectedValueOnce(new Error('resize failed'))
-    await act(async () => {
-      await expect(
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 409 })
+    await act(async () =>
+      expect(
         latest.mutateStructure({ type: 'resize', groupId: 'group-1', sizes: [40, 60] })
-      ).rejects.toThrow('resize failed')
-    })
+      ).rejects.toThrow('Failed to update dashboard layout (409)')
+    )
     expect(latest.resizeReconcileVersion).toBe(1)
-    expect(latest.hasResizePersistenceError).toBe(true)
 
-    await act(async () => {
-      await latest.mutateStructure({ type: 'resize', groupId: 'group-1', sizes: [45, 55] })
-    })
+    await act(() => latest.mutateStructure({ type: 'resize', groupId: 'group-1', sizes: [45, 55] }))
     expect(latest.hasResizePersistenceError).toBe(false)
   })
 

--- a/apps/tradinggoose/app/workspace/[workspaceId]/dashboard/use-dashboard-layout-doc.ts
+++ b/apps/tradinggoose/app/workspace/[workspaceId]/dashboard/use-dashboard-layout-doc.ts
@@ -12,7 +12,6 @@ import { useYjsSubscription } from '@/lib/yjs/use-yjs-subscription'
 import {
   type DashboardLayoutListMutation,
   mutateDashboardLayoutListAction,
-  mutateDashboardLayoutStructureAction,
 } from '@/app/workspace/[workspaceId]/dashboard/actions'
 import {
   type DashboardLayoutStructureMutation,
@@ -162,7 +161,17 @@ export function useDashboardLayoutDocument(input: {
     (mutation: DashboardLayoutStructureMutation) => {
       const commit = async () => {
         if (!input.workspaceId || !input.layoutId) return
-        await mutateDashboardLayoutStructureAction(input.workspaceId, input.layoutId, mutation)
+        const response = await fetch(
+          `/api/workspaces/${encodeURIComponent(input.workspaceId)}/dashboard-layouts/${encodeURIComponent(input.layoutId)}/structure`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(mutation),
+          }
+        )
+        if (!response.ok) {
+          throw new Error(`Failed to update dashboard layout (${response.status})`)
+        }
       }
       const next = mutationState.queue.then(commit, commit)
       mutationState.queue = next.catch(() => undefined)

--- a/apps/tradinggoose/app/workspace/[workspaceId]/dashboard/use-dashboard-layout-doc.ts
+++ b/apps/tradinggoose/app/workspace/[workspaceId]/dashboard/use-dashboard-layout-doc.ts
@@ -155,7 +155,6 @@ export function useDashboardLayoutDocument(input: {
     [input.workspaceId, input.layoutId]
   )
   const [resizeReconcileVersion, setResizeReconcileVersion] = useState(0)
-  const hasResizePersistenceError = resizeReconcileVersion > 0
 
   const mutateStructure = useCallback(
     (mutation: DashboardLayoutStructureMutation) => {
@@ -203,7 +202,6 @@ export function useDashboardLayoutDocument(input: {
     isLoading,
     error,
     resizeReconcileVersion,
-    hasResizePersistenceError,
     mutateStructure,
   }
 }

--- a/apps/tradinggoose/i18n/messages/en.json
+++ b/apps/tradinggoose/i18n/messages/en.json
@@ -995,8 +995,7 @@
       "layoutState": {
         "loading": "Loading dashboard layout...",
         "empty": "No dashboard layout is available.",
-        "error": "The dashboard layout could not be loaded.",
-        "resizePersistenceError": "The resize was not saved. The previous layout was restored."
+        "error": "The dashboard layout could not be loaded."
       },
       "pages": {
         "records": "Records",

--- a/apps/tradinggoose/i18n/messages/es.json
+++ b/apps/tradinggoose/i18n/messages/es.json
@@ -995,8 +995,7 @@
       "layoutState": {
         "loading": "Cargando el diseño del panel...",
         "empty": "No hay ningún diseño de panel disponible.",
-        "error": "No se pudo cargar el diseño del panel.",
-        "resizePersistenceError": "No se guardó el cambio de tamaño. Se restauró el diseño anterior."
+        "error": "No se pudo cargar el diseño del panel."
       },
       "pages": {
         "records": "Registros",

--- a/apps/tradinggoose/i18n/messages/zh.json
+++ b/apps/tradinggoose/i18n/messages/zh.json
@@ -982,8 +982,7 @@
       "layoutState": {
         "loading": "正在加载仪表盘布局...",
         "empty": "没有可用的仪表盘布局。",
-        "error": "无法加载仪表盘布局。",
-        "resizePersistenceError": "调整大小未保存，已恢复之前的布局。"
+        "error": "无法加载仪表盘布局。"
       },
       "pages": {
         "records": "记录",

--- a/apps/tradinggoose/lib/yjs/server/apply-entity-state.test.ts
+++ b/apps/tradinggoose/lib/yjs/server/apply-entity-state.test.ts
@@ -4,7 +4,6 @@
 
 import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 import * as Y from 'yjs'
-import { StructuredServerToolError } from '@/lib/copilot/server-tool-errors'
 import { WatchlistDocumentError } from '@/lib/watchlists/validation'
 import {
   getDashboardWidgetMap,
@@ -108,12 +107,9 @@ vi.mock('@/lib/yjs/server/mutation-idempotency', () => ({
   beginRealtimeMutationTransaction: mockBeginRealtimeMutation,
 }))
 
-const {
-  applySavedEntityState,
-  saveDashboardYjsDocsToDb,
-  saveSavedEntityYjsDocToDb,
-  toSavedEntityTransportError,
-} = await import('./apply-entity-state')
+const { applySavedEntityState, saveDashboardYjsDocsToDb, saveSavedEntityYjsDocToDb } = await import(
+  './apply-entity-state'
+)
 const { getEntityFields, getFieldsMap, seedEntitySession, updateWatchlistItems } = await import(
   '@/lib/yjs/entity-session'
 )
@@ -467,6 +463,7 @@ describe('applySavedEntityState', () => {
   })
 
   it.each([
+    [new MockSocketServerBridgeError(403, 'Forbidden'), 403, false],
     [new MockSocketServerBridgeError(410, 'Review target expired'), 410, false],
     [new TypeError('fetch failed'), 503, true],
   ])(
@@ -485,19 +482,4 @@ describe('applySavedEntityState', () => {
       expect(events).toEqual([])
     }
   )
-
-  it('preserves structured bridge status, code, and retryability', async () => {
-    expect(
-      toSavedEntityTransportError(
-        new StructuredServerToolError({
-          status: 409,
-          body: { error: 'Review is stale', code: 'stale_server_tool_review', retryable: true },
-        })
-      )
-    ).toMatchObject({
-      status: 409,
-      code: 'stale_server_tool_review',
-      retryable: true,
-    })
-  })
 })

--- a/apps/tradinggoose/lib/yjs/server/apply-entity-state.ts
+++ b/apps/tradinggoose/lib/yjs/server/apply-entity-state.ts
@@ -55,15 +55,13 @@ import { DashboardLayoutValidationError } from '@/widgets/layout-document'
 
 export function toSavedEntityTransportError(error: unknown): SavedEntityPersistenceError | null {
   if (error instanceof SavedEntityPersistenceError) return error
-  if (error instanceof StructuredServerToolError) {
-    return new SavedEntityPersistenceError(error.status, error.message, error.code, error.retryable)
-  }
   if (!(error instanceof SocketServerBridgeError)) return null
   if (
-    error.status === 400 ||
-    error.status === 404 ||
-    error.status === 409 ||
-    error.status === 410
+    error.status >= 400 &&
+    error.status < 500 &&
+    error.status !== 408 &&
+    error.status !== 425 &&
+    error.status !== 429
   ) {
     return new SavedEntityPersistenceError(error.status, error.message)
   }

--- a/apps/tradinggoose/lib/yjs/server/entity-loaders.test.ts
+++ b/apps/tradinggoose/lib/yjs/server/entity-loaders.test.ts
@@ -4,75 +4,72 @@ const mocks = vi.hoisted(() => ({
   select: vi.fn(),
   fenced: vi.fn(),
   refresh: vi.fn(),
+  members: [] as Array<Record<string, unknown>>,
+  events: [] as string[],
 }))
 
-vi.mock('@tradinggoose/db', () => ({
-  db: { select: mocks.select },
-}))
-
+vi.mock('@tradinggoose/db', () => ({ db: { select: mocks.select } }))
 vi.mock('@/lib/yjs/server/snapshot-bridge', () => ({
   runYjsDrainFencedTransaction: mocks.fenced,
   refreshEntityListSession: mocks.refresh,
 }))
 
-import { deleteSavedEntity, SAVED_ENTITY_LIST_LOCK_KINDS } from '@/lib/yjs/server/entity-loaders'
+import { deleteSavedEntity } from '@/lib/yjs/server/entity-loaders'
 
-function selectRows(rows: unknown[]) {
-  return {
-    from: vi.fn(() => ({
-      where: vi.fn(() => ({
-        limit: vi.fn().mockResolvedValue(rows),
-      })),
-    })),
-  }
-}
+const protectedKinds = ['skill', 'custom_tool', 'indicator', 'mcp_server', 'watchlist'] as const
+const query = (read: () => unknown[]) => ({
+  from: () => ({ where: () => ({ limit: read, orderBy: read }) }),
+})
+const member = (id: string) => ({
+  id,
+  settings: { showLogo: true, showTicker: true, showDescription: true },
+})
+const mutation = { where: () => ({ returning: async () => [{}] }) }
+const protectedScenarios = protectedKinds.map(
+  (entityKind) => [entityKind, [`${entityKind}-1`], 409, ['lock', 'read']] as const
+)
 
 describe('deleteSavedEntity', () => {
-  beforeEach(() => vi.clearAllMocks())
-
-  it('uses one shared lock-kind set for workspace entity lists', () => {
-    expect(SAVED_ENTITY_LIST_LOCK_KINDS).toEqual(expect.arrayContaining(['workflow', 'watchlist']))
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.members = []
+    mocks.events = []
+    mocks.select.mockReturnValue(query(() => [{ workspaceId: 'workspace-1' }]))
+    mocks.fenced.mockImplementation((_target, mutate) =>
+      mutate({
+        execute: async () => void mocks.events.push('lock'),
+        select: () =>
+          query(() => {
+            mocks.events.push('read')
+            return mocks.members
+          }),
+        delete: () => mutation,
+        update: () => ({ set: () => mutation }),
+      })
+    )
+    mocks.refresh.mockImplementation(async () => void mocks.events.push('refresh'))
   })
 
-  it.each(['skill', 'watchlist'] as const)(
-    'does not fence %s outside the workspace',
-    async (entityKind) => {
-      const entityId = `${entityKind}-1`
-      mocks.select.mockReturnValue(selectRows([{ workspaceId: 'workspace-2' }]))
-
-      await expect(deleteSavedEntity(entityKind, entityId, 'workspace-1')).resolves.toBe(false)
-      expect(mocks.fenced).not.toHaveBeenCalled()
+  it.each([
+    ...protectedScenarios,
+    ['skill', ['skill-1', 'remaining'], true, ['lock', 'read', 'refresh']],
+    ['skill', ['remaining'], false, ['lock', 'read']],
+    ['knowledge_base', [], true, ['lock', 'refresh']],
+  ] as const)(
+    'enforces the locked %s deletion scenario',
+    async (entityKind, ids, expected, events) => {
+      mocks.members = ids.map(member)
+      const deletion = deleteSavedEntity(entityKind, `${entityKind}-1`, 'workspace-1')
+      if (expected === 409)
+        await expect(deletion).rejects.toMatchObject({ status: 409, retryable: false })
+      else await expect(deletion).resolves.toBe(expected)
+      expect(mocks.events).toEqual(events)
     }
   )
 
-  it.each([
-    ['skill', 'delete'],
-    ['knowledge_base', 'update'],
-    ['watchlist', 'delete'],
-  ] as const)('fences, locks, writes, and refreshes %s in order', async (entityKind, write) => {
-    const entityId = `${entityKind}-1`
-    const events: string[] = []
-    mocks.select.mockReturnValue(selectRows([{ workspaceId: 'workspace-1' }]))
-    const query = {
-      where: () => ({
-        returning: async () => {
-          events.push(write)
-          return [{ id: entityId }]
-        },
-      }),
-    }
-    mocks.fenced.mockImplementation(async (_target, mutate) => {
-      events.push('fence')
-      return mutate({
-        execute: async () => events.push('lock'),
-        delete: () => query,
-        update: () => ({ set: () => query }),
-      })
-    })
-    mocks.refresh.mockImplementation(async () => void events.push('refresh'))
-
-    await expect(deleteSavedEntity(entityKind, entityId, 'workspace-1')).resolves.toBe(true)
-    expect(mocks.fenced).toHaveBeenCalledWith({ sessionIds: [entityId] }, expect.any(Function))
-    expect(events).toEqual(['fence', 'lock', write, 'refresh'])
+  it('does not fence a target outside the workspace', async () => {
+    mocks.select.mockReturnValue(query(() => [{ workspaceId: 'workspace-2' }]))
+    await expect(deleteSavedEntity('skill', 'skill-1', 'workspace-1')).resolves.toBe(false)
+    expect(mocks.fenced).not.toHaveBeenCalled()
   })
 })

--- a/apps/tradinggoose/lib/yjs/server/entity-loaders.ts
+++ b/apps/tradinggoose/lib/yjs/server/entity-loaders.ts
@@ -22,6 +22,7 @@ import {
 } from '@/lib/watchlists/document'
 import {
   type SavedEntityKind,
+  SavedEntityPersistenceError,
   type SavedEntityRow,
   savedEntityRowToContent,
 } from '@/lib/yjs/entity-state'
@@ -127,14 +128,21 @@ export async function deleteSavedEntity(
 
   const deleted = await runYjsDrainFencedTransaction({ sessionIds: [entityId] }, async (tx) => {
     await lockSavedEntityList(tx, entityKind, workspaceId)
-    let deleted: boolean
+    if (entityKind !== 'knowledge_base') {
+      const members = await readEntityListMembersFromDb(entityKind, workspaceId, null, tx)
+      if (!members.some((member) => member.id === entityId)) return false
+      if (members.length === 1)
+        throw new SavedEntityPersistenceError(409, 'Cannot delete the final saved item')
+    }
+
     if (entityKind === 'watchlist') {
       const [row] = await tx
         .delete(watchlistTable)
         .where(rootWatchlistCondition(workspaceId, entityId))
         .returning({ id: watchlistTable.id })
-      deleted = Boolean(row)
-    } else if (entityKind === 'knowledge_base') {
+      return Boolean(row)
+    }
+    if (entityKind === 'knowledge_base') {
       const now = new Date()
       const [row] = await tx
         .update(knowledgeBase)
@@ -146,18 +154,16 @@ export async function deleteSavedEntity(
           ])
         )
         .returning({ id: knowledgeBase.id })
-      deleted = Boolean(row)
-    } else {
-      const { table } = ENTITY_TABLES[entityKind]
-      const [row] = await tx
-        .delete(table)
-        .where(
-          entityCondition(entityKind, [eq(table.id, entityId), eq(table.workspaceId, workspaceId)])
-        )
-        .returning({ id: table.id })
-      deleted = Boolean(row)
+      return Boolean(row)
     }
-    return deleted
+    const { table } = ENTITY_TABLES[entityKind]
+    const [row] = await tx
+      .delete(table)
+      .where(
+        entityCondition(entityKind, [eq(table.id, entityId), eq(table.workspaceId, workspaceId)])
+      )
+      .returning({ id: table.id })
+    return Boolean(row)
   })
   if (deleted) await refreshEntityListSession(entityKind, workspaceId)
   return deleted

--- a/apps/tradinggoose/lib/yjs/server/snapshot-bridge.test.ts
+++ b/apps/tradinggoose/lib/yjs/server/snapshot-bridge.test.ts
@@ -145,17 +145,28 @@ describe('applyEntityStateInSocketServer', () => {
       workspaceId: 'workspace-1',
       fields: persistedFields,
     })
+  })
 
+  it('preserves structured dashboard mutation errors', async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(
-        JSON.stringify({ error: 'Invalid widget target', code: 'invalid_widget_target' }),
+        JSON.stringify({
+          error: 'Invalid',
+          code: 'invalid_dashboard_layout_edit',
+          retryable: true,
+        }),
         { status: 422 }
       )
     )
-    await expect(applyEntityState({})).rejects.toMatchObject({
-      status: 422,
-      code: 'invalid_widget_target',
-    })
+    const { applyDashboardStructureMutationInSocketServer } = await import('./snapshot-bridge')
+    await expect(
+      applyDashboardStructureMutationInSocketServer({
+        entityId: 'layout-1',
+        workspaceId: 'workspace-1',
+        ownerUserId: 'user-1',
+        mutation: null,
+      })
+    ).rejects.toMatchObject({ status: 422, code: 'invalid_dashboard_layout_edit', retryable: true })
   })
 
   it.each([

--- a/apps/tradinggoose/lib/yjs/server/snapshot-bridge.ts
+++ b/apps/tradinggoose/lib/yjs/server/snapshot-bridge.ts
@@ -25,7 +25,6 @@ import {
 import type { WorkflowSnapshot } from '@/lib/yjs/workflow-session'
 import {
   type DashboardLayoutProjectionContent,
-  type DashboardLayoutStructureMutation,
   normalizeDashboardLayoutProjection,
 } from '@/widgets/layout-document'
 
@@ -334,7 +333,7 @@ export function applyDashboardStructureMutationInSocketServer(input: {
   entityId: string
   workspaceId: string
   ownerUserId: string
-  mutation: DashboardLayoutStructureMutation
+  mutation: unknown
 }): Promise<void> {
   return postJsonToSocketServer(
     `/internal/yjs/dashboard-layouts/${encodeURIComponent(input.entityId)}/edit`,

--- a/apps/tradinggoose/lib/yjs/server/snapshot-bridge.ts
+++ b/apps/tradinggoose/lib/yjs/server/snapshot-bridge.ts
@@ -347,7 +347,9 @@ export function applyDashboardStructureMutationInSocketServer(input: {
     {
       responseDeadlineMs: DASHBOARD_RESPONSE_DEADLINE_MS,
     }
-  ).then(() => undefined)
+  )
+    .then(() => undefined)
+    .catch(rethrowStructuredBridgeError)
 }
 
 /**

--- a/apps/tradinggoose/socket-server/index.ts
+++ b/apps/tradinggoose/socket-server/index.ts
@@ -24,7 +24,7 @@ const logger = createLogger('CollaborativeSocketServer')
 const httpServer = createServer()
 
 // Yjs WebSocket server - noServer mode, upgrade handled manually
-const yjsWss = new WebSocketServer({ noServer: true })
+const yjsWss = new WebSocketServer({ noServer: true, maxPayload: 1024 * 1024 })
 let isShuttingDown = false
 const SHUTDOWN_DRAIN_RETRY_MS = 1_000
 

--- a/apps/tradinggoose/socket-server/yjs/upstream-utils.test.ts
+++ b/apps/tradinggoose/socket-server/yjs/upstream-utils.test.ts
@@ -148,6 +148,35 @@ describe('shared document lifecycle', () => {
     descriptor: buildSavedEntityDescriptor('watchlist', sessionId, null),
   })
 
+  it('hands pre-admission messages to the canonical connection listener', async () => {
+    const source = new Y.Doc()
+    source.getMap('fields').set('received', true)
+    const socket = new TestSocket()
+    const doc = await acquireDocument(
+      'pre-admission-message',
+      { workspaceId: 'workspace-1', initialize: () => undefined },
+      (shared) => {
+        setupWSConnection(socket as unknown as WebSocket, {} as IncomingMessage, {
+          doc: shared,
+          userId: 'user-1',
+          accessMode: 'write',
+          descriptor: buildSavedEntityDescriptor(
+            'watchlist',
+            'pre-admission-message',
+            'workspace-1'
+          ),
+          initialMessages: [createSyncUpdateMessage(Y.encodeStateAsUpdate(source))],
+        })
+        return shared
+      }
+    )
+
+    await vi.waitFor(() => expect(doc.getMap('fields').get('received')).toBe(true))
+    expect(socket.listenerCount('message')).toBe(1)
+    socket.emit('close')
+    source.destroy()
+  })
+
   it('serves reconnect bursts from their reserved admission connections', async () => {
     const capacity = 30
     const allOuterConnections = deferred()

--- a/apps/tradinggoose/socket-server/yjs/upstream-utils.ts
+++ b/apps/tradinggoose/socket-server/yjs/upstream-utils.ts
@@ -632,6 +632,7 @@ export function setupWSConnection(
     userId: string
     accessMode: ReviewAccessMode
     descriptor: ReviewTargetDescriptor
+    initialMessages?: readonly Uint8Array[]
     persist?: (doc: Y.Doc, requestId: string, identityName?: string) => Promise<void>
     onDocumentUpdate?: DocumentPersistenceHandler
     onDocumentUpdateDebounceMs?: number
@@ -642,6 +643,7 @@ export function setupWSConnection(
     userId,
     accessMode,
     descriptor,
+    initialMessages,
     persist,
     onDocumentUpdate,
     onDocumentUpdateDebounceMs,
@@ -734,6 +736,8 @@ export function setupWSConnection(
     )
     send(doc, conn, encoding.toUint8Array(awarenessEncoder))
   }
+
+  initialMessages?.forEach((message) => handleMessage(conn, doc, message))
 }
 
 export async function discardDocument(candidate: Y.Doc): Promise<void> {

--- a/apps/tradinggoose/socket-server/yjs/ws-handler.test.ts
+++ b/apps/tradinggoose/socket-server/yjs/ws-handler.test.ts
@@ -5,7 +5,7 @@
 import { EventEmitter } from 'node:events'
 import type { IncomingMessage } from 'http'
 import type { Duplex } from 'stream'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { WebSocketServer } from 'ws'
 import * as Y from 'yjs'
 import {
@@ -13,13 +13,6 @@ import {
   YJS_CLOSE_CODE_RETRY_REQUIRED,
 } from '@/lib/copilot/review-sessions/types'
 import type { DocumentAdmission } from './upstream-utils'
-
-const mockLogger = {
-  debug: vi.fn(),
-  info: vi.fn(),
-  warn: vi.fn(),
-  error: vi.fn(),
-}
 
 const mockAuthenticateYjsConnection = vi.fn()
 const mockInitializeSavedReviewTargetDocument = vi.fn()
@@ -32,8 +25,6 @@ const mockPersistStagedDocuments = vi.fn()
 const mockSaveSavedEntityYjsDocToDb = vi.fn()
 const mockRefreshActiveEntityListSession = vi.fn()
 const mockUpgradedSocketClose = vi.fn()
-const mockRawSocketPause = vi.fn()
-const mockRawSocketResume = vi.fn()
 
 class MockYjsAuthError extends Error {
   constructor(
@@ -87,12 +78,7 @@ function createYjsRequest(
 }
 
 function createSocket() {
-  return {
-    write: vi.fn(),
-    destroy: vi.fn(),
-    pause: mockRawSocketPause,
-    resume: mockRawSocketResume,
-  } as unknown as Duplex
+  return {} as Duplex
 }
 
 function createWebSocketServer() {
@@ -101,9 +87,9 @@ function createWebSocketServer() {
   }
 
   wss.handleUpgrade = vi.fn((request, socket, head, callback) => {
-    callback({
-      close: mockUpgradedSocketClose,
-    } as any)
+    const ws = Object.assign(new EventEmitter(), { close: mockUpgradedSocketClose })
+    callback(ws as any)
+    ws.emit('message', new Uint8Array([0, 0]))
   })
 
   return wss
@@ -208,11 +194,9 @@ beforeEach(() => {
   mockSaveSavedEntityYjsDocToDb.mockReset()
   mockRefreshActiveEntityListSession.mockReset().mockResolvedValue(undefined)
   mockUpgradedSocketClose.mockReset()
-  mockRawSocketPause.mockReset()
-  mockRawSocketResume.mockReset()
 
   vi.doMock('@/lib/logs/console/logger', () => ({
-    createLogger: vi.fn(() => mockLogger),
+    createLogger: vi.fn(() => ({ info: vi.fn(), error: vi.fn() })),
   }))
 
   vi.doMock('./auth', () => ({
@@ -248,10 +232,6 @@ beforeEach(() => {
   }))
 })
 
-afterEach(() => {
-  vi.clearAllMocks()
-})
-
 describe('handleYjsUpgrade', () => {
   it('rejects an in-flight upgrade when shutdown begins during authentication', async () => {
     const sessionId = 'workflow-shutdown-race'
@@ -268,6 +248,7 @@ describe('handleYjsUpgrade', () => {
 
     const { handleYjsUpgrade } = await loadModule()
     handleYjsUpgrade(wss, request, socket, Buffer.alloc(0), () => acceptsConnections)
+    expect(wss.handleUpgrade).not.toHaveBeenCalled()
     acceptsConnections = false
     resolveAuthentication({
       userId: 'user-1',
@@ -303,8 +284,7 @@ describe('handleYjsUpgrade', () => {
     handleYjsUpgrade(wss, request, socket, Buffer.alloc(0))
     await new Promise((resolve) => setImmediate(resolve))
 
-    expect(mockRawSocketPause).toHaveBeenCalledOnce()
-    expect(mockRawSocketResume).not.toHaveBeenCalled()
+    expect(wss.handleUpgrade).toHaveBeenCalledOnce()
     expect(mockUpgradedSocketClose).toHaveBeenCalledWith(
       YJS_CLOSE_CODE_RETRY_REQUIRED,
       'Failed to attach Yjs session'
@@ -313,7 +293,11 @@ describe('handleYjsUpgrade', () => {
 
   it('allows dashboard widget write upgrades through canonical bootstrap', async () => {
     const sessionId = 'dashboard-widget:layout-1:widget-1'
-    const { request } = await runYjsUpgrade({
+    const receivedInitialSync = vi.fn()
+    mockSetupWSConnection.mockImplementationOnce((ws: EventEmitter) => {
+      ws.on('message', receivedInitialSync)
+    })
+    const { request, wss } = await runYjsUpgrade({
       target: {
         sessionId,
         entityKind: 'dashboard_widget',
@@ -336,12 +320,13 @@ describe('handleYjsUpgrade', () => {
         onDocumentUpdate: expect.any(Function),
       })
     )
-    expect(mockRawSocketPause.mock.invocationCallOrder[0]).toBeLessThan(
-      mockAuthenticateYjsConnection.mock.invocationCallOrder[0]!
+    expect(mockInitializeSavedReviewTargetDocument.mock.invocationCallOrder[0]).toBeLessThan(
+      wss.handleUpgrade.mock.invocationCallOrder[0]!
     )
-    expect(mockSetupWSConnection.mock.invocationCallOrder[0]).toBeLessThan(
-      mockRawSocketResume.mock.invocationCallOrder[0]!
+    expect(wss.handleUpgrade.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSetupWSConnection.mock.invocationCallOrder[0]!
     )
+    expect(receivedInitialSync).toHaveBeenCalledWith(expect.any(Uint8Array))
   })
 
   it.each([
@@ -467,15 +452,24 @@ describe('handleYjsUpgrade', () => {
   })
 
   it.each([
-    [YJS_CLOSE_CODE_AUTHORIZATION_REVOKED, new MockYjsAuthError(403, 'Forbidden')],
-    [YJS_CLOSE_CODE_RETRY_REQUIRED, new MockYjsSessionAdmissionError('watchlist-fenced')],
-  ])('maps an acquisition failure to close code %i', async (closeCode, error) => {
-    mockAcquireDocument.mockRejectedValueOnce(error)
+    ['acquisition', YJS_CLOSE_CODE_AUTHORIZATION_REVOKED, new MockYjsAuthError(403, 'Forbidden')],
+    [
+      'acquisition',
+      YJS_CLOSE_CODE_RETRY_REQUIRED,
+      new MockYjsSessionAdmissionError('watchlist-fenced'),
+    ],
+    ['setup', YJS_CLOSE_CODE_RETRY_REQUIRED, new Error('Failed to setup Yjs connection')],
+  ])('maps a %s failure to close code %i', async (stage, closeCode, error) => {
+    const failingOperation = stage === 'setup' ? mockSetupWSConnection : mockAcquireDocument
+    failingOperation.mockImplementationOnce(() => {
+      throw error
+    })
 
-    await runYjsUpgrade({
+    const { wss } = await runYjsUpgrade({
       target: { sessionId: 'watchlist-fenced', entityKind: 'watchlist' },
     })
 
+    expect(wss.handleUpgrade).toHaveBeenCalledOnce()
     expect(mockUpgradedSocketClose).toHaveBeenCalledWith(closeCode, 'Failed to attach Yjs session')
   })
 

--- a/apps/tradinggoose/socket-server/yjs/ws-handler.test.ts
+++ b/apps/tradinggoose/socket-server/yjs/ws-handler.test.ts
@@ -32,8 +32,8 @@ const mockPersistStagedDocuments = vi.fn()
 const mockSaveSavedEntityYjsDocToDb = vi.fn()
 const mockRefreshActiveEntityListSession = vi.fn()
 const mockUpgradedSocketClose = vi.fn()
-const mockUpgradedSocketPause = vi.fn()
-const mockUpgradedSocketResume = vi.fn()
+const mockRawSocketPause = vi.fn()
+const mockRawSocketResume = vi.fn()
 
 class MockYjsAuthError extends Error {
   constructor(
@@ -90,6 +90,8 @@ function createSocket() {
   return {
     write: vi.fn(),
     destroy: vi.fn(),
+    pause: mockRawSocketPause,
+    resume: mockRawSocketResume,
   } as unknown as Duplex
 }
 
@@ -101,8 +103,6 @@ function createWebSocketServer() {
   wss.handleUpgrade = vi.fn((request, socket, head, callback) => {
     callback({
       close: mockUpgradedSocketClose,
-      pause: mockUpgradedSocketPause,
-      resume: mockUpgradedSocketResume,
     } as any)
   })
 
@@ -208,8 +208,8 @@ beforeEach(() => {
   mockSaveSavedEntityYjsDocToDb.mockReset()
   mockRefreshActiveEntityListSession.mockReset().mockResolvedValue(undefined)
   mockUpgradedSocketClose.mockReset()
-  mockUpgradedSocketPause.mockReset()
-  mockUpgradedSocketResume.mockReset()
+  mockRawSocketPause.mockReset()
+  mockRawSocketResume.mockReset()
 
   vi.doMock('@/lib/logs/console/logger', () => ({
     createLogger: vi.fn(() => mockLogger),
@@ -303,8 +303,8 @@ describe('handleYjsUpgrade', () => {
     handleYjsUpgrade(wss, request, socket, Buffer.alloc(0))
     await new Promise((resolve) => setImmediate(resolve))
 
-    expect(mockUpgradedSocketPause).toHaveBeenCalledOnce()
-    expect(mockUpgradedSocketResume).not.toHaveBeenCalled()
+    expect(mockRawSocketPause).toHaveBeenCalledOnce()
+    expect(mockRawSocketResume).not.toHaveBeenCalled()
     expect(mockUpgradedSocketClose).toHaveBeenCalledWith(
       YJS_CLOSE_CODE_RETRY_REQUIRED,
       'Failed to attach Yjs session'
@@ -336,11 +336,11 @@ describe('handleYjsUpgrade', () => {
         onDocumentUpdate: expect.any(Function),
       })
     )
-    expect(mockUpgradedSocketPause.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(mockRawSocketPause.mock.invocationCallOrder[0]).toBeLessThan(
       mockAuthenticateYjsConnection.mock.invocationCallOrder[0]!
     )
     expect(mockSetupWSConnection.mock.invocationCallOrder[0]).toBeLessThan(
-      mockUpgradedSocketResume.mock.invocationCallOrder[0]!
+      mockRawSocketResume.mock.invocationCallOrder[0]!
     )
   })
 

--- a/apps/tradinggoose/socket-server/yjs/ws-handler.test.ts
+++ b/apps/tradinggoose/socket-server/yjs/ws-handler.test.ts
@@ -6,7 +6,7 @@ import { EventEmitter } from 'node:events'
 import type { IncomingMessage } from 'http'
 import type { Duplex } from 'stream'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { WebSocketServer } from 'ws'
+import type { RawData, WebSocketServer } from 'ws'
 import * as Y from 'yjs'
 import {
   YJS_CLOSE_CODE_AUTHORIZATION_REVOKED,
@@ -127,10 +127,7 @@ function requestFor(target: TestTarget, accessMode: 'read' | 'write' = 'write') 
   } as IncomingMessage
 }
 
-function websocketServer(
-  messages: Uint8Array[] = [new Uint8Array([0, 0])],
-  maxPayload = 1024 * 1024
-) {
+function websocketServer(messages: RawData[] = [Buffer.from([0, 0])], maxPayload = 1024 * 1024) {
   const wss = Object.assign(new EventEmitter(), {
     options: { maxPayload },
     handleUpgrade: vi.fn((_request, _socket, _head, callback) => {
@@ -147,7 +144,7 @@ async function runUpgrade(
   options: {
     accessMode?: 'read' | 'write'
     bootstrap?: { workspaceId?: string | null; state: Uint8Array } | null
-    messages?: Uint8Array[]
+    messages?: RawData[]
     maxPayload?: number
   } = {}
 ) {
@@ -250,7 +247,7 @@ describe('handleYjsUpgrade', () => {
       entityId: 'widget-1',
       ownerUserId: 'user-1',
     }
-    const messages = [new Uint8Array([0, 0]), new Uint8Array([1, 2, 3])]
+    const messages = [Buffer.from([0, 0]), Buffer.from([1, 2, 3])]
     const { request, wss } = await runUpgrade(target, { messages })
 
     expect(mocks.initialize).toHaveBeenCalledWith(
@@ -262,18 +259,56 @@ describe('handleYjsUpgrade', () => {
       request,
       expect.objectContaining({
         accessMode: 'write',
-        initialMessages: messages,
+        initialMessages: messages.map((message) => Uint8Array.from(message)),
         onDocumentUpdate: expect.any(Function),
       })
     )
+    const initialMessages = mocks.setup.mock.calls[0]?.[2].initialMessages as Uint8Array[]
+    initialMessages.forEach((message, index) => {
+      expect(message).not.toBe(messages[index])
+    })
     expect(wss.handleUpgrade.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.initialize.mock.invocationCallOrder[0]!
     )
   })
 
+  it('rejects an oversized pre-admission frame before copying it', () => {
+    const target = { sessionId: 'watchlist-oversized-frame', entityKind: 'watchlist' }
+    const copy = vi.spyOn(Uint8Array, 'from')
+    mocks.authenticate.mockReturnValue(new Promise(() => {}))
+
+    handleYjsUpgrade(
+      websocketServer([Buffer.alloc(2 * 1024 * 1024)]),
+      requestFor(target),
+      {} as Duplex,
+      Buffer.alloc(0)
+    )
+
+    expect(copy).not.toHaveBeenCalled()
+    expect(mocks.close).toHaveBeenCalledWith(1009, 'Yjs message exceeds transport payload limit')
+    copy.mockRestore()
+  })
+
+  it('rejects an oversized fragmented frame before concatenating it', () => {
+    const target = { sessionId: 'watchlist-oversized-fragments', entityKind: 'watchlist' }
+    const concat = vi.spyOn(Buffer, 'concat')
+    mocks.authenticate.mockReturnValue(new Promise(() => {}))
+
+    handleYjsUpgrade(
+      websocketServer([[Buffer.alloc(1024 * 1024), Buffer.alloc(1024 * 1024)]]),
+      requestFor(target),
+      {} as Duplex,
+      Buffer.alloc(0)
+    )
+
+    expect(concat).not.toHaveBeenCalled()
+    expect(mocks.close).toHaveBeenCalledWith(1009, 'Yjs message exceeds transport payload limit')
+    concat.mockRestore()
+  })
+
   it('closes cumulative pre-admission overflow without attaching it', async () => {
     const target = { sessionId: 'watchlist-overflow', entityKind: 'watchlist' }
-    const messages = [new Uint8Array([0, 0]), new Uint8Array([1, 2, 3])]
+    const messages = [Buffer.from([0, 0]), Buffer.from([1, 2, 3])]
     const { wss } = await runUpgrade(target, { messages, maxPayload: 4 })
 
     expect(wss.handleUpgrade).toHaveBeenCalledOnce()
@@ -284,7 +319,7 @@ describe('handleYjsUpgrade', () => {
   it('closes zero-byte frame overflow without attaching it', async () => {
     const target = { sessionId: 'watchlist-frame-overflow', entityKind: 'watchlist' }
     const { wss } = await runUpgrade(target, {
-      messages: Array.from({ length: 65 }, () => new Uint8Array()),
+      messages: Array.from({ length: 65 }, () => Buffer.alloc(0)),
     })
 
     expect(wss.handleUpgrade).toHaveBeenCalledOnce()

--- a/apps/tradinggoose/socket-server/yjs/ws-handler.test.ts
+++ b/apps/tradinggoose/socket-server/yjs/ws-handler.test.ts
@@ -225,11 +225,18 @@ describe('handleYjsUpgrade', () => {
     )
   })
 
-  it('rejects invalid authentication on the already-upgraded socket', async () => {
+  it('starts authentication only after upgrade and rejects invalid credentials', async () => {
     const target = { sessionId: 'workflow-invalid-token', entityKind: 'workflow' }
-    const wss = websocketServer()
     mocks.authenticate.mockRejectedValue(new mocks.YjsAuthError(401, 'Invalid token'))
 
+    const malformed = websocketServer()
+    malformed.handleUpgrade.mockImplementation(() => undefined)
+    handleYjsUpgrade(malformed, requestFor(target), {} as Duplex, Buffer.alloc(0))
+    await tick()
+    expect(malformed.handleUpgrade).toHaveBeenCalledOnce()
+    expect(mocks.authenticate).not.toHaveBeenCalled()
+
+    const wss = websocketServer()
     handleYjsUpgrade(wss, requestFor(target), {} as Duplex, Buffer.alloc(0))
     await tick()
 

--- a/apps/tradinggoose/socket-server/yjs/ws-handler.test.ts
+++ b/apps/tradinggoose/socket-server/yjs/ws-handler.test.ts
@@ -13,36 +13,65 @@ import {
   YJS_CLOSE_CODE_RETRY_REQUIRED,
 } from '@/lib/copilot/review-sessions/types'
 import type { DocumentAdmission } from './upstream-utils'
+import { handleYjsUpgrade } from './ws-handler'
 
-const mockAuthenticateYjsConnection = vi.fn()
-const mockInitializeSavedReviewTargetDocument = vi.fn()
-const mockBindEntityListSession = vi.fn()
-const mockAcquireDocument = vi.fn()
-const mockAdmissionReadStore = { select: vi.fn() }
-const mockDocuments = new Map<string, { doc: Y.Doc; seeded: boolean }>()
-const mockSetupWSConnection = vi.fn()
-const mockPersistStagedDocuments = vi.fn()
-const mockSaveSavedEntityYjsDocToDb = vi.fn()
-const mockRefreshActiveEntityListSession = vi.fn()
-const mockUpgradedSocketClose = vi.fn()
-
-class MockYjsAuthError extends Error {
-  constructor(
-    public status: number,
-    message: string
-  ) {
-    super(message)
-    this.name = 'YjsAuthError'
+const mocks = vi.hoisted(() => {
+  class YjsAuthError extends Error {
+    constructor(
+      public status: number,
+      message: string
+    ) {
+      super(message)
+    }
   }
-}
-
-class MockYjsSessionAdmissionError extends Error {
-  constructor(_sessionId: string) {
-    super('Yjs session is not accepting connections')
+  class YjsSessionAdmissionError extends Error {
+    constructor(_sessionId: string) {
+      super('Yjs session is not accepting connections')
+    }
   }
-}
+  return {
+    YjsAuthError,
+    YjsSessionAdmissionError,
+    authenticate: vi.fn(),
+    initialize: vi.fn(),
+    bindList: vi.fn(),
+    acquire: vi.fn(),
+    setup: vi.fn(),
+    persistStaged: vi.fn(),
+    saveEntity: vi.fn(),
+    refreshList: vi.fn(),
+    close: vi.fn(),
+  }
+})
 
-type YjsTestTarget = {
+vi.mock('@/lib/logs/console/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn() }),
+}))
+vi.mock('./auth', () => ({
+  authenticateYjsConnection: mocks.authenticate,
+  YjsAuthError: mocks.YjsAuthError,
+}))
+vi.mock('@/lib/yjs/server/bootstrap-review-target', () => ({
+  initializeSavedReviewTargetDocument: mocks.initialize,
+}))
+vi.mock('@/lib/yjs/server/revocation-fence', () => ({
+  YjsSessionAdmissionError: mocks.YjsSessionAdmissionError,
+}))
+vi.mock('./entity-list-session', () => ({
+  bindEntityListSession: mocks.bindList,
+  refreshActiveEntityListSession: mocks.refreshList,
+}))
+vi.mock('@/lib/workflows/db-helpers', () => ({ saveWorkflowYjsDocToDb: vi.fn() }))
+vi.mock('@/lib/yjs/server/apply-entity-state', () => ({
+  saveSavedEntityYjsDocToDb: mocks.saveEntity,
+}))
+vi.mock('./upstream-utils', () => ({
+  acquireDocument: mocks.acquire,
+  persistStagedDocuments: mocks.persistStaged,
+  setupWSConnection: mocks.setup,
+}))
+
+type TestTarget = {
   sessionId: string
   entityKind: string
   entityId?: string | null
@@ -53,110 +82,98 @@ type YjsTestTarget = {
   draftSessionId?: string | null
 }
 
-function createYjsRequest(
-  target: YjsTestTarget,
-  accessMode: 'read' | 'write' = 'write'
-): IncomingMessage {
-  const targetKind = target.targetKind ?? 'entity'
-  const entityId = target.entityId === undefined ? target.sessionId : target.entityId
+const readStore = { select: vi.fn() }
+const documents = new Map<string, { doc: Y.Doc; seeded: boolean }>()
+const tick = () => new Promise((resolve) => setImmediate(resolve))
+const entityId = (target: TestTarget) =>
+  target.entityId === undefined ? target.sessionId : target.entityId
+
+function authentication(target: TestTarget) {
+  return {
+    userId: 'user-1',
+    envelope: {
+      targetKind: target.targetKind ?? 'entity',
+      sessionId: target.sessionId,
+      reviewSessionId: target.reviewSessionId ?? null,
+      workspaceId: target.workspaceId ?? 'workspace-1',
+      ownerUserId: target.ownerUserId ?? null,
+      entityKind: target.entityKind,
+      entityId: entityId(target),
+      draftSessionId: target.draftSessionId ?? null,
+    },
+  }
+}
+
+function requestFor(target: TestTarget, accessMode: 'read' | 'write' = 'write') {
   const params = new URLSearchParams({
     token: 'test-token',
     accessMode,
-    targetKind,
+    targetKind: target.targetKind ?? 'entity',
     sessionId: target.sessionId,
     entityKind: target.entityKind,
   })
-  if (entityId) params.set('entityId', entityId)
-  if (target.workspaceId) params.set('workspaceId', target.workspaceId)
-  if (target.ownerUserId) params.set('ownerUserId', target.ownerUserId)
-  if (target.reviewSessionId) params.set('reviewSessionId', target.reviewSessionId)
-  if (target.draftSessionId) params.set('draftSessionId', target.draftSessionId)
+  for (const [key, value] of Object.entries({
+    entityId: entityId(target),
+    workspaceId: target.workspaceId,
+    ownerUserId: target.ownerUserId,
+    reviewSessionId: target.reviewSessionId,
+    draftSessionId: target.draftSessionId,
+  })) {
+    if (value) params.set(key, value)
+  }
   return {
     url: `/yjs/${encodeURIComponent(target.sessionId)}?${params}`,
     headers: { host: 'localhost:3000' },
   } as IncomingMessage
 }
 
-function createSocket() {
-  return {} as Duplex
-}
-
-function createWebSocketServer() {
-  const wss = new EventEmitter() as WebSocketServer & {
-    handleUpgrade: ReturnType<typeof vi.fn>
-  }
-
-  wss.handleUpgrade = vi.fn((request, socket, head, callback) => {
-    const ws = Object.assign(new EventEmitter(), { close: mockUpgradedSocketClose })
-    callback(ws as any)
-    ws.emit('message', new Uint8Array([0, 0]))
+function websocketServer(
+  messages: Uint8Array[] = [new Uint8Array([0, 0])],
+  maxPayload = 1024 * 1024
+) {
+  const wss = Object.assign(new EventEmitter(), {
+    options: { maxPayload },
+    handleUpgrade: vi.fn((_request, _socket, _head, callback) => {
+      const ws = Object.assign(new EventEmitter(), { close: mocks.close })
+      callback(ws)
+      messages.forEach((message) => ws.emit('message', message))
+    }),
   })
-
-  return wss
+  return wss as unknown as WebSocketServer & { handleUpgrade: ReturnType<typeof vi.fn> }
 }
 
-async function loadModule() {
-  return import('./ws-handler')
-}
-
-async function runYjsUpgrade(input: {
-  target: YjsTestTarget
-  accessMode?: 'read' | 'write'
-  bootstrap?: { workspaceId?: string | null; state: Uint8Array } | null
-}) {
-  const accessMode = input.accessMode ?? 'write'
-  const { target } = input
-  const targetKind = target.targetKind ?? 'entity'
-  const entityId = target.entityId === undefined ? target.sessionId : target.entityId
-  const request = createYjsRequest(target, accessMode)
-  const socket = createSocket()
-  const wss = createWebSocketServer()
-  const bootstrapUpdate = new Uint8Array([0, 0])
-  mockAuthenticateYjsConnection.mockResolvedValue({
-    userId: 'user-1',
-    envelope: {
-      targetKind,
-      sessionId: target.sessionId,
-      reviewSessionId: target.reviewSessionId ?? null,
-      workspaceId: target.workspaceId ?? 'workspace-1',
-      ownerUserId: target.ownerUserId ?? null,
-      entityKind: target.entityKind,
-      entityId,
-      draftSessionId: target.draftSessionId ?? null,
-    },
-  })
-  const bootstrap =
-    input.bootstrap === undefined
-      ? {
-          workspaceId: target.workspaceId ?? 'workspace-1',
-          state: bootstrapUpdate,
-        }
-      : input.bootstrap
-  if (bootstrap)
-    mockInitializeSavedReviewTargetDocument.mockResolvedValue({
-      workspaceId: bootstrap.workspaceId ?? target.workspaceId ?? 'workspace-1',
-      state: bootstrap.state,
-    })
-  else
-    mockInitializeSavedReviewTargetDocument.mockRejectedValue(
+async function runUpgrade(
+  target: TestTarget,
+  options: {
+    accessMode?: 'read' | 'write'
+    bootstrap?: { workspaceId?: string | null; state: Uint8Array } | null
+    messages?: Uint8Array[]
+    maxPayload?: number
+  } = {}
+) {
+  const request = requestFor(target, options.accessMode)
+  const wss = websocketServer(options.messages, options.maxPayload)
+  mocks.authenticate.mockResolvedValue(authentication(target))
+  if (options.bootstrap === null) {
+    mocks.initialize.mockRejectedValue(
       Object.assign(new Error('Review target is not bootstrapped'), { status: 404 })
     )
-
-  const { handleYjsUpgrade } = await loadModule()
-  handleYjsUpgrade(wss, request, socket, Buffer.alloc(0))
-  await new Promise((resolve) => setImmediate(resolve))
-  return { request, socket, wss }
+  } else {
+    mocks.initialize.mockResolvedValue({
+      workspaceId: options.bootstrap?.workspaceId ?? target.workspaceId ?? 'workspace-1',
+      state: options.bootstrap?.state ?? new Uint8Array([0, 0]),
+    })
+  }
+  handleYjsUpgrade(wss, request, {} as Duplex, Buffer.alloc(0))
+  await tick()
+  return { request, wss }
 }
 
 beforeEach(() => {
-  vi.resetModules()
-
-  mockAuthenticateYjsConnection.mockReset()
-  mockInitializeSavedReviewTargetDocument.mockReset()
-  mockBindEntityListSession.mockClear()
-  for (const { doc } of mockDocuments.values()) doc.destroy()
-  mockDocuments.clear()
-  mockAcquireDocument.mockReset().mockImplementation(
+  vi.clearAllMocks()
+  for (const { doc } of documents.values()) doc.destroy()
+  documents.clear()
+  mocks.acquire.mockImplementation(
     async (
       sessionId: string,
       options: {
@@ -164,169 +181,116 @@ beforeEach(() => {
         initialize: (
           doc: Y.Doc,
           admission: DocumentAdmission | undefined,
-          readStore: typeof mockAdmissionReadStore
+          store: typeof readStore
         ) => Promise<{ state?: Uint8Array } | undefined> | { state?: Uint8Array } | undefined
       },
-      use: (doc: Y.Doc, admission?: DocumentAdmission) => Promise<unknown> | unknown
+      use: (doc: Y.Doc, admission?: DocumentAdmission) => unknown
     ) => {
-      const admission = options.admission
-      const entry = mockDocuments.get(sessionId) ?? { doc: new Y.Doc(), seeded: false }
-      mockDocuments.set(sessionId, entry)
+      const entry = documents.get(sessionId) ?? { doc: new Y.Doc(), seeded: false }
+      documents.set(sessionId, entry)
       if (!entry.seeded) {
-        const initializedDocument = await options.initialize(
-          entry.doc,
-          admission,
-          mockAdmissionReadStore
-        )
-        if (initializedDocument?.state) Y.applyUpdate(entry.doc, initializedDocument.state)
+        const initialized = await options.initialize(entry.doc, options.admission, readStore)
+        if (initialized?.state) Y.applyUpdate(entry.doc, initialized.state)
         entry.seeded = true
       }
-      return use(entry.doc, admission)
+      return use(entry.doc, options.admission)
     }
   )
-  mockSetupWSConnection.mockReset()
-  mockPersistStagedDocuments
-    .mockReset()
-    .mockImplementation(
-      async (targets: Array<{ doc: Y.Doc }>, persist: (staged: Y.Doc[]) => Promise<unknown>) =>
-        persist(targets.map(({ doc }) => doc))
-    )
-  mockSaveSavedEntityYjsDocToDb.mockReset()
-  mockRefreshActiveEntityListSession.mockReset().mockResolvedValue(undefined)
-  mockUpgradedSocketClose.mockReset()
-
-  vi.doMock('@/lib/logs/console/logger', () => ({
-    createLogger: vi.fn(() => ({ info: vi.fn(), error: vi.fn() })),
-  }))
-
-  vi.doMock('./auth', () => ({
-    authenticateYjsConnection: mockAuthenticateYjsConnection,
-    YjsAuthError: MockYjsAuthError,
-  }))
-
-  vi.doMock('@/lib/yjs/server/bootstrap-review-target', () => ({
-    initializeSavedReviewTargetDocument: mockInitializeSavedReviewTargetDocument,
-  }))
-
-  vi.doMock('@/lib/yjs/server/revocation-fence', () => ({
-    YjsSessionAdmissionError: MockYjsSessionAdmissionError,
-  }))
-
-  vi.doMock('./entity-list-session', () => ({
-    bindEntityListSession: mockBindEntityListSession,
-    refreshActiveEntityListSession: mockRefreshActiveEntityListSession,
-  }))
-
-  vi.doMock('@/lib/workflows/db-helpers', () => ({
-    saveWorkflowYjsDocToDb: vi.fn(),
-  }))
-
-  vi.doMock('@/lib/yjs/server/apply-entity-state', () => ({
-    saveSavedEntityYjsDocToDb: mockSaveSavedEntityYjsDocToDb,
-  }))
-
-  vi.doMock('./upstream-utils', () => ({
-    acquireDocument: mockAcquireDocument,
-    persistStagedDocuments: mockPersistStagedDocuments,
-    setupWSConnection: mockSetupWSConnection,
-  }))
+  mocks.persistStaged.mockImplementation(
+    async (targets: Array<{ doc: Y.Doc }>, persist: (docs: Y.Doc[]) => Promise<unknown>) =>
+      persist(targets.map(({ doc }) => doc))
+  )
+  mocks.refreshList.mockResolvedValue(undefined)
 })
 
 describe('handleYjsUpgrade', () => {
-  it('rejects an in-flight upgrade when shutdown begins during authentication', async () => {
-    const sessionId = 'workflow-shutdown-race'
-    const request = createYjsRequest({ sessionId, entityKind: 'workflow' })
-    const socket = createSocket()
-    const wss = createWebSocketServer()
+  it('upgrades once before authentication and rejects shutdown races', async () => {
+    const target = { sessionId: 'workflow-shutdown-race', entityKind: 'workflow' }
     let resolveAuthentication!: (value: unknown) => void
-    mockAuthenticateYjsConnection.mockReturnValueOnce(
+    mocks.authenticate.mockReturnValue(
       new Promise((resolve) => {
         resolveAuthentication = resolve
       })
     )
-    let acceptsConnections = true
+    const wss = websocketServer()
+    let accepting = true
 
-    const { handleYjsUpgrade } = await loadModule()
-    handleYjsUpgrade(wss, request, socket, Buffer.alloc(0), () => acceptsConnections)
-    expect(wss.handleUpgrade).not.toHaveBeenCalled()
-    acceptsConnections = false
-    resolveAuthentication({
-      userId: 'user-1',
-      envelope: {
-        targetKind: 'entity',
-        sessionId,
-        reviewSessionId: null,
-        workspaceId: 'workspace-1',
-        entityKind: 'workflow',
-        entityId: sessionId,
-        draftSessionId: null,
-      },
-    })
-    await new Promise((resolve) => setImmediate(resolve))
+    handleYjsUpgrade(wss, requestFor(target), {} as Duplex, Buffer.alloc(0), () => accepting)
+    expect(wss.handleUpgrade).toHaveBeenCalledOnce()
+    expect(mocks.setup).not.toHaveBeenCalled()
+    accepting = false
+    resolveAuthentication(authentication(target))
+    await tick()
 
-    expect(mockUpgradedSocketClose).toHaveBeenCalledWith(
+    expect(mocks.close).toHaveBeenCalledWith(
       YJS_CLOSE_CODE_RETRY_REQUIRED,
       'Failed to attach Yjs session'
     )
   })
 
-  it('rejects websocket upgrades when the Yjs auth token is invalid', async () => {
-    const sessionId = 'workflow-invalid-token'
-    const request = createYjsRequest({ sessionId, entityKind: 'workflow' })
-    const socket = createSocket()
-    const wss = createWebSocketServer()
+  it('rejects invalid authentication on the already-upgraded socket', async () => {
+    const target = { sessionId: 'workflow-invalid-token', entityKind: 'workflow' }
+    const wss = websocketServer()
+    mocks.authenticate.mockRejectedValue(new mocks.YjsAuthError(401, 'Invalid token'))
 
-    mockAuthenticateYjsConnection.mockRejectedValue(
-      new MockYjsAuthError(401, 'Invalid or expired token')
-    )
-
-    const { handleYjsUpgrade } = await loadModule()
-    handleYjsUpgrade(wss, request, socket, Buffer.alloc(0))
-    await new Promise((resolve) => setImmediate(resolve))
+    handleYjsUpgrade(wss, requestFor(target), {} as Duplex, Buffer.alloc(0))
+    await tick()
 
     expect(wss.handleUpgrade).toHaveBeenCalledOnce()
-    expect(mockUpgradedSocketClose).toHaveBeenCalledWith(
+    expect(mocks.close).toHaveBeenCalledWith(
       YJS_CLOSE_CODE_RETRY_REQUIRED,
       'Failed to attach Yjs session'
     )
   })
 
-  it('allows dashboard widget write upgrades through canonical bootstrap', async () => {
-    const sessionId = 'dashboard-widget:layout-1:widget-1'
-    const receivedInitialSync = vi.fn()
-    mockSetupWSConnection.mockImplementationOnce((ws: EventEmitter) => {
-      ws.on('message', receivedInitialSync)
-    })
-    const { request, wss } = await runYjsUpgrade({
-      target: {
-        sessionId,
-        entityKind: 'dashboard_widget',
-        entityId: 'widget-1',
-        ownerUserId: 'user-1',
-      },
-      accessMode: 'write',
-    })
+  it('buffers ordered widget messages until canonical bootstrap completes', async () => {
+    const target = {
+      sessionId: 'dashboard-widget:layout-1:widget-1',
+      entityKind: 'dashboard_widget',
+      entityId: 'widget-1',
+      ownerUserId: 'user-1',
+    }
+    const messages = [new Uint8Array([0, 0]), new Uint8Array([1, 2, 3])]
+    const { request, wss } = await runUpgrade(target, { messages })
 
-    expect(mockInitializeSavedReviewTargetDocument).toHaveBeenCalledWith(
+    expect(mocks.initialize).toHaveBeenCalledWith(
       expect.objectContaining({ entityKind: 'dashboard_widget', entityId: 'widget-1' }),
-      mockAdmissionReadStore
+      readStore
     )
-    expect(mockSetupWSConnection).toHaveBeenCalledWith(
+    expect(mocks.setup).toHaveBeenCalledWith(
       expect.anything(),
       request,
       expect.objectContaining({
-        doc: expect.any(Y.Doc),
         accessMode: 'write',
+        initialMessages: messages,
         onDocumentUpdate: expect.any(Function),
       })
     )
-    expect(mockInitializeSavedReviewTargetDocument.mock.invocationCallOrder[0]).toBeLessThan(
-      wss.handleUpgrade.mock.invocationCallOrder[0]!
-    )
     expect(wss.handleUpgrade.mock.invocationCallOrder[0]).toBeLessThan(
-      mockSetupWSConnection.mock.invocationCallOrder[0]!
+      mocks.initialize.mock.invocationCallOrder[0]!
     )
-    expect(receivedInitialSync).toHaveBeenCalledWith(expect.any(Uint8Array))
+  })
+
+  it('closes cumulative pre-admission overflow without attaching it', async () => {
+    const target = { sessionId: 'watchlist-overflow', entityKind: 'watchlist' }
+    const messages = [new Uint8Array([0, 0]), new Uint8Array([1, 2, 3])]
+    const { wss } = await runUpgrade(target, { messages, maxPayload: 4 })
+
+    expect(wss.handleUpgrade).toHaveBeenCalledOnce()
+    expect(mocks.close).toHaveBeenCalledWith(1009, 'Yjs message exceeds transport payload limit')
+    expect(mocks.setup).not.toHaveBeenCalled()
+  })
+
+  it('closes zero-byte frame overflow without attaching it', async () => {
+    const target = { sessionId: 'watchlist-frame-overflow', entityKind: 'watchlist' }
+    const { wss } = await runUpgrade(target, {
+      messages: Array.from({ length: 65 }, () => new Uint8Array()),
+    })
+
+    expect(wss.handleUpgrade).toHaveBeenCalledOnce()
+    expect(mocks.close).toHaveBeenCalledOnce()
+    expect(mocks.close).toHaveBeenCalledWith(1009, 'Yjs message exceeds transport payload limit')
+    expect(mocks.setup).not.toHaveBeenCalled()
   })
 
   it.each([
@@ -340,154 +304,118 @@ describe('handleYjsUpgrade', () => {
       },
     ],
   ])('allows %s read-mode websocket upgrades', async (_label, target) => {
-    const { request, wss } = await runYjsUpgrade({ target, accessMode: 'read' })
+    const { request } = await runUpgrade(target, { accessMode: 'read' })
 
-    expect(wss.handleUpgrade).toHaveBeenCalledOnce()
-    expect(mockSetupWSConnection).toHaveBeenCalledWith(
+    expect(mocks.setup).toHaveBeenCalledWith(
       expect.anything(),
       request,
-      expect.objectContaining({
-        doc: expect.any(Y.Doc),
-        accessMode: 'read',
-        onDocumentUpdate: undefined,
-      })
+      expect.objectContaining({ accessMode: 'read', onDocumentUpdate: undefined })
     )
   })
 
-  it('binds an entity-list reconciler during document initialization', async () => {
-    const sessionId = 'list:watchlist:workspace-1'
-    const listDoc = new Y.Doc()
-    mockDocuments.set(sessionId, { doc: listDoc, seeded: false })
-    try {
-      await runYjsUpgrade({
-        target: { sessionId, entityKind: 'watchlist', entityId: null, targetKind: 'entity_list' },
-        accessMode: 'read',
-      })
-
-      expect(mockBindEntityListSession).toHaveBeenCalledWith(
-        listDoc,
-        'watchlist',
-        'workspace-1',
-        null
-      )
-      expect(mockInitializeSavedReviewTargetDocument).not.toHaveBeenCalled()
-    } finally {
-      listDoc.destroy()
+  it('binds entity-list reconciliation instead of entity bootstrap', async () => {
+    const target = {
+      sessionId: 'list:watchlist:workspace-1',
+      entityKind: 'watchlist',
+      entityId: null,
+      targetKind: 'entity_list' as const,
     }
+    const listDoc = new Y.Doc()
+    documents.set(target.sessionId, { doc: listDoc, seeded: false })
+
+    await runUpgrade(target, { accessMode: 'read' })
+
+    expect(mocks.bindList).toHaveBeenCalledWith(listDoc, 'watchlist', 'workspace-1', null)
+    expect(mocks.initialize).not.toHaveBeenCalled()
   })
 
-  it('persists writable watchlist updates through the saved-document lifecycle', async () => {
-    const sessionId = 'watchlist-write'
-    await runYjsUpgrade({ target: { sessionId, entityKind: 'watchlist' } })
-
-    const options = mockSetupWSConnection.mock.calls[0]?.[2]
-    expect(options).toEqual(
-      expect.objectContaining({
-        doc: expect.any(Y.Doc),
-        onDocumentUpdate: expect.any(Function),
-      })
-    )
+  it('persists writable watchlists through their saved-document lifecycle', async () => {
+    await runUpgrade({ sessionId: 'watchlist-write', entityKind: 'watchlist' })
+    const persist = mocks.setup.mock.calls[0]?.[2].onDocumentUpdate
     const doc = new Y.Doc()
-    const metadata = doc.getMap('metadata')
-    metadata.set('entityKind', 'skill')
-    metadata.set('entityId', 'client-controlled-entity')
-    metadata.set('workspaceId', 'client-controlled-workspace')
-    metadata.set('draftSessionId', 'client-controlled-draft')
-    metadata.set('reviewSessionId', null)
-    await options.onDocumentUpdate(sessionId, doc)
 
-    expect(mockSaveSavedEntityYjsDocToDb).toHaveBeenCalledWith(
+    await persist('watchlist-write', doc)
+
+    expect(mocks.saveEntity).toHaveBeenCalledWith(
       'watchlist',
-      sessionId,
+      'watchlist-write',
       'workspace-1',
       doc
     )
-    expect(mockRefreshActiveEntityListSession).toHaveBeenCalledWith('watchlist', 'workspace-1')
+    expect(mocks.refreshList).toHaveBeenCalledWith('watchlist', 'workspace-1')
     doc.destroy()
   })
 
-  it('persists manual saved-entity updates through the websocket lifecycle', async () => {
-    const sessionId = 'skill-write'
-    await runYjsUpgrade({ target: { sessionId, entityKind: 'skill' } })
-
-    const options = mockSetupWSConnection.mock.calls[0]?.[2]
-    expect(options).toEqual(
-      expect.objectContaining({
-        doc: expect.any(Y.Doc),
-        persist: expect.any(Function),
-        onDocumentUpdate: undefined,
-      })
-    )
+  it('persists manual entity documents and identity names together', async () => {
+    await runUpgrade({ sessionId: 'skill-write', entityKind: 'skill' })
+    const persist = mocks.setup.mock.calls[0]?.[2].persist
     const doc = new Y.Doc()
-    await options.persist(doc, 'request-1', 'Renamed skill')
 
-    expect(mockPersistStagedDocuments).toHaveBeenCalledWith(
-      [{ doc }],
-      expect.any(Function),
-      'request-1'
-    )
-    expect(mockSaveSavedEntityYjsDocToDb).toHaveBeenCalledWith(
-      'skill',
-      sessionId,
-      'workspace-1',
-      doc,
-      { identity: { name: 'Renamed skill' } }
-    )
-    expect(mockRefreshActiveEntityListSession).toHaveBeenCalledWith('skill', 'workspace-1')
+    await persist(doc, 'request-1', 'Renamed skill')
+
+    expect(mocks.persistStaged).toHaveBeenCalledWith([{ doc }], expect.any(Function), 'request-1')
+    expect(mocks.saveEntity).toHaveBeenCalledWith('skill', 'skill-write', 'workspace-1', doc, {
+      identity: { name: 'Renamed skill' },
+    })
+    expect(mocks.refreshList).toHaveBeenCalledWith('skill', 'workspace-1')
     doc.destroy()
   })
 
-  it('rejects writable dashboard layout websocket upgrades', async () => {
-    const sessionId = 'layout-write'
-    await runYjsUpgrade({
-      target: {
-        sessionId,
-        entityKind: 'dashboard_layout',
-        ownerUserId: 'user-1',
-      },
+  it('rejects writable dashboard layout sockets', async () => {
+    await runUpgrade({
+      sessionId: 'layout-write',
+      entityKind: 'dashboard_layout',
+      ownerUserId: 'user-1',
     })
 
-    expect(mockSetupWSConnection).not.toHaveBeenCalled()
-    expect(mockUpgradedSocketClose).toHaveBeenCalledWith(4403, 'Failed to attach Yjs session')
+    expect(mocks.setup).not.toHaveBeenCalled()
+    expect(mocks.close).toHaveBeenCalledWith(4403, 'Failed to attach Yjs session')
   })
 
   it.each([
-    ['acquisition', YJS_CLOSE_CODE_AUTHORIZATION_REVOKED, new MockYjsAuthError(403, 'Forbidden')],
-    [
-      'acquisition',
-      YJS_CLOSE_CODE_RETRY_REQUIRED,
-      new MockYjsSessionAdmissionError('watchlist-fenced'),
-    ],
-    ['setup', YJS_CLOSE_CODE_RETRY_REQUIRED, new Error('Failed to setup Yjs connection')],
-  ])('maps a %s failure to close code %i', async (stage, closeCode, error) => {
-    const failingOperation = stage === 'setup' ? mockSetupWSConnection : mockAcquireDocument
-    failingOperation.mockImplementationOnce(() => {
-      throw error
-    })
-
-    const { wss } = await runYjsUpgrade({
-      target: { sessionId: 'watchlist-fenced', entityKind: 'watchlist' },
+    [YJS_CLOSE_CODE_AUTHORIZATION_REVOKED, new mocks.YjsAuthError(403, 'Forbidden')],
+    [YJS_CLOSE_CODE_RETRY_REQUIRED, new mocks.YjsSessionAdmissionError('watchlist-fenced')],
+  ])('maps acquisition failures to close code %i', async (closeCode, error) => {
+    mocks.acquire.mockRejectedValueOnce(error)
+    const { wss } = await runUpgrade({
+      sessionId: 'watchlist-fenced',
+      entityKind: 'watchlist',
     })
 
     expect(wss.handleUpgrade).toHaveBeenCalledOnce()
-    expect(mockUpgradedSocketClose).toHaveBeenCalledWith(closeCode, 'Failed to attach Yjs session')
+    expect(mocks.close).toHaveBeenCalledWith(closeCode, 'Failed to attach Yjs session')
   })
 
-  it('rejects websocket upgrades for missing non-entity review sessions', async () => {
-    const sessionId = 'review-unbootstrapped'
-    await runYjsUpgrade({
-      target: {
-        sessionId,
+  it('maps setup failures without attempting another upgrade', async () => {
+    mocks.setup.mockImplementationOnce(() => {
+      throw new Error('setup failed')
+    })
+    const { wss } = await runUpgrade({
+      sessionId: 'watchlist-setup-failed',
+      entityKind: 'watchlist',
+    })
+
+    expect(wss.handleUpgrade).toHaveBeenCalledOnce()
+    expect(mocks.close).toHaveBeenCalledWith(
+      YJS_CLOSE_CODE_RETRY_REQUIRED,
+      'Failed to attach Yjs session'
+    )
+  })
+
+  it('rejects missing non-entity review sessions', async () => {
+    await runUpgrade(
+      {
+        sessionId: 'review-unbootstrapped',
         entityKind: 'skill',
         entityId: null,
         targetKind: 'review_session',
         workspaceId: 'workspace-3',
-        reviewSessionId: sessionId,
+        reviewSessionId: 'review-unbootstrapped',
         draftSessionId: 'draft-1',
       },
-      bootstrap: null,
-    })
+      { bootstrap: null }
+    )
 
-    expect(mockUpgradedSocketClose).toHaveBeenCalledWith(4410, 'Failed to attach Yjs session')
+    expect(mocks.close).toHaveBeenCalledWith(4410, 'Failed to attach Yjs session')
   })
 })

--- a/apps/tradinggoose/socket-server/yjs/ws-handler.ts
+++ b/apps/tradinggoose/socket-server/yjs/ws-handler.ts
@@ -137,8 +137,7 @@ export function handleYjsUpgrade(
   canAcceptConnection: () => boolean = () => true
 ): void {
   const url = new URL(request.url || '', `http://${request.headers.host}`)
-  const pathname = url.pathname
-  const match = pathname.match(/^\/yjs\/([^/]+)$/)
+  const match = url.pathname.match(/^\/yjs\/([^/]+)$/)
 
   if (!match || !match[1]) {
     rejectUpgrade(socket, 400, 'Invalid Yjs path')
@@ -146,8 +145,8 @@ export function handleYjsUpgrade(
   }
 
   const yjsSessionId = decodeURIComponent(match[1])
+  socket.pause()
   wss.handleUpgrade(request, socket, head, (ws: WebSocket) => {
-    ws.pause()
     const rejectConnection = (error: unknown) => {
       logger.error('Failed to attach Yjs connection', { docId: yjsSessionId, error })
       ws.close(yjsConnectionRejectionCode(error), 'Failed to attach Yjs session')
@@ -190,7 +189,7 @@ export function handleYjsUpgrade(
             onDocumentUpdate: livePersistenceHandler(accessMode, descriptor),
             onDocumentUpdateDebounceMs: SAVED_DOCUMENT_LIVE_PERSIST_DEBOUNCE_MS,
           })
-          ws.resume()
+          socket.resume()
         }
       )
     })().catch(rejectConnection)

--- a/apps/tradinggoose/socket-server/yjs/ws-handler.ts
+++ b/apps/tradinggoose/socket-server/yjs/ws-handler.ts
@@ -169,17 +169,19 @@ export function handleYjsUpgrade(
   }
   function collectPendingMessage(data: RawData) {
     if (!awaitingAdmission) return
-    const message = copyWebSocketMessage(data)
-    pendingMessageBytes += message.byteLength
+    const messageBytes = Array.isArray(data)
+      ? data.reduce((total, fragment) => total + fragment.byteLength, 0)
+      : data.byteLength
     if (
       pendingMessages.length >= MAX_PENDING_MESSAGE_COUNT ||
-      pendingMessageBytes > wss.options.maxPayload!
+      pendingMessageBytes + messageBytes > wss.options.maxPayload!
     ) {
       abandonPendingMessages()
       ws.close(1009, 'Yjs message exceeds transport payload limit')
       return
     }
-    pendingMessages.push(message)
+    pendingMessageBytes += messageBytes
+    pendingMessages.push(copyWebSocketMessage(data))
   }
 
   wss.handleUpgrade(request, socket, head, (upgraded: WebSocket) => {

--- a/apps/tradinggoose/socket-server/yjs/ws-handler.ts
+++ b/apps/tradinggoose/socket-server/yjs/ws-handler.ts
@@ -145,54 +145,58 @@ export function handleYjsUpgrade(
   }
 
   const yjsSessionId = decodeURIComponent(match[1])
-  socket.pause()
-  wss.handleUpgrade(request, socket, head, (ws: WebSocket) => {
-    const rejectConnection = (error: unknown) => {
-      logger.error('Failed to attach Yjs connection', { docId: yjsSessionId, error })
-      ws.close(yjsConnectionRejectionCode(error), 'Failed to attach Yjs session')
-    }
+  const rejectConnection = (ws: WebSocket, error: unknown) => {
+    logger.error('Failed to attach Yjs connection', { docId: yjsSessionId, error })
+    ws.close(yjsConnectionRejectionCode(error), 'Failed to attach Yjs session')
+  }
 
-    void (async () => {
-      if (!canAcceptConnection()) throw new YjsSessionAdmissionError(yjsSessionId)
-      const authenticated = await authenticateYjsUpgrade(yjsSessionId, url)
-      if (!canAcceptConnection()) throw new YjsSessionAdmissionError(yjsSessionId)
+  void (async () => {
+    if (!canAcceptConnection()) throw new YjsSessionAdmissionError(yjsSessionId)
+    const authenticated = await authenticateYjsUpgrade(yjsSessionId, url)
 
-      await acquireDocument(
-        yjsSessionId,
-        {
-          workspaceId: authenticated.descriptor.workspaceId,
-          admission: authenticated,
-          initialize: (_doc, admission, readStore) => {
-            if (!admission) throw new YjsAuthError(503, 'Yjs authorization is unavailable')
-            if (isEntityListSessionId(admission.descriptor.yjsSessionId)) {
-              bindEntityListSession(
-                _doc,
-                admission.descriptor.entityKind as ReviewEntityKind,
-                admission.descriptor.workspaceId as string,
-                admission.descriptor.ownerUserId ?? null
-              )
-              return
-            }
-            return initializeSavedReviewTargetDocument(admission.descriptor, readStore)
-          },
-        },
-        async (doc, admission) => {
+    await acquireDocument(
+      yjsSessionId,
+      {
+        workspaceId: authenticated.descriptor.workspaceId,
+        admission: authenticated,
+        initialize: (_doc, admission, readStore) => {
           if (!admission) throw new YjsAuthError(503, 'Yjs authorization is unavailable')
-          const { accessMode, userId, descriptor } = admission
-          logger.info('Yjs connection established', { docId: yjsSessionId, userId })
-          setupWSConnection(ws, request, {
-            doc,
-            userId,
-            accessMode,
-            descriptor,
-            persist: manualPersistenceHandler(accessMode, descriptor),
-            onDocumentUpdate: livePersistenceHandler(accessMode, descriptor),
-            onDocumentUpdateDebounceMs: SAVED_DOCUMENT_LIVE_PERSIST_DEBOUNCE_MS,
-          })
-          socket.resume()
-        }
-      )
-    })().catch(rejectConnection)
+          if (isEntityListSessionId(admission.descriptor.yjsSessionId)) {
+            bindEntityListSession(
+              _doc,
+              admission.descriptor.entityKind as ReviewEntityKind,
+              admission.descriptor.workspaceId as string,
+              admission.descriptor.ownerUserId ?? null
+            )
+            return
+          }
+          return initializeSavedReviewTargetDocument(admission.descriptor, readStore)
+        },
+      },
+      (doc, admission) => {
+        if (!admission) throw new YjsAuthError(503, 'Yjs authorization is unavailable')
+        if (!canAcceptConnection()) throw new YjsSessionAdmissionError(yjsSessionId)
+        const { accessMode, userId, descriptor } = admission
+        wss.handleUpgrade(request, socket, head, (ws: WebSocket) => {
+          try {
+            setupWSConnection(ws, request, {
+              doc,
+              userId,
+              accessMode,
+              descriptor,
+              persist: manualPersistenceHandler(accessMode, descriptor),
+              onDocumentUpdate: livePersistenceHandler(accessMode, descriptor),
+              onDocumentUpdateDebounceMs: SAVED_DOCUMENT_LIVE_PERSIST_DEBOUNCE_MS,
+            })
+            logger.info('Yjs connection established', { docId: yjsSessionId, userId })
+          } catch (error) {
+            rejectConnection(ws, error)
+          }
+        })
+      }
+    )
+  })().catch((error) => {
+    wss.handleUpgrade(request, socket, head, (ws: WebSocket) => rejectConnection(ws, error))
   })
 }
 

--- a/apps/tradinggoose/socket-server/yjs/ws-handler.ts
+++ b/apps/tradinggoose/socket-server/yjs/ws-handler.ts
@@ -146,104 +146,101 @@ export function handleYjsUpgrade(
   }
 
   const yjsSessionId = decodeURIComponent(match[1])
-  const rejectConnection = (ws: WebSocket, error: unknown) => {
-    logger.error('Failed to attach Yjs connection', { docId: yjsSessionId, error })
-    ws.close(yjsConnectionRejectionCode(error), 'Failed to attach Yjs session')
-  }
-
-  const pendingMessages: Uint8Array[] = []
-  let pendingMessageBytes = 0
-  let awaitingAdmission = true
-  let ws!: WebSocket
-
-  function detachPendingListeners() {
-    ws.off('message', collectPendingMessage)
-    ws.off('close', abandonPendingMessages)
-    ws.off('error', abandonPendingMessages)
-  }
-  function abandonPendingMessages() {
-    if (!awaitingAdmission) return
-    awaitingAdmission = false
-    pendingMessages.length = 0
-    detachPendingListeners()
-  }
-  function collectPendingMessage(data: RawData) {
-    if (!awaitingAdmission) return
-    const messageBytes = Array.isArray(data)
-      ? data.reduce((total, fragment) => total + fragment.byteLength, 0)
-      : data.byteLength
-    if (
-      pendingMessages.length >= MAX_PENDING_MESSAGE_COUNT ||
-      pendingMessageBytes + messageBytes > wss.options.maxPayload!
-    ) {
-      abandonPendingMessages()
-      ws.close(1009, 'Yjs message exceeds transport payload limit')
-      return
+  wss.handleUpgrade(request, socket, head, (ws: WebSocket) => {
+    const rejectConnection = (error: unknown) => {
+      logger.error('Failed to attach Yjs connection', { docId: yjsSessionId, error })
+      ws.close(yjsConnectionRejectionCode(error), 'Failed to attach Yjs session')
     }
-    pendingMessageBytes += messageBytes
-    pendingMessages.push(copyWebSocketMessage(data))
-  }
+    const pendingMessages: Uint8Array[] = []
+    let pendingMessageBytes = 0
+    let awaitingAdmission = true
 
-  wss.handleUpgrade(request, socket, head, (upgraded: WebSocket) => {
-    ws = upgraded
+    function detachPendingListeners() {
+      ws.off('message', collectPendingMessage)
+      ws.off('close', abandonPendingMessages)
+      ws.off('error', abandonPendingMessages)
+    }
+    function abandonPendingMessages() {
+      if (!awaitingAdmission) return
+      awaitingAdmission = false
+      pendingMessages.length = 0
+      detachPendingListeners()
+    }
+    function collectPendingMessage(data: RawData) {
+      if (!awaitingAdmission) return
+      const messageBytes = Array.isArray(data)
+        ? data.reduce((total, fragment) => total + fragment.byteLength, 0)
+        : data.byteLength
+      if (
+        pendingMessages.length >= MAX_PENDING_MESSAGE_COUNT ||
+        pendingMessageBytes + messageBytes > wss.options.maxPayload!
+      ) {
+        abandonPendingMessages()
+        ws.close(1009, 'Yjs message exceeds transport payload limit')
+        return
+      }
+      pendingMessageBytes += messageBytes
+      pendingMessages.push(copyWebSocketMessage(data))
+    }
+
     ws.binaryType = 'arraybuffer'
     ws.on('message', collectPendingMessage)
     ws.once('close', abandonPendingMessages)
     ws.once('error', abandonPendingMessages)
-  })
 
-  void (async () => {
-    if (!canAcceptConnection()) throw new YjsSessionAdmissionError(yjsSessionId)
-    const authenticated = await authenticateYjsUpgrade(yjsSessionId, url)
+    void (async () => {
+      if (!canAcceptConnection()) throw new YjsSessionAdmissionError(yjsSessionId)
+      const authenticated = await authenticateYjsUpgrade(yjsSessionId, url)
 
-    await acquireDocument(
-      yjsSessionId,
-      {
-        workspaceId: authenticated.descriptor.workspaceId,
-        admission: authenticated,
-        initialize: (_doc, admission, readStore) => {
-          if (!admission) throw new YjsAuthError(503, 'Yjs authorization is unavailable')
-          if (isEntityListSessionId(admission.descriptor.yjsSessionId)) {
-            bindEntityListSession(
-              _doc,
-              admission.descriptor.entityKind as ReviewEntityKind,
-              admission.descriptor.workspaceId as string,
-              admission.descriptor.ownerUserId ?? null
-            )
-            return
-          }
-          return initializeSavedReviewTargetDocument(admission.descriptor, readStore)
+      await acquireDocument(
+        yjsSessionId,
+        {
+          workspaceId: authenticated.descriptor.workspaceId,
+          admission: authenticated,
+          initialize: (_doc, admission, readStore) => {
+            if (!admission) throw new YjsAuthError(503, 'Yjs authorization is unavailable')
+            if (isEntityListSessionId(admission.descriptor.yjsSessionId)) {
+              bindEntityListSession(
+                _doc,
+                admission.descriptor.entityKind as ReviewEntityKind,
+                admission.descriptor.workspaceId as string,
+                admission.descriptor.ownerUserId ?? null
+              )
+              return
+            }
+            return initializeSavedReviewTargetDocument(admission.descriptor, readStore)
+          },
         },
-      },
-      (doc, admission) => {
-        if (!admission) throw new YjsAuthError(503, 'Yjs authorization is unavailable')
-        if (!canAcceptConnection()) throw new YjsSessionAdmissionError(yjsSessionId)
-        if (!awaitingAdmission) return
-        const { accessMode, userId, descriptor } = admission
-        const initialMessages = pendingMessages.splice(0)
-        awaitingAdmission = false
-        detachPendingListeners()
-        try {
-          setupWSConnection(ws, request, {
-            doc,
-            userId,
-            accessMode,
-            descriptor,
-            initialMessages,
-            persist: manualPersistenceHandler(accessMode, descriptor),
-            onDocumentUpdate: livePersistenceHandler(accessMode, descriptor),
-            onDocumentUpdateDebounceMs: SAVED_DOCUMENT_LIVE_PERSIST_DEBOUNCE_MS,
-          })
-          logger.info('Yjs connection established', { docId: yjsSessionId, userId })
-        } catch (error) {
-          rejectConnection(ws, error)
+        (doc, admission) => {
+          if (!admission) throw new YjsAuthError(503, 'Yjs authorization is unavailable')
+          if (!canAcceptConnection()) throw new YjsSessionAdmissionError(yjsSessionId)
+          if (!awaitingAdmission) return
+          const { accessMode, userId, descriptor } = admission
+          const initialMessages = pendingMessages.splice(0)
+          awaitingAdmission = false
+          detachPendingListeners()
+          try {
+            setupWSConnection(ws, request, {
+              doc,
+              userId,
+              accessMode,
+              descriptor,
+              initialMessages,
+              persist: manualPersistenceHandler(accessMode, descriptor),
+              onDocumentUpdate: livePersistenceHandler(accessMode, descriptor),
+              onDocumentUpdateDebounceMs: SAVED_DOCUMENT_LIVE_PERSIST_DEBOUNCE_MS,
+            })
+            logger.info('Yjs connection established', { docId: yjsSessionId, userId })
+          } catch (error) {
+            rejectConnection(error)
+          }
         }
-      }
-    )
-  })().catch((error) => {
-    if (!awaitingAdmission) return
-    abandonPendingMessages()
-    rejectConnection(ws, error)
+      )
+    })().catch((error) => {
+      if (!awaitingAdmission) return
+      abandonPendingMessages()
+      rejectConnection(error)
+    })
   })
 }
 

--- a/apps/tradinggoose/socket-server/yjs/ws-handler.ts
+++ b/apps/tradinggoose/socket-server/yjs/ws-handler.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage } from 'http'
 import type { Duplex } from 'stream'
-import type { WebSocket, WebSocketServer } from 'ws'
+import type { RawData, WebSocket, WebSocketServer } from 'ws'
 import type * as Y from 'yjs'
 import {
   buildReviewTargetDescriptorFromEnvelope,
@@ -36,6 +36,7 @@ import {
 
 const logger = createLogger('YjsWsHandler')
 const SAVED_DOCUMENT_LIVE_PERSIST_DEBOUNCE_MS = 1500
+const MAX_PENDING_MESSAGE_COUNT = 64
 
 function manualPersistenceHandler(
   accessMode: ReviewAccessMode,
@@ -150,6 +151,45 @@ export function handleYjsUpgrade(
     ws.close(yjsConnectionRejectionCode(error), 'Failed to attach Yjs session')
   }
 
+  const pendingMessages: Uint8Array[] = []
+  let pendingMessageBytes = 0
+  let awaitingAdmission = true
+  let ws!: WebSocket
+
+  function detachPendingListeners() {
+    ws.off('message', collectPendingMessage)
+    ws.off('close', abandonPendingMessages)
+    ws.off('error', abandonPendingMessages)
+  }
+  function abandonPendingMessages() {
+    if (!awaitingAdmission) return
+    awaitingAdmission = false
+    pendingMessages.length = 0
+    detachPendingListeners()
+  }
+  function collectPendingMessage(data: RawData) {
+    if (!awaitingAdmission) return
+    const message = copyWebSocketMessage(data)
+    pendingMessageBytes += message.byteLength
+    if (
+      pendingMessages.length >= MAX_PENDING_MESSAGE_COUNT ||
+      pendingMessageBytes > wss.options.maxPayload!
+    ) {
+      abandonPendingMessages()
+      ws.close(1009, 'Yjs message exceeds transport payload limit')
+      return
+    }
+    pendingMessages.push(message)
+  }
+
+  wss.handleUpgrade(request, socket, head, (upgraded: WebSocket) => {
+    ws = upgraded
+    ws.binaryType = 'arraybuffer'
+    ws.on('message', collectPendingMessage)
+    ws.once('close', abandonPendingMessages)
+    ws.once('error', abandonPendingMessages)
+  })
+
   void (async () => {
     if (!canAcceptConnection()) throw new YjsSessionAdmissionError(yjsSessionId)
     const authenticated = await authenticateYjsUpgrade(yjsSessionId, url)
@@ -176,28 +216,42 @@ export function handleYjsUpgrade(
       (doc, admission) => {
         if (!admission) throw new YjsAuthError(503, 'Yjs authorization is unavailable')
         if (!canAcceptConnection()) throw new YjsSessionAdmissionError(yjsSessionId)
+        if (!awaitingAdmission) return
         const { accessMode, userId, descriptor } = admission
-        wss.handleUpgrade(request, socket, head, (ws: WebSocket) => {
-          try {
-            setupWSConnection(ws, request, {
-              doc,
-              userId,
-              accessMode,
-              descriptor,
-              persist: manualPersistenceHandler(accessMode, descriptor),
-              onDocumentUpdate: livePersistenceHandler(accessMode, descriptor),
-              onDocumentUpdateDebounceMs: SAVED_DOCUMENT_LIVE_PERSIST_DEBOUNCE_MS,
-            })
-            logger.info('Yjs connection established', { docId: yjsSessionId, userId })
-          } catch (error) {
-            rejectConnection(ws, error)
-          }
-        })
+        const initialMessages = pendingMessages.splice(0)
+        awaitingAdmission = false
+        detachPendingListeners()
+        try {
+          setupWSConnection(ws, request, {
+            doc,
+            userId,
+            accessMode,
+            descriptor,
+            initialMessages,
+            persist: manualPersistenceHandler(accessMode, descriptor),
+            onDocumentUpdate: livePersistenceHandler(accessMode, descriptor),
+            onDocumentUpdateDebounceMs: SAVED_DOCUMENT_LIVE_PERSIST_DEBOUNCE_MS,
+          })
+          logger.info('Yjs connection established', { docId: yjsSessionId, userId })
+        } catch (error) {
+          rejectConnection(ws, error)
+        }
       }
     )
   })().catch((error) => {
-    wss.handleUpgrade(request, socket, head, (ws: WebSocket) => rejectConnection(ws, error))
+    if (!awaitingAdmission) return
+    abandonPendingMessages()
+    rejectConnection(ws, error)
   })
+}
+
+function copyWebSocketMessage(data: RawData): Uint8Array {
+  const bytes = Array.isArray(data)
+    ? Buffer.concat(data)
+    : data instanceof ArrayBuffer
+      ? new Uint8Array(data)
+      : data
+  return Uint8Array.from(bytes)
 }
 
 function yjsConnectionRejectionCode(error: unknown): number {

--- a/apps/tradinggoose/widgets/widgets/_shared/custom_tool/components/custom-tool-list-item.tsx
+++ b/apps/tradinggoose/widgets/widgets/_shared/custom_tool/components/custom-tool-list-item.tsx
@@ -26,6 +26,7 @@ interface CustomToolListItemProps {
   onDelete: (customToolId: string) => Promise<void>
   onRename: (customToolId: string, title: string) => Promise<void>
   canEdit: boolean
+  canDelete?: boolean
   isDeleting?: boolean
 }
 
@@ -38,6 +39,7 @@ export function CustomToolListItem({
   onDelete,
   onRename,
   canEdit,
+  canDelete = true,
   isDeleting = false,
 }: CustomToolListItemProps) {
   const locale = useLocale() as LocaleCode
@@ -108,7 +110,7 @@ export function CustomToolListItem({
   }
 
   const handleConfirmDelete = async () => {
-    if (isDeleting) return
+    if (isDeleting || !canDelete) return
     try {
       await onDelete(tool.id)
       setShowDeleteDialog(false)
@@ -207,16 +209,18 @@ export function CustomToolListItem({
               <Pencil className='!h-3.5 !w-3.5' />
               <span className='sr-only'>{copy.renameCustomTool}</span>
             </Button>
-            <Button
-              variant='ghost'
-              size='icon'
-              onClick={() => setShowDeleteDialog(true)}
-              disabled={isDeleting}
-              className='h-4 w-4 p-0 text-muted-foreground transition-colors hover:bg-transparent hover:text-foreground disabled:opacity-50'
-            >
-              <Trash2 className='!h-3.5 !w-3.5' />
-              <span className='sr-only'>{copy.deleteCustomTool}</span>
-            </Button>
+            {canDelete && (
+              <Button
+                variant='ghost'
+                size='icon'
+                onClick={() => setShowDeleteDialog(true)}
+                disabled={isDeleting}
+                className='h-4 w-4 p-0 text-muted-foreground transition-colors hover:bg-transparent hover:text-foreground disabled:opacity-50'
+              >
+                <Trash2 className='!h-3.5 !w-3.5' />
+                <span className='sr-only'>{copy.deleteCustomTool}</span>
+              </Button>
+            )}
           </div>
         )}
       </div>

--- a/apps/tradinggoose/widgets/widgets/_shared/skill/components/skill-list-item.tsx
+++ b/apps/tradinggoose/widgets/widgets/_shared/skill/components/skill-list-item.tsx
@@ -25,6 +25,7 @@ interface SkillListItemProps {
   onDelete: (skillId: string) => Promise<void>
   onRename: (skillId: string, name: string) => Promise<void>
   canEdit: boolean
+  canDelete?: boolean
   isDeleting?: boolean
 }
 
@@ -35,6 +36,7 @@ export function SkillListItem({
   onDelete,
   onRename,
   canEdit,
+  canDelete = true,
   isDeleting = false,
 }: SkillListItemProps) {
   const locale = useLocale()
@@ -105,7 +107,7 @@ export function SkillListItem({
   }
 
   const handleConfirmDelete = async () => {
-    if (isDeleting) return
+    if (isDeleting || !canDelete) return
     try {
       await onDelete(skill.id)
       setShowDeleteDialog(false)
@@ -204,16 +206,18 @@ export function SkillListItem({
               <Pencil className='!h-3.5 !w-3.5' />
               <span className='sr-only'>{copy.renameSkill}</span>
             </Button>
-            <Button
-              variant='ghost'
-              size='icon'
-              onClick={() => setShowDeleteDialog(true)}
-              disabled={isDeleting}
-              className='h-4 w-4 p-0 text-muted-foreground transition-colors hover:bg-transparent hover:text-foreground disabled:opacity-50'
-            >
-              <Trash2 className='!h-3.5 !w-3.5' />
-              <span className='sr-only'>{copy.deleteSkill}</span>
-            </Button>
+            {canDelete && (
+              <Button
+                variant='ghost'
+                size='icon'
+                onClick={() => setShowDeleteDialog(true)}
+                disabled={isDeleting}
+                className='h-4 w-4 p-0 text-muted-foreground transition-colors hover:bg-transparent hover:text-foreground disabled:opacity-50'
+              >
+                <Trash2 className='!h-3.5 !w-3.5' />
+                <span className='sr-only'>{copy.deleteSkill}</span>
+              </Button>
+            )}
           </div>
         )}
       </div>

--- a/apps/tradinggoose/widgets/widgets/data_chart/components/chart-body.tsx
+++ b/apps/tradinggoose/widgets/widgets/data_chart/components/chart-body.tsx
@@ -78,7 +78,6 @@ export const DataChartWidgetBody = ({ params, context, panelId, widget }: Widget
     : ''
   const { listing, listingIdentitySignature, resolvedListing, isResolving } = useListingState({
     listingValue,
-    intervalLabel,
   })
   const listingLabel = useMemo(() => {
     if (resolvedListing) {

--- a/apps/tradinggoose/widgets/widgets/data_chart/hooks/use-listing-state.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/data_chart/hooks/use-listing-state.test.tsx
@@ -1,0 +1,132 @@
+/** @vitest-environment jsdom */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ListingIdentity, ListingInputValue, ListingOption } from '@/lib/listing/identity'
+import { type ListingState, useListingState } from './use-listing-state'
+
+const mockResolve = vi.hoisted(() => vi.fn())
+
+vi.mock('@/components/listing-selector/selector/resolve-request', () => ({
+  requestListingResolution: mockResolve,
+}))
+
+const APPLE_IDENTITY: ListingIdentity = {
+  listing_id: 'AAPL',
+  base_id: '',
+  quote_id: '',
+  listing_type: 'default',
+}
+const APPLE_OPTION: ListingOption = {
+  ...APPLE_IDENTITY,
+  base: 'AAPL',
+  quote: null,
+  name: 'Apple Inc.',
+}
+const MSFT_IDENTITY: ListingIdentity = {
+  listing_id: 'MSFT',
+  base_id: '',
+  quote_id: '',
+  listing_type: 'default',
+}
+const MSFT_OPTION: ListingOption = {
+  ...MSFT_IDENTITY,
+  base: 'MSFT',
+  quote: null,
+  name: 'Microsoft Corp.',
+}
+
+let latest: ListingState
+function Harness({ listingValue }: { listingValue: ListingInputValue }) {
+  latest = useListingState({ listingValue })
+  return null
+}
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean
+}
+
+describe('useListingState', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let pending: Array<(value: ListingOption | null) => void>
+
+  beforeEach(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+    pending = []
+    mockResolve.mockReset()
+    mockResolve.mockImplementation(
+      () => new Promise<ListingOption | null>((resolve) => pending.push(resolve))
+    )
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = false
+  })
+
+  const render = async (listingValue: ListingInputValue) => {
+    await act(async () => {
+      root.render(<Harness listingValue={listingValue} />)
+    })
+  }
+
+  const settleNextResolution = async (value: ListingOption | null) => {
+    await act(async () => {
+      pending.shift()?.(value)
+      await Promise.resolve()
+    })
+  }
+
+  it('resolves the identity into full listing details', async () => {
+    await render(APPLE_IDENTITY)
+    expect(latest.isResolving).toBe(true)
+    expect(latest.resolvedListing).toBeNull()
+    expect(mockResolve).toHaveBeenCalledTimes(1)
+
+    await settleNextResolution(APPLE_OPTION)
+    expect(latest.isResolving).toBe(false)
+    expect(latest.resolvedListing).toEqual(APPLE_OPTION)
+  })
+
+  it('does not cancel or restart an in-flight resolution when the listing value is a new object for the same identity', async () => {
+    await render(APPLE_IDENTITY)
+    expect(mockResolve).toHaveBeenCalledTimes(1)
+
+    // A fresh object with an identical identity — mirrors Yjs-backed widget
+    // params handing `params.listing` a new reference on unrelated updates.
+    await render({ ...APPLE_IDENTITY })
+    expect(mockResolve).toHaveBeenCalledTimes(1)
+
+    await settleNextResolution(APPLE_OPTION)
+    expect(latest.isResolving).toBe(false)
+    expect(latest.resolvedListing).toEqual(APPLE_OPTION)
+  })
+
+  it('re-resolves when the identity actually changes', async () => {
+    await render(APPLE_IDENTITY)
+    await settleNextResolution(APPLE_OPTION)
+    expect(latest.resolvedListing).toEqual(APPLE_OPTION)
+
+    await render(MSFT_IDENTITY)
+    expect(mockResolve).toHaveBeenCalledTimes(2)
+    expect(latest.isResolving).toBe(true)
+    expect(latest.resolvedListing).toBeNull()
+
+    await settleNextResolution(MSFT_OPTION)
+    expect(latest.resolvedListing).toEqual(MSFT_OPTION)
+  })
+
+  it('reports no resolution work when there is no listing', async () => {
+    await render(null)
+    expect(latest.isResolving).toBe(false)
+    expect(latest.resolvedListing).toBeNull()
+    expect(latest.listingIdentitySignature).toBeNull()
+    expect(mockResolve).not.toHaveBeenCalled()
+  })
+})

--- a/apps/tradinggoose/widgets/widgets/data_chart/hooks/use-listing-state.ts
+++ b/apps/tradinggoose/widgets/widgets/data_chart/hooks/use-listing-state.ts
@@ -3,17 +3,15 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { requestListingResolution } from '@/components/listing-selector/selector/resolve-request'
 import {
-  areListingIdentitiesEqual,
+  getListingIdentityKey,
   type ListingIdentity,
   type ListingInputValue,
   type ListingOption,
   toListingValueObject,
 } from '@/lib/listing/identity'
-import { buildListingDisplay, getFlagData } from '@/widgets/widgets/data_chart/utils/listing-utils'
 
 type UseListingStateArgs = {
   listingValue: ListingInputValue
-  intervalLabel?: string | null
 }
 
 export type ListingState = {
@@ -21,189 +19,77 @@ export type ListingState = {
   listingIdentitySignature: string | null
   resolvedListing: ListingOption | null
   isResolving: boolean
-  tooltipTitle: string
 }
 
-const getListingDetailsFromValue = (listingValue: ListingInputValue) => {
-  if (!listingValue || typeof listingValue !== 'object') return null
-  const candidate = listingValue as ListingOption
-  if (!hasResolvedListingDetails(candidate)) return null
-  return candidate
+const RESOLVE_RETRY_MS = 1000
+
+type ResolvedEntry = {
+  signature: string
+  listing: ListingOption
 }
 
-const hasResolvedListingDetails = (listing?: ListingOption | null): boolean => {
-  if (!listing) return false
-  const base = listing.base?.trim()
-  if (!base) return false
-  if (listing.listing_type === 'default') return true
-  const quote = listing.quote?.trim()
-  return Boolean(quote)
-}
+/**
+ * Resolves a widget-param listing identity into full listing details.
+ *
+ * `params.listing` is always the minimal `ListingIdentity` (the widget contract
+ * normalizes it), so the only source of display details is the market
+ * resolution endpoint. Resolution is keyed on the stable identity *signature*
+ * string — not on the identity object reference — so unrelated widget-param
+ * re-renders (view/interval/live bars/drawings churn) never cancel or restart
+ * an in-flight resolution.
+ */
+export const useListingState = ({ listingValue }: UseListingStateArgs): ListingState => {
+  const listing = useMemo(() => toListingValueObject(listingValue), [listingValue])
+  const listingIdentitySignature = listing ? getListingIdentityKey(listing) : null
 
-export const useListingState = ({
-  listingValue,
-  intervalLabel,
-}: UseListingStateArgs): ListingState => {
-  const [resolvedListingState, setResolvedListing] = useState<ListingOption | null>(null)
-  const [isResolving, setIsResolving] = useState(false)
-  const listingResolveRef = useRef(0)
-  const hydratedListingRef = useRef<ListingIdentity | null>(null)
-  const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const listingIdentityRef = useRef<ListingIdentity | null>(null)
+  const [resolved, setResolved] = useState<ResolvedEntry | null>(null)
 
-  const listingIdentity = useMemo(() => {
-    if (!listingValue || typeof listingValue !== 'object') return null
-    return toListingValueObject(listingValue)
-  }, [listingValue])
-
-  const listing = listingIdentity ?? null
-  const listingIdentitySignature = useMemo(() => {
-    if (!listingIdentity) return null
-    return `${listingIdentity.listing_type}|${listingIdentity.listing_id}|${listingIdentity.base_id}|${listingIdentity.quote_id}`
-  }, [listingIdentity])
-
-  const listingDetailsFromValue = useMemo(
-    () => getListingDetailsFromValue(listingValue),
-    [listingValue]
-  )
+  // The effect below is keyed on `listingIdentitySignature` (a value-stable
+  // string). This ref hands it the current identity object without adding an
+  // unstable dependency that would re-run — and cancel — resolution on every
+  // param re-render.
+  const listingRef = useRef<ListingIdentity | null>(listing)
+  listingRef.current = listing
 
   useEffect(() => {
-    if (
-      listingIdentity &&
-      !areListingIdentitiesEqual(listingIdentityRef.current, listingIdentity)
-    ) {
-      listingIdentityRef.current = listingIdentity
-    }
-
-    const activeIdentity = listingIdentityRef.current
-    if (!activeIdentity || !listingIdentitySignature) {
-      setResolvedListing(null)
-      setIsResolving(false)
-      hydratedListingRef.current = null
-      if (retryTimeoutRef.current) {
-        clearTimeout(retryTimeoutRef.current)
-        retryTimeoutRef.current = null
-      }
-      return
-    }
-
-    if (listingDetailsFromValue) {
-      setResolvedListing(listingDetailsFromValue)
-      setIsResolving(false)
-      hydratedListingRef.current = activeIdentity
-      if (retryTimeoutRef.current) {
-        clearTimeout(retryTimeoutRef.current)
-        retryTimeoutRef.current = null
-      }
-      return
-    }
-
-    setResolvedListing(null)
+    const identity = listingRef.current
+    if (!listingIdentitySignature || !identity) return
 
     let cancelled = false
-    const retryDelayMs = 1000
+    let retryTimer: ReturnType<typeof setTimeout> | null = null
 
-    const scheduleRetry = () => {
-      if (cancelled) return
-      if (retryTimeoutRef.current) {
-        clearTimeout(retryTimeoutRef.current)
-      }
-      retryTimeoutRef.current = setTimeout(() => {
-        runResolve()
-      }, retryDelayMs)
-    }
-
-    const runResolve = () => {
-      if (cancelled) return
-      setIsResolving(true)
-      const requestId = ++listingResolveRef.current
-      requestListingResolution(activeIdentity)
-        .then((resolved) => {
-          if (cancelled || listingResolveRef.current !== requestId) return
-          if (resolved) {
-            setResolvedListing(resolved)
-            setIsResolving(false)
-            if (retryTimeoutRef.current) {
-              clearTimeout(retryTimeoutRef.current)
-              retryTimeoutRef.current = null
-            }
+    const run = () => {
+      requestListingResolution(identity)
+        .then((result) => {
+          if (cancelled) return
+          if (result) {
+            setResolved({ signature: listingIdentitySignature, listing: result })
             return
           }
-          scheduleRetry()
+          retryTimer = setTimeout(run, RESOLVE_RETRY_MS)
         })
         .catch(() => {
-          if (cancelled || listingResolveRef.current !== requestId) return
-          scheduleRetry()
+          if (cancelled) return
+          retryTimer = setTimeout(run, RESOLVE_RETRY_MS)
         })
     }
 
-    if (!areListingIdentitiesEqual(hydratedListingRef.current, activeIdentity)) {
-      hydratedListingRef.current = activeIdentity
-      if (retryTimeoutRef.current) {
-        clearTimeout(retryTimeoutRef.current)
-        retryTimeoutRef.current = null
-      }
-      runResolve()
-    }
+    run()
 
     return () => {
       cancelled = true
-      if (retryTimeoutRef.current) {
-        clearTimeout(retryTimeoutRef.current)
-        retryTimeoutRef.current = null
-      }
+      if (retryTimer) clearTimeout(retryTimer)
     }
-  }, [listingDetailsFromValue, listingIdentity, listingIdentitySignature])
+  }, [listingIdentitySignature])
 
-  const resolvedListingIdentity = useMemo(
-    () => toListingValueObject(resolvedListingState),
-    [resolvedListingState]
-  )
-  const displayListing = useMemo(() => {
-    if (listingDetailsFromValue) return listingDetailsFromValue
-    if (!listingIdentity || !resolvedListingState) return null
-    if (
-      resolvedListingIdentity &&
-      !areListingIdentitiesEqual(resolvedListingIdentity, listingIdentity)
-    ) {
-      return null
-    }
-    return resolvedListingState
-  }, [listingDetailsFromValue, listingIdentity, resolvedListingIdentity, resolvedListingState])
-
-  const listingType = displayListing?.listing_type ?? listingIdentity?.listing_type
-  const { listingSymbolText, listingName } = useMemo(
-    () => buildListingDisplay(displayListing),
-    [displayListing]
-  )
-  const flagData = useMemo(
-    () => (listingType === 'default' ? getFlagData(displayListing?.countryCode) : null),
-    [displayListing?.countryCode, listingType]
-  )
-  const overlayLabel = useMemo(() => {
-    let text = listingSymbolText
-    if (listingName && listingName !== listingSymbolText) {
-      text = `${text} - ${listingName}`
-    }
-    return text
-  }, [listingName, listingSymbolText])
-  const tooltipLabel = useMemo(() => {
-    if (listingType === 'default' && flagData?.emoji) {
-      return `${overlayLabel} ${flagData.emoji}`
-    }
-    return overlayLabel
-  }, [flagData?.emoji, listingType, overlayLabel])
-  const intervalText = intervalLabel ?? ''
-  const tooltipTitle = useMemo(() => {
-    if (!intervalText) return tooltipLabel
-    return `${tooltipLabel} - ${intervalText}`
-  }, [intervalText, tooltipLabel])
+  const resolvedListing =
+    resolved && resolved.signature === listingIdentitySignature ? resolved.listing : null
+  const isResolving = Boolean(listingIdentitySignature) && !resolvedListing
 
   return {
     listing,
     listingIdentitySignature,
-    resolvedListing: displayListing,
+    resolvedListing,
     isResolving,
-    tooltipTitle,
   }
 }

--- a/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-editor/panel/node-editor-panel.tsx
+++ b/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-editor/panel/node-editor-panel.tsx
@@ -45,6 +45,11 @@ const PARALLEL_TYPE_OPTIONS: Array<{ value: ParallelType; label: string }> = [
 const panelClassName =
   'allow-scroll !m-2 max-h-[calc(100%-1rem)] min-w-0 w-[calc(100%-1rem)] max-w-96 overflow-y-auto rounded-lg border bg-card shadow-md'
 
+// React Flow's `.react-flow__panel` hard-codes `z-index: 5`; FloatingControls sits
+// at `z-10` in the same stacking context. An inline style is the reliable way to
+// lift the panel above it (beats the class rule, needs no Tailwind class generation).
+const panelStyle = { zIndex: 20 }
+
 export function NodeEditorPanel({ selectedNodeId }: NodeEditorPanelProps) {
   const { workflowEditorCopy, workflowInspectorCopy } = useWorkflowI18n()
   const canEdit = useOptionalWorkflowSession()?.canEdit === true
@@ -359,6 +364,7 @@ export function NodeEditorPanel({ selectedNodeId }: NodeEditorPanelProps) {
     return (
       <Panel
         position='top-right'
+        style={panelStyle}
         className={`${panelClassName} p-4`}
         onMouseDown={stopPanelEvent}
         onPointerDown={stopPanelEvent}
@@ -377,6 +383,7 @@ export function NodeEditorPanel({ selectedNodeId }: NodeEditorPanelProps) {
     return (
       <Panel
         position='top-right'
+        style={panelStyle}
         className={`${panelClassName} p-4`}
         onMouseDown={stopPanelEvent}
         onPointerDown={stopPanelEvent}
@@ -396,6 +403,7 @@ export function NodeEditorPanel({ selectedNodeId }: NodeEditorPanelProps) {
   return (
     <Panel
       position='top-right'
+      style={panelStyle}
       className={`${panelClassName} px-4 pb-4`}
       onMouseDown={stopPanelEvent}
       onPointerDown={stopPanelEvent}

--- a/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-editor/workflow-canvas.tsx
+++ b/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-editor/workflow-canvas.tsx
@@ -1608,11 +1608,6 @@ const WorkflowCanvas = React.memo(
             />
           )}
 
-          {/* Floating Controls (Zoom, Undo, Redo) */}
-          {uiConfig.floatingControls && (
-            <FloatingControls constrainToContainer={Boolean(viewportBounds)} />
-          )}
-
           <ReactFlow
             id={reactFlowId}
             nodes={nodes}
@@ -1668,6 +1663,11 @@ const WorkflowCanvas = React.memo(
             }}
           >
             <Background bgColor='transparent' color='hsl(var(--workflow-dots))' size={4} gap={40} />
+            {/* Floating Controls (Zoom, Undo, Redo) — rendered inside ReactFlow so it shares the
+                same stacking context as NodeEditorPanel, which sits above it via its higher z-index. */}
+            {uiConfig.floatingControls && (
+              <FloatingControls constrainToContainer={Boolean(viewportBounds)} />
+            )}
             <NodeEditorPanel selectedNodeId={resolvedSelectedNodeId} />
           </ReactFlow>
 

--- a/apps/tradinggoose/widgets/widgets/list_custom_tool/index.tsx
+++ b/apps/tradinggoose/widgets/widgets/list_custom_tool/index.tsx
@@ -381,6 +381,7 @@ function ListCustomToolWidgetBodyInner({
               onDelete={handleDeleteTool}
               onRename={handleRenameTool}
               canEdit={permissions.canEdit}
+              canDelete={tools.length > 1}
               isDeleting={deletingToolIds.has(tool.id)}
             />
           ))}

--- a/apps/tradinggoose/widgets/widgets/list_indicator/components/indicator-list/components/indicator-list-item.tsx
+++ b/apps/tradinggoose/widgets/widgets/list_indicator/components/indicator-list/components/indicator-list-item.tsx
@@ -26,6 +26,7 @@ interface IndicatorListItemProps {
   onDelete: (indicatorId: string) => Promise<void>
   onRename: (indicatorId: string, name: string) => Promise<void>
   canEdit: boolean
+  canDelete?: boolean
   isCopying: boolean
   isDeleting: boolean
 }
@@ -38,6 +39,7 @@ export function IndicatorListItem({
   onDelete,
   onRename,
   canEdit,
+  canDelete = true,
   isCopying,
   isDeleting,
 }: IndicatorListItemProps) {
@@ -109,7 +111,7 @@ export function IndicatorListItem({
   }
 
   const handleConfirmDelete = async () => {
-    if (isDeleting) return
+    if (isDeleting || !canDelete) return
     try {
       await onDelete(indicator.entityId)
       setShowDeleteDialog(false)
@@ -232,16 +234,18 @@ export function IndicatorListItem({
               <Pencil className='!h-3.5 !w-3.5' />
               <span className='sr-only'>{copy.renameIndicator}</span>
             </Button>
-            <Button
-              variant='ghost'
-              size='icon'
-              onClick={() => setShowDeleteDialog(true)}
-              disabled={isDeleting}
-              className='h-4 w-4 p-0 text-muted-foreground transition-colors hover:bg-transparent hover:text-foreground disabled:opacity-50'
-            >
-              <Trash2 className='!h-3.5 !w-3.5' />
-              <span className='sr-only'>{copy.deleteIndicator}</span>
-            </Button>
+            {canDelete && (
+              <Button
+                variant='ghost'
+                size='icon'
+                onClick={() => setShowDeleteDialog(true)}
+                disabled={isDeleting}
+                className='h-4 w-4 p-0 text-muted-foreground transition-colors hover:bg-transparent hover:text-foreground disabled:opacity-50'
+              >
+                <Trash2 className='!h-3.5 !w-3.5' />
+                <span className='sr-only'>{copy.deleteIndicator}</span>
+              </Button>
+            )}
           </div>
         )}
       </div>

--- a/apps/tradinggoose/widgets/widgets/list_indicator/components/indicator-list/indicator-list.tsx
+++ b/apps/tradinggoose/widgets/widgets/list_indicator/components/indicator-list/indicator-list.tsx
@@ -168,6 +168,7 @@ export function IndicatorList({
               onDelete={handleDelete}
               onRename={handleRename}
               canEdit={permissions.canEdit}
+              canDelete={members.length > 1}
               isCopying={copyingIds.has(indicator.entityId)}
               isDeleting={deletingIds.has(indicator.entityId)}
             />

--- a/apps/tradinggoose/widgets/widgets/list_mcp/index.tsx
+++ b/apps/tradinggoose/widgets/widgets/list_mcp/index.tsx
@@ -310,6 +310,7 @@ const ListMcpWidgetContent = ({
               onRename={handleRenameServer}
               onDelete={handleDeleteServer}
               canEdit={permissions.canEdit}
+              canDelete={workspaceServers.length > 1}
               isDeleting={deletingIds.has(server.id)}
             />
           ))}
@@ -326,6 +327,7 @@ const McpServerListItem = ({
   onRename,
   onDelete,
   canEdit,
+  canDelete = true,
   isDeleting,
 }: {
   server: McpServerListEntry
@@ -334,6 +336,7 @@ const McpServerListItem = ({
   onRename: (serverId: string, name: string) => Promise<void>
   onDelete: (serverId: string) => void | Promise<void>
   canEdit: boolean
+  canDelete?: boolean
   isDeleting: boolean
 }) => {
   const copy = useMessages().workspace.widgets.mcpList.listItem
@@ -403,13 +406,14 @@ const McpServerListItem = ({
   }
 
   const handleConfirmDelete = useCallback(async () => {
+    if (!canDelete) return
     try {
       await Promise.resolve(onDelete(server.id))
       setShowDeleteDialog(false)
     } catch (error) {
       console.error('Failed to delete MCP server', error)
     }
-  }, [onDelete, server.id])
+  }, [canDelete, onDelete, server.id])
 
   return (
     <div className='mb-1'>
@@ -500,16 +504,18 @@ const McpServerListItem = ({
               <Pencil className='!h-3.5 !w-3.5' />
               <span className='sr-only'>{copy.renameMcpServer}</span>
             </Button>
-            <Button
-              variant='ghost'
-              size='icon'
-              onClick={() => setShowDeleteDialog(true)}
-              disabled={isDeleting}
-              className='h-4 w-4 p-0 text-muted-foreground transition-colors hover:bg-transparent hover:text-foreground disabled:opacity-50'
-            >
-              <Trash2 className='!h-3.5 !w-3.5' />
-              <span className='sr-only'>{copy.deleteMcpServer}</span>
-            </Button>
+            {canDelete && (
+              <Button
+                variant='ghost'
+                size='icon'
+                onClick={() => setShowDeleteDialog(true)}
+                disabled={isDeleting}
+                className='h-4 w-4 p-0 text-muted-foreground transition-colors hover:bg-transparent hover:text-foreground disabled:opacity-50'
+              >
+                <Trash2 className='!h-3.5 !w-3.5' />
+                <span className='sr-only'>{copy.deleteMcpServer}</span>
+              </Button>
+            )}
           </div>
         )}
       </div>

--- a/apps/tradinggoose/widgets/widgets/list_skill/components/skill-list/skill-list.tsx
+++ b/apps/tradinggoose/widgets/widgets/list_skill/components/skill-list/skill-list.tsx
@@ -129,6 +129,7 @@ export function SkillList({ context, params, onWidgetLinkedParamsPatch }: Widget
               onDelete={handleDelete}
               onRename={handleRename}
               canEdit={permissions.canEdit}
+              canDelete={listSkills.length > 1}
               isDeleting={deletingIds.has(skill.id)}
             />
           ))}

--- a/apps/tradinggoose/widgets/widgets/watchlist/components/watchlist-header-controls.tsx
+++ b/apps/tradinggoose/widgets/widgets/watchlist/components/watchlist-header-controls.tsx
@@ -2,7 +2,6 @@
 
 import {
   type ChangeEvent,
-  Fragment,
   type KeyboardEvent,
   useCallback,
   useEffect,
@@ -35,6 +34,8 @@ import {
   widgetHeaderControlClassName,
   widgetHeaderIconButtonClassName,
   widgetHeaderMenuContentClassName,
+  widgetHeaderMenuIconClassName,
+  widgetHeaderMenuItemClassName,
   widgetHeaderMenuTextClassName,
 } from '@/components/widget-header-control'
 import { type ListingOption, toListingValue } from '@/lib/listing/identity'
@@ -370,7 +371,6 @@ export const WatchlistHeaderRightControls = ({
   const { canEdit, isLoading: isPermissionsLoading } = useUserPermissionsContext()
   const canMutateWatchlist = !isPermissionsLoading && canEdit
   const [listDropdownOpen, setListDropdownOpen] = useState(false)
-  const [listActionsOpen, setListActionsOpen] = useState(false)
   const [editingListId, setEditingListId] = useState<string | null>(null)
   const [renamingListValue, setRenamingListValue] = useState('')
   const [listToDelete, setListToDelete] = useState<WatchlistListOption | null>(null)
@@ -407,6 +407,8 @@ export const WatchlistHeaderRightControls = ({
   const canMutateSelectedWatchlist = canMutateWatchlist && selectedDocument.canMutateDocument
   const canManageContainers = canMutateSelectedWatchlist && hasSelectedWatchlist
   const isMutating = Boolean(pendingAction)
+  const listRowActionButtonClassName =
+    'flex h-5 w-5 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50'
 
   const handleSelectList = (watchlistId: string | null) => {
     if (!canEditWidgetParams) return
@@ -430,7 +432,7 @@ export const WatchlistHeaderRightControls = ({
   }
 
   const startRenameList = (option: WatchlistListOption) => {
-    if (!canMutateSelectedWatchlist || option.id !== selectedWatchlist?.id || isMutating) return
+    if (!canMutateWatchlist || isMutating) return
     setEditingListId(option.id)
     setRenamingListValue(option.name)
   }
@@ -492,19 +494,17 @@ export const WatchlistHeaderRightControls = ({
   }
 
   const commitListRename = async () => {
-    if (
-      !canMutateSelectedWatchlist ||
-      !workspaceId ||
-      !editingListId ||
-      !selectedWatchlist ||
-      editingListId !== selectedWatchlist.id
-    ) {
+    const optionBeingRenamed = editingListId
+      ? (listOptions.find((option) => option.id === editingListId) ?? null)
+      : null
+
+    if (!canMutateWatchlist || !workspaceId || !editingListId || !optionBeingRenamed) {
       cancelListRename()
       return
     }
 
     const nextName = renamingListValue.trim()
-    if (!nextName || nextName === selectedWatchlist.name) {
+    if (!nextName || nextName === optionBeingRenamed.name) {
       cancelListRename()
       return
     }
@@ -513,7 +513,7 @@ export const WatchlistHeaderRightControls = ({
       setPendingAction('rename-list')
       await renameSavedEntityAction({
         entityKind: 'watchlist',
-        entityId: selectedWatchlist.id,
+        entityId: editingListId,
         workspaceId,
         name: nextName,
       })
@@ -528,14 +528,21 @@ export const WatchlistHeaderRightControls = ({
   const handleListRenameKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
       event.preventDefault()
+      event.stopPropagation()
       void commitListRename()
       return
     }
 
     if (event.key === 'Escape') {
       event.preventDefault()
+      event.stopPropagation()
       cancelListRename()
+      return
     }
+
+    // Keep the dropdown's typeahead and arrow-key navigation from stealing
+    // keystrokes while the inline rename input is focused.
+    event.stopPropagation()
   }
 
   useEffect(() => {
@@ -546,9 +553,9 @@ export const WatchlistHeaderRightControls = ({
 
   useEffect(() => {
     if (!editingListId) return
-    if (selectedWatchlist?.id === editingListId) return
+    if (listOptions.some((option) => option.id === editingListId)) return
     cancelListRename()
-  }, [editingListId, selectedWatchlist?.id])
+  }, [editingListId, listOptions])
 
   const handleImportClick = () => {
     if (canMutateSelectedWatchlist) fileInputRef.current?.click()
@@ -716,99 +723,125 @@ export const WatchlistHeaderRightControls = ({
               sideOffset={6}
               className={cn(
                 widgetHeaderMenuContentClassName,
-                'max-h-[20rem] w-[240px] overflow-y-auto p-2 shadow-lg'
+                'max-h-[20rem] w-[240px] overflow-y-auto shadow-lg'
               )}
               onWheel={(event) => event.stopPropagation()}
             >
               {listOptions.map((option) => {
                 const isSelected = option.id === selectedOptionId
                 const optionColor = resolveWatchlistListColor(option)
+                const isEditingOption = editingListId === option.id
+
+                const optionBadge = (
+                  <span
+                    className='flex h-5 w-5 shrink-0 items-center justify-center rounded-xs p-0.5'
+                    style={{ backgroundColor: `${optionColor}20` }}
+                    aria-hidden='true'
+                  >
+                    <List className='h-4 w-4' aria-hidden='true' style={{ color: optionColor }} />
+                  </span>
+                )
+
+                if (isEditingOption) {
+                  return (
+                    <div
+                      key={option.id}
+                      className={cn(widgetHeaderMenuItemClassName, 'cursor-text')}
+                    >
+                      {optionBadge}
+                      <input
+                        ref={renameListInputRef}
+                        value={renamingListValue}
+                        onChange={(event) => setRenamingListValue(event.target.value)}
+                        onBlur={() => {
+                          void commitListRename()
+                        }}
+                        onKeyDown={handleListRenameKeyDown}
+                        onPointerDown={(event) => event.stopPropagation()}
+                        className='min-w-0 flex-1 border-0 bg-transparent p-0 font-medium font-sans text-foreground text-sm outline-none focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0'
+                        maxLength={100}
+                        disabled={!canMutateWatchlist || pendingAction === 'rename-list'}
+                        autoComplete='off'
+                        autoCorrect='off'
+                        autoCapitalize='off'
+                        spellCheck='false'
+                        aria-label={copy.header.renameList}
+                      />
+                    </div>
+                  )
+                }
 
                 return (
-                  <Fragment key={option.id}>
-                    <DropdownMenuItem
-                      onSelect={() => {
-                        selectListOption(option)
-                      }}
-                      className={cn(
-                        'flex h-8 items-center gap-2 font-medium font-sans text-sm',
-                        isSelected ? 'bg-secondary/60' : 'hover:bg-secondary/30'
-                      )}
-                    >
-                      <span
-                        className='flex h-5 w-5 shrink-0 items-center justify-center rounded-xs p-0.5'
-                        style={{ backgroundColor: `${optionColor}20` }}
-                        aria-hidden='true'
-                      >
-                        <List
-                          className='h-4 w-4'
-                          aria-hidden='true'
-                          style={{ color: optionColor }}
-                        />
-                      </span>
+                  <DropdownMenuItem
+                    key={option.id}
+                    data-active={isSelected ? '' : undefined}
+                    onSelect={() => {
+                      selectListOption(option)
+                    }}
+                    className={cn(
+                      widgetHeaderMenuItemClassName,
+                      'justify-between',
+                      isSelected
+                        ? 'bg-secondary/60 text-foreground hover:bg-secondary/60'
+                        : undefined
+                    )}
+                  >
+                    <div className='flex min-w-0 flex-1 items-center gap-2'>
+                      {optionBadge}
                       <span
                         className={cn(
-                          'min-w-0 flex-1 select-none truncate pr-1 font-medium font-sans text-sm',
                           widgetHeaderMenuTextClassName,
+                          'min-w-0 flex-1 select-none truncate',
                           isSelected ? 'text-foreground' : 'text-muted-foreground'
                         )}
                       >
                         {option.name}
                       </span>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      aria-label={`${copy.header.deleteList}: ${option.name}`}
-                      disabled={!canMutateWatchlist || isMutating}
-                      onSelect={() => {
-                        setListToDelete(option)
-                      }}
-                    >
-                      <Trash2 className='h-3.5 w-3.5' aria-hidden='true' />
-                      {copy.header.deleteList}
-                      <span className='sr-only'> {option.name}</span>
-                    </DropdownMenuItem>
-                  </Fragment>
+                    </div>
+                    {canMutateWatchlist ? (
+                      <div className='pointer-events-none flex shrink-0 items-center gap-1 opacity-0 transition-opacity focus-within:pointer-events-auto focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100'>
+                        <button
+                          type='button'
+                          disabled={isMutating}
+                          className={listRowActionButtonClassName}
+                          onPointerDown={(event) => event.stopPropagation()}
+                          onClick={(event) => {
+                            event.preventDefault()
+                            event.stopPropagation()
+                            startRenameList(option)
+                          }}
+                        >
+                          <Pencil className={widgetHeaderMenuIconClassName} aria-hidden='true' />
+                          <span className='sr-only'>
+                            {copy.header.renameList}: {option.name}
+                          </span>
+                        </button>
+                        <button
+                          type='button'
+                          disabled={isMutating}
+                          className={listRowActionButtonClassName}
+                          onPointerDown={(event) => event.stopPropagation()}
+                          onClick={(event) => {
+                            event.preventDefault()
+                            event.stopPropagation()
+                            setListDropdownOpen(false)
+                            setListToDelete(option)
+                          }}
+                        >
+                          <Trash2 className={widgetHeaderMenuIconClassName} aria-hidden='true' />
+                          <span className='sr-only'>
+                            {copy.header.deleteList}: {option.name}
+                          </span>
+                        </button>
+                      </div>
+                    ) : null}
+                  </DropdownMenuItem>
                 )
               })}
-              {editingListId ? (
-                <div className='px-2 py-1'>
-                  <input
-                    ref={renameListInputRef}
-                    value={renamingListValue}
-                    onChange={(event) => setRenamingListValue(event.target.value)}
-                    onBlur={() => {
-                      void commitListRename()
-                    }}
-                    onKeyDown={handleListRenameKeyDown}
-                    className='w-full border-0 bg-transparent p-0 font-medium font-sans text-sm outline-none focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0'
-                    maxLength={100}
-                    disabled={!canMutateSelectedWatchlist || pendingAction === 'rename-list'}
-                    autoComplete='off'
-                    autoCorrect='off'
-                    autoCapitalize='off'
-                    spellCheck='false'
-                    aria-label={copy.header.renameList}
-                  />
-                </div>
-              ) : null}
-              {selectedOption ? (
-                <DropdownMenuItem
-                  disabled={!canMutateSelectedWatchlist || isMutating}
-                  onSelect={(event) => {
-                    event.preventDefault()
-                    startRenameList(selectedOption)
-                  }}
-                >
-                  <Pencil className='h-3.5 w-3.5' aria-hidden='true' />
-                  {copy.header.renameList}
-                </DropdownMenuItem>
-              ) : null}
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
         <WatchlistListActionsButton
-          open={listActionsOpen}
-          onOpenChange={setListActionsOpen}
           disabled={!workspaceId}
           createListDisabled={!canMutateWatchlist || !workspaceId || isMutating}
           createSectionDisabled={!workspaceId || !canManageContainers || isMutating}

--- a/apps/tradinggoose/widgets/widgets/watchlist/components/watchlist-header-controls.tsx
+++ b/apps/tradinggoose/widgets/widgets/watchlist/components/watchlist-header-controls.tsx
@@ -469,7 +469,14 @@ export const WatchlistHeaderRightControls = ({
 
   const handleConfirmRemoveList = async () => {
     const watchlistId = listToDelete?.id
-    if (!canMutateWatchlist || !workspaceId || !watchlistId || pendingAction) return
+    if (
+      !canMutateWatchlist ||
+      !workspaceId ||
+      !watchlistId ||
+      pendingAction ||
+      listOptions.length <= 1
+    )
+      return
 
     try {
       setPendingAction('delete-list')
@@ -816,23 +823,25 @@ export const WatchlistHeaderRightControls = ({
                             {copy.header.renameList}: {option.name}
                           </span>
                         </button>
-                        <button
-                          type='button'
-                          disabled={isMutating}
-                          className={listRowActionButtonClassName}
-                          onPointerDown={(event) => event.stopPropagation()}
-                          onClick={(event) => {
-                            event.preventDefault()
-                            event.stopPropagation()
-                            setListDropdownOpen(false)
-                            setListToDelete(option)
-                          }}
-                        >
-                          <Trash2 className={widgetHeaderMenuIconClassName} aria-hidden='true' />
-                          <span className='sr-only'>
-                            {copy.header.deleteList}: {option.name}
-                          </span>
-                        </button>
+                        {listOptions.length > 1 && (
+                          <button
+                            type='button'
+                            disabled={isMutating}
+                            className={listRowActionButtonClassName}
+                            onPointerDown={(event) => event.stopPropagation()}
+                            onClick={(event) => {
+                              event.preventDefault()
+                              event.stopPropagation()
+                              setListDropdownOpen(false)
+                              setListToDelete(option)
+                            }}
+                          >
+                            <Trash2 className={widgetHeaderMenuIconClassName} aria-hidden='true' />
+                            <span className='sr-only'>
+                              {copy.header.deleteList}: {option.name}
+                            </span>
+                          </button>
+                        )}
                       </div>
                     ) : null}
                   </DropdownMenuItem>

--- a/apps/tradinggoose/widgets/widgets/watchlist/components/watchlist-header-controls.ui.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/watchlist/components/watchlist-header-controls.ui.test.tsx
@@ -456,8 +456,14 @@ describe('watchlist header controls', () => {
     expect(mockPatchWidgetLinkedParams).not.toHaveBeenCalled()
   })
 
-  it('clears the active widget link when its document is still loading', async () => {
+  it('re-points the active widget link after deleting the selected list while its document is still loading', async () => {
     isSelectedWatchlistDocumentReady = false
+    const secondWatchlist: WatchlistRecord = {
+      ...rootWatchlist,
+      id: 'watchlist-2',
+      name: 'Secondary',
+    }
+    currentWatchlists = [rootWatchlist, secondWatchlist]
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ success: true }), {
         status: 200,
@@ -501,6 +507,6 @@ describe('watchlist header controls', () => {
     })
 
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
-    expect(mockPatchWidgetLinkedParams).toHaveBeenCalledWith({ watchlistId: null })
+    expect(mockPatchWidgetLinkedParams).toHaveBeenCalledWith({ watchlistId: 'watchlist-2' })
   })
 })

--- a/apps/tradinggoose/widgets/widgets/watchlist/components/watchlist-header-controls.ui.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/watchlist/components/watchlist-header-controls.ui.test.tsx
@@ -178,6 +178,7 @@ vi.mock('@/components/widget-header-control', () => ({
     ['control', className].filter(Boolean).join(' '),
   widgetHeaderIconButtonClassName: () => 'icon-button',
   widgetHeaderMenuContentClassName: 'menu-content',
+  widgetHeaderMenuIconClassName: 'menu-icon',
   widgetHeaderMenuItemClassName: 'menu-item',
   widgetHeaderMenuTextClassName: 'menu-text',
 }))
@@ -479,9 +480,9 @@ describe('watchlist header controls', () => {
     })
 
     const deleteButton = await vi.waitFor(() => {
-      const button = Array.from(document.querySelectorAll<HTMLButtonElement>('button')).find(
-        (candidate) => /delete list/i.test(candidate.textContent ?? '')
-      )
+      const button = Array.from(document.querySelectorAll<HTMLButtonElement>('button'))
+        .filter((candidate) => !candidate.querySelector('button'))
+        .find((candidate) => /delete list/i.test(candidate.textContent ?? ''))
       expect(button).toBeTruthy()
       return button!
     })

--- a/apps/tradinggoose/widgets/widgets/watchlist/components/watchlist-list-actions-button.test.tsx
+++ b/apps/tradinggoose/widgets/widgets/watchlist/components/watchlist-list-actions-button.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 
-import type { ComponentProps, ReactNode } from 'react'
+import type { ButtonHTMLAttributes, ComponentProps, ReactNode } from 'react'
 import { act } from 'react'
 import { NextIntlClientProvider } from 'next-intl'
 import { createRoot, type Root } from 'react-dom/client'
@@ -10,50 +10,40 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import enMessages from '@/i18n/messages/en.json'
 import { WatchlistListActionsButton } from '@/widgets/widgets/watchlist/components/watchlist-list-actions-button'
 
-const popoverMocks = vi.hoisted(() => {
-  const state: {
-    contentProps: { onOpenAutoFocus?: (event: { preventDefault: () => void }) => void } | null
-  } = {
-    contentProps: null,
-  }
-  const Popover = ({ children }: { children: ReactNode }) => <div>{children}</div>
-  const PopoverTrigger = ({ children }: { children: ReactNode }) => <div>{children}</div>
-  const PopoverContent = ({
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+    <div data-testid='menu-content'>{children}</div>
+  ),
+  DropdownMenuItem: ({
     children,
+    onSelect,
     ...props
-  }: {
-    children: ReactNode
-    onOpenAutoFocus?: (event: { preventDefault: () => void }) => void
-  }) => {
-    state.contentProps = props
-    return <div data-testid='popover-content'>{children}</div>
-  }
-
-  return { Popover, PopoverTrigger, PopoverContent, state }
-})
-
-vi.mock('@/components/ui/popover', () => ({
-  Popover: popoverMocks.Popover,
-  PopoverTrigger: popoverMocks.PopoverTrigger,
-  PopoverContent: popoverMocks.PopoverContent,
+  }: ButtonHTMLAttributes<HTMLButtonElement> & { onSelect?: (event: Event) => void }) => (
+    <button type='button' {...props} onClick={(event) => onSelect?.(event.nativeEvent)}>
+      {children}
+    </button>
+  ),
 }))
 
 vi.mock('@/components/ui/tooltip', () => ({
   Tooltip: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  TooltipTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
   TooltipContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }))
 
 vi.mock('@/components/widget-header-control', () => ({
   widgetHeaderIconButtonClassName: () => 'icon-button',
+  widgetHeaderMenuContentClassName: 'menu-content',
+  widgetHeaderMenuIconClassName: 'menu-icon',
   widgetHeaderMenuItemClassName: 'menu-item',
+  widgetHeaderMenuTextClassName: 'menu-text',
 }))
 
 type WatchlistListActionsButtonTestProps = ComponentProps<typeof WatchlistListActionsButton>
 
 const createProps = (): WatchlistListActionsButtonTestProps => ({
-  open: true,
-  onOpenChange: vi.fn(),
   onCreateList: vi.fn(),
   onCreateSection: vi.fn(),
   onImport: vi.fn(),
@@ -65,7 +55,7 @@ const reactActEnvironment = globalThis as typeof globalThis & {
 }
 
 const getMenuButtons = (container: HTMLElement) =>
-  Array.from(container.querySelectorAll('[data-testid="popover-content"] button'))
+  Array.from(container.querySelectorAll('[data-testid="menu-content"] button'))
 
 const findMenuButton = (items: Element[], label: string) =>
   items.find((item) => item.textContent === label) as HTMLButtonElement | undefined
@@ -76,7 +66,6 @@ describe('WatchlistListActionsButton', () => {
 
   beforeEach(() => {
     reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true
-    popoverMocks.state.contentProps = null
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -98,35 +87,20 @@ describe('WatchlistListActionsButton', () => {
     })
   }
 
-  it('prevents popover auto-focus when opening list actions', () => {
+  it('renders the watchlist action set as dropdown menu items', () => {
     renderActionsButton()
-
-    const onOpenAutoFocus = popoverMocks.state.contentProps?.onOpenAutoFocus
-    expect(onOpenAutoFocus).toBeTypeOf('function')
-
-    const preventDefault = vi.fn()
-    onOpenAutoFocus?.({ preventDefault })
-
-    expect(preventDefault).toHaveBeenCalledOnce()
-  })
-
-  it('renders the reduced watchlist action set', () => {
-    const props = createProps()
-    renderActionsButton(props)
     const items = getMenuButtons(container)
 
     expect(items).toHaveLength(4)
-    expect(findMenuButton(items, 'Add Symbol')).toBeUndefined()
-    expect(findMenuButton(items, 'Clear list')).toBeUndefined()
     expect(findMenuButton(items, 'Create List')).toBeTruthy()
-    expect(findMenuButton(items, 'Rename List')).toBeUndefined()
     expect(findMenuButton(items, 'Create Section')).toBeTruthy()
     expect(findMenuButton(items, 'Import')).toBeTruthy()
     expect(findMenuButton(items, 'Export')).toBeTruthy()
+    expect(findMenuButton(items, 'Add Symbol')).toBeUndefined()
     expect(findMenuButton(items, 'Delete watchlist')).toBeUndefined()
   })
 
-  it('renders an icon-only trigger and closes menu before running create list action', () => {
+  it('renders an icon-only trigger and runs the create list action on select', () => {
     const props = createProps()
     renderActionsButton(props)
     const trigger = container.querySelector('button')
@@ -143,25 +117,26 @@ describe('WatchlistListActionsButton', () => {
       createListButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    expect(props.onOpenChange).toHaveBeenCalledWith(false)
     expect(props.onCreateList).toHaveBeenCalledOnce()
   })
 
-  it('hides disabled actions instead of rendering disabled menu buttons', () => {
-    renderActionsButton({
-      ...createProps(),
-      importDisabled: true,
-    })
-
+  it('shows disabled actions as disabled menu items instead of hiding them', () => {
+    const props = { ...createProps(), importDisabled: true }
+    renderActionsButton(props)
     const items = getMenuButtons(container)
 
-    expect(findMenuButton(items, 'Add Symbol')).toBeUndefined()
-    expect(findMenuButton(items, 'Import')).toBeUndefined()
-    expect(findMenuButton(items, 'Clear list')).toBeUndefined()
-    expect(findMenuButton(items, 'Delete watchlist')).toBeUndefined()
-    expect(findMenuButton(items, 'Create List')).toBeTruthy()
-    expect(findMenuButton(items, 'Create Section')).toBeTruthy()
-    expect(findMenuButton(items, 'Export')).toBeTruthy()
+    expect(items).toHaveLength(4)
+    const importButton = findMenuButton(items, 'Import')
+    expect(importButton?.disabled).toBe(true)
+    expect(findMenuButton(items, 'Create List')?.disabled).toBe(false)
+    expect(findMenuButton(items, 'Create Section')?.disabled).toBe(false)
+    expect(findMenuButton(items, 'Export')?.disabled).toBe(false)
+
+    act(() => {
+      importButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(props.onImport).not.toHaveBeenCalled()
   })
 
   it('disables the trigger when every action is unavailable', () => {
@@ -174,9 +149,9 @@ describe('WatchlistListActionsButton', () => {
     })
 
     const trigger = container.querySelector('button')
-    const content = container.querySelector('[data-testid="popover-content"]')
+    const items = getMenuButtons(container)
 
     expect(trigger?.disabled).toBe(true)
-    expect(content).toBeNull()
+    expect(items.every((item) => (item as HTMLButtonElement).disabled)).toBe(true)
   })
 })

--- a/apps/tradinggoose/widgets/widgets/watchlist/components/watchlist-list-actions-button.tsx
+++ b/apps/tradinggoose/widgets/widgets/watchlist/components/watchlist-list-actions-button.tsx
@@ -1,18 +1,24 @@
 'use client'
 
-import type { ReactNode } from 'react'
 import { Download, FileUp, FolderPlus, ListPlus, Plus } from 'lucide-react'
-import { useLocale, useMessages } from 'next-intl'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { useMessages } from 'next-intl'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   widgetHeaderIconButtonClassName,
+  widgetHeaderMenuContentClassName,
+  widgetHeaderMenuIconClassName,
   widgetHeaderMenuItemClassName,
+  widgetHeaderMenuTextClassName,
 } from '@/components/widget-header-control'
+import { cn } from '@/lib/utils'
 
 type WatchlistListActionsButtonProps = {
-  open: boolean
-  onOpenChange: (nextOpen: boolean) => void
   disabled?: boolean
   createListDisabled?: boolean
   createSectionDisabled?: boolean
@@ -24,16 +30,7 @@ type WatchlistListActionsButtonProps = {
   onExport: () => void
 }
 
-type VisibleAction = {
-  key: string
-  icon: ReactNode
-  label: string
-  onClick: () => void
-}
-
 export const WatchlistListActionsButton = ({
-  open,
-  onOpenChange,
   disabled = false,
   createListDisabled = false,
   createSectionDisabled = false,
@@ -44,91 +41,80 @@ export const WatchlistListActionsButton = ({
   onImport,
   onExport,
 }: WatchlistListActionsButtonProps) => {
-  const locale = useLocale()
   const copy = useMessages().workspace.widgets.watchlist.header
-  const closeAndRun = (action: () => void) => {
-    onOpenChange(false)
-    action()
-  }
 
-  const visibleActions: VisibleAction[] = []
-
-  if (!createListDisabled) {
-    visibleActions.push({
+  const actions = [
+    {
       key: 'create-list',
-      icon: <FolderPlus className='h-3.5 w-3.5' />,
+      icon: FolderPlus,
       label: copy.createList,
-      onClick: () => closeAndRun(onCreateList),
-    })
-  }
-
-  if (!createSectionDisabled) {
-    visibleActions.push({
+      disabled: createListDisabled,
+      handler: onCreateList,
+    },
+    {
       key: 'create-section',
-      icon: <ListPlus className='h-3.5 w-3.5' />,
+      icon: ListPlus,
       label: copy.createSection,
-      onClick: () => closeAndRun(onCreateSection),
-    })
-  }
-
-  if (!importDisabled) {
-    visibleActions.push({
+      disabled: createSectionDisabled,
+      handler: onCreateSection,
+    },
+    {
       key: 'import',
-      icon: <FileUp className='h-3.5 w-3.5' />,
+      icon: FileUp,
       label: copy.import,
-      onClick: () => closeAndRun(onImport),
-    })
-  }
-
-  if (!exportDisabled) {
-    visibleActions.push({
+      disabled: importDisabled,
+      handler: onImport,
+    },
+    {
       key: 'export',
-      icon: <Download className='h-3.5 w-3.5' />,
+      icon: Download,
       label: copy.export,
-      onClick: () => closeAndRun(onExport),
-    })
-  }
+      disabled: exportDisabled,
+      handler: onExport,
+    },
+  ]
 
-  const triggerDisabled = disabled || visibleActions.length === 0
+  const allDisabled = disabled || actions.every((action) => action.disabled)
 
   return (
-    <Popover open={open} onOpenChange={onOpenChange}>
+    <DropdownMenu>
       <Tooltip>
         <TooltipTrigger asChild>
           <span className='inline-flex'>
-            <PopoverTrigger asChild>
+            <DropdownMenuTrigger asChild>
               <button
                 type='button'
                 className={widgetHeaderIconButtonClassName()}
-                disabled={triggerDisabled}
+                disabled={allDisabled}
               >
                 <Plus className='h-3.5 w-3.5' />
                 <span className='sr-only'>{copy.listActionsAriaLabel}</span>
               </button>
-            </PopoverTrigger>
+            </DropdownMenuTrigger>
           </span>
         </TooltipTrigger>
         <TooltipContent side='top'>{copy.listActionsTooltip}</TooltipContent>
       </Tooltip>
-      {visibleActions.length > 0 ? (
-        <PopoverContent
-          align='end'
-          className='w-56 p-1'
-          onOpenAutoFocus={(event) => event.preventDefault()}
-        >
-          {visibleActions.map((action) => (
-            <button
-              key={action.key}
-              type='button'
-              className={widgetHeaderMenuItemClassName}
-              onClick={action.onClick}
-            >
-              {action.icon}
-              <span>{action.label}</span>
-            </button>
-          ))}
-        </PopoverContent>
-      ) : null}
-    </Popover>
+      <DropdownMenuContent
+        align='end'
+        sideOffset={6}
+        className={cn(widgetHeaderMenuContentClassName, 'w-56 p-1')}
+      >
+        {actions.map(({ key, icon: Icon, label, disabled: actionDisabled, handler }) => (
+          <DropdownMenuItem
+            key={key}
+            className={widgetHeaderMenuItemClassName}
+            disabled={actionDisabled}
+            onSelect={() => {
+              if (actionDisabled) return
+              handler()
+            }}
+          >
+            <Icon className={widgetHeaderMenuIconClassName} aria-hidden='true' />
+            <span className={widgetHeaderMenuTextClassName}>{label}</span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }

--- a/apps/tradinggoose/widgets/widgets/watchlist/components/watchlist-table.tsx
+++ b/apps/tradinggoose/widgets/widgets/watchlist/components/watchlist-table.tsx
@@ -843,27 +843,35 @@ export const WatchlistTable = ({
             handleMove(active.id, over ? resolveOverSortableId(active, over) : null)
           }}
         >
-          <table className='w-full table-auto'>
+          <table className='w-full min-w-[720px] table-fixed'>
+            <colgroup>
+              <col />
+              <col className='w-28' />
+              <col className='w-28' />
+              <col className='w-28' />
+              <col className='w-28' />
+              <col className='w-24' />
+            </colgroup>
             <thead className='sticky top-0 z-10 border-b bg-card'>
               <tr>
-                <th className='px-4 pt-2 pb-3 text-center align-middle font-medium'>
+                <th className='whitespace-nowrap px-4 pt-2 pb-3 text-center align-middle font-medium'>
                   <span className='text-muted-foreground text-xs leading-none'>{copy.symbol}</span>
                 </th>
-                <th className='px-4 pt-2 pb-3 text-center align-middle font-medium'>
+                <th className='whitespace-nowrap px-4 pt-2 pb-3 text-center align-middle font-medium'>
                   <span className='text-muted-foreground text-xs leading-none'>{copy.asset}</span>
                 </th>
-                <th className='px-4 pt-2 pb-3 text-center align-middle font-medium'>
+                <th className='whitespace-nowrap px-4 pt-2 pb-3 text-center align-middle font-medium'>
                   <span className='text-muted-foreground text-xs leading-none'>{copy.last}</span>
                 </th>
-                <th className='px-4 pt-2 pb-3 text-center align-middle font-medium'>
+                <th className='whitespace-nowrap px-4 pt-2 pb-3 text-center align-middle font-medium'>
                   <span className='text-muted-foreground text-xs leading-none'>{copy.change}</span>
                 </th>
-                <th className='px-4 pt-2 pb-3 text-center align-middle font-medium'>
+                <th className='whitespace-nowrap px-4 pt-2 pb-3 text-center align-middle font-medium'>
                   <span className='text-muted-foreground text-xs leading-none'>
                     {copy.changePercent}
                   </span>
                 </th>
-                <th className='px-4 pt-2 pb-3 text-center align-middle font-medium'>
+                <th className='whitespace-nowrap px-4 pt-2 pb-3 text-center align-middle font-medium'>
                   <span className='text-muted-foreground text-xs leading-none'>{copy.actions}</span>
                 </th>
               </tr>

--- a/changelog/July-24-2026.md
+++ b/changelog/July-24-2026.md
@@ -1,0 +1,62 @@
+# July-24-2026
+
+## fix/layout-maps @ edffe95c vs origin/staging
+
+### Summary
+- Moves dashboard topology mutations behind an authenticated HTTP route and keeps the client-side structure queue responsible for serializing requests and triggering resize reconciliation.
+- Buffers bounded Yjs frames while a socket is being authenticated and admitted, then replays them only after the canonical document connection is established.
+- Reworks watchlist list controls into consistent dropdown menus and fixed table columns.
+- Documents the current dirty tree separately: stable chart-listing resolution, last-item deletion protection for saved-entity lists and watchlists, and corrected workflow editor layering.
+
+### Branch Scope
+- Compared 4bf567971877e9b3d01e74251f119589f1c236ad..edffe95c; the merge base equals refreshed origin/staging.
+- Committed branch delta: 19 files changed, 711 insertions, and 712 deletions across dashboard persistence, Yjs socket admission, watchlist UI, translations, and focused tests. git diff --name-status --find-renames reported one added route and no deleted or renamed paths.
+- Included pre-existing local work separately from the committed range: 13 modified files (160 insertions and 231 deletions) plus the untracked apps/tradinggoose/widgets/widgets/data_chart/hooks/use-listing-state.test.tsx. It touches data-chart listing resolution, custom tool/skill/indicator/MCP list deletion controls, workflow canvas layering, and watchlist deletion behavior.
+- The changelog itself is the only file added by this documentation run. No generated migration files were edited.
+
+### Key Changes
+- apps/tradinggoose/app/api/workspaces/[id]/dashboard-layouts/[layoutId]/structure/route.ts now authenticates the caller, forwards raw structure JSON to applyDashboardStructureMutationInSocketServer(), returns 204 on success, and converts saved-entity transport failures through createSavedEntityErrorResponse().
+- apps/tradinggoose/app/workspace/[workspaceId]/dashboard/use-dashboard-layout-doc.ts replaces mutateDashboardLayoutStructureAction() with queued POST requests to the structure route. Failed resize writes increment resizeReconcileVersion so the layout can reconcile; apps/tradinggoose/app/workspace/[workspaceId]/dashboard/dashboard-client.tsx no longer presents a persistent resize-error alert.
+- apps/tradinggoose/socket-server/yjs/ws-handler.ts establishes the WebSocket once, captures up to 64 copied pre-admission messages, enforces the server maxPayload budget, and supplies those messages to setupWSConnection() only after authentication, document acquisition, and shutdown checks succeed. apps/tradinggoose/socket-server/yjs/upstream-utils.ts now accepts initialMessages and feeds them through the normal message handler after its durable checkpoint, sync, and awareness setup. apps/tradinggoose/socket-server/index.ts sets the Yjs server maxPayload to 1 MiB.
+- apps/tradinggoose/widgets/widgets/watchlist/components/watchlist-list-actions-button.tsx replaces the Popover action surface with DropdownMenu items that retain disabled actions instead of hiding them. apps/tradinggoose/widgets/widgets/watchlist/components/watchlist-header-controls.tsx moves watchlist rename/delete controls into each dropdown row, and apps/tradinggoose/widgets/widgets/watchlist/components/watchlist-table.tsx adopts a 720px minimum, fixed column widths, and non-wrapping headers.
+- Local data-chart work simplifies apps/tradinggoose/widgets/widgets/data_chart/hooks/use-listing-state.ts so it resolves the normalized ListingIdentity through requestListingResolution(), keys in-flight work by getListingIdentityKey(), retries unresolved identities after one second, and ignores stale resolved records. apps/tradinggoose/widgets/widgets/data_chart/components/chart-body.tsx no longer couples that resolver to the interval label.
+- Local list UI work adds canDelete to CustomToolListItem, SkillListItem, IndicatorListItem, and McpServerListItem. Their parent lists pass count > 1, and each deletion handler independently refuses a disallowed delete. The local watchlist header change likewise rejects deletion when listOptions.length <= 1 and points an active widget at the next remaining watchlist after a successful deletion.
+- Local workflow work renders FloatingControls inside ReactFlow and applies zIndex: 20 to NodeEditorPanel, ensuring the inspector stays above the controls within the same stacking context.
+
+### Design Decisions
+- The dashboard HTTP route owns request authentication and transport-error mapping, while the socket bridge remains the shared owner of the internal realtime request. The client hook intentionally queues topology writes per workspace/layout pair instead of allowing concurrent POST requests to reorder them.
+- WebSocket upgrade is intentionally performed once before asynchronous admission so early client frames can be captured, but the connection is not attached to a Yjs document until authorization and canonical bootstrap complete. Message-count and payload limits bound the admission buffer.
+- Watchlist actions use the repository dropdown-menu primitives and widget-header menu classes rather than a separate Popover implementation. Disabled actions remain visible to communicate capability state.
+- Listing resolution is keyed by a stable identity signature, not the object identity of Yjs-backed widget params. Unrelated param updates therefore do not cancel or restart an active listing lookup.
+- The local last-item rule is enforced both when rendering the delete affordance and when executing a confirm handler. This protects persisted default entities from UI races without introducing a parallel deletion service.
+- Workflow controls and node inspector are deliberately in the React Flow stacking context; styling only the panel without moving the controls would leave two independent layer hierarchies.
+
+### Shared Contracts and Helpers to Reuse
+- Use POST /api/workspaces/[id]/dashboard-layouts/[layoutId]/structure for browser-originated topology changes. The route delegates to apps/tradinggoose/lib/yjs/server/snapshot-bridge.ts: applyDashboardStructureMutationInSocketServer(); useDashboardLayoutDocument().mutateStructure() is the canonical client caller.
+- Reuse setupWSConnection(..., { initialMessages }) in apps/tradinggoose/socket-server/yjs/upstream-utils.ts when a guarded admission phase must replay early frames. Keep message handling through the existing handler rather than implementing a second replay path.
+- Reuse apps/tradinggoose/lib/listing/identity.ts: toListingValueObject() and getListingIdentityKey(), plus apps/tradinggoose/components/listing-selector/selector/resolve-request.ts: requestListingResolution(), for widget-param listing lookup. apps/tradinggoose/widgets/widgets/data_chart/hooks/use-listing-state.ts is the canonical data-chart consumer.
+- Pass canDelete={items.length > 1} into the affected saved-entity list-item components. The item components own both the hidden delete control and the defensive confirmation guard; later list widgets should follow this boundary rather than only disabling a parent button.
+- Reuse apps/tradinggoose/widgets/widgets/watchlist/components/watchlist-list-actions-button.tsx and the shared widgetHeaderMenuContentClassName, widgetHeaderMenuIconClassName, widgetHeaderMenuItemClassName, and widgetHeaderMenuTextClassName styles for compact widget-header action menus.
+
+### Removed or Replaced Items
+- apps/tradinggoose/app/workspace/[workspaceId]/dashboard/actions.ts no longer exports mutateDashboardLayoutStructureAction(). Do not restore the server-action topology path; use the structure route and the socket bridge instead.
+- The hasResizePersistenceError return value, DashboardClient resize error banner, and dashboard.layoutState.resizePersistenceError translations were removed. Preserve resizeReconcileVersion as the recovery signal rather than recreating a stale visible error state.
+- The committed watchlist Popover action model, open/onOpenChange props, action-hiding behavior, and separate selected-list rename action were replaced by DropdownMenu rows and per-row controls. Do not reintroduce a second menu implementation.
+- Local useListingState work removes the old inline ListingOption detail shortcut, interval-derived tooltip state, hydrated identity refs, and object-reference effect dependencies. Resolve the canonical ListingIdentity and let callers render details from the resolved response.
+- No files were deleted or renamed in the committed merge-base range, and there is no migration replacement to carry forward.
+
+### Future Branch Guardrails
+- Keep dashboard topology writes queued through useDashboardLayoutDocument().mutateStructure() and its authenticated HTTP route. Do not bypass it with direct client-to-socket mutation code or restore the removed server action.
+- Maintain Yjs pre-admission bounds: do not attach a connection before admission, do not replay raw buffers outside setupWSConnection(), and retain both the 64-message and maxPayload protections.
+- Key async listing resolution by getListingIdentityKey(), not a ListingIdentity object reference. Do not make view, interval, live-bars, or drawing updates restart the same lookup.
+- Do not expose deletion of the final custom tool, skill, indicator, MCP server, or watchlist. Keep the UI canDelete gate and the confirm-handler guard in sync.
+- Keep watchlist action menus on DropdownMenu and preserve fixed table column geometry so labels and controls remain scannable in narrow widget panels.
+- Keep FloatingControls inside ReactFlow and the NodeEditorPanel z-index above them. Do not move either back into a separate overlay hierarchy.
+- The listed local changes are not part of edffe95c until committed. Follow-on work must continue to distinguish them from the committed branch range.
+
+### Validation Notes
+- Reviewed AGENTS.md, changelog/TEMPLATE.md, the existing dated changelog layout, git status --short --branch, git fetch origin staging, git merge-base origin/staging fix/layout-maps, git log --oneline 4bf567971877e9b3d01e74251f119589f1c236ad..fix/layout-maps, git diff --stat, git diff --name-status --find-renames, and the full git diff HEAD for the dirty tree.
+- Inspected the dashboard route/hook/client/test, snapshot bridge, socket-server admission code and tests, watchlist controls/actions/table tests, listing identity/resolution helpers, the untracked listing-state test, saved-entity list callers, and workflow canvas/panel code.
+- git diff --check 4bf567971877e9b3d01e74251f119589f1c236ad..fix/layout-maps completed without whitespace errors.
+- Ran from apps/tradinggoose: bun run test -- socket-server/yjs/ws-handler.test.ts socket-server/yjs/upstream-utils.test.ts app/workspace/[workspaceId]/dashboard/use-dashboard-layout-doc.test.tsx widgets/widgets/watchlist/components/watchlist-header-controls.ui.test.tsx widgets/widgets/watchlist/components/watchlist-list-actions-button.test.tsx widgets/widgets/data_chart/hooks/use-listing-state.test.tsx. Result: 6 files and 55 tests passed.
+- The full turbo test suite, type-check, formatter, and application build were not run for this changelog-only update.


### PR DESCRIPTION
## Summary
- Route dashboard structure mutations through an authenticated HTTP endpoint while preserving serialized client-side writes and resize reconciliation.
- Buffer bounded Yjs messages during session admission, then replay them after authenticated document setup.
- Improve watchlist menus and fixed table layout; prevent deletion of the final saved item or watchlist.
- Stabilize data-chart listing resolution and keep the workflow node editor above floating controls.

## Why
Dashboard topology updates and Yjs admission could fail or race under reconnect/early-message conditions. Widget controls also allowed destructive last-item actions and had layout/accessibility issues in constrained panels.

## Affected Areas
- [x] `apps/tradinggoose`
- [ ] `apps/docs`
- [ ] `packages/*`
- [x] Workflows / execution
- [x] Realtime / sockets
- [x] Market data / charting
- [ ] Dev tooling / CI / infra
- [ ] Documentation only
- [ ] Other:

## Issue Links( if any )
#167 

## Validation
```bash
git diff --check origin/staging...HEAD

cd apps/tradinggoose && bun run test -- \
  socket-server/yjs/ws-handler.test.ts \
  socket-server/yjs/upstream-utils.test.ts \
  'app/workspace/[workspaceId]/dashboard/use-dashboard-layout-doc.test.tsx' \
  widgets/widgets/watchlist/components/watchlist-header-controls.ui.test.tsx \
  widgets/widgets/watchlist/components/watchlist-list-actions-button.test.tsx \
  widgets/widgets/data_chart/hooks/use-listing-state.test.tsx