### PR TITLE
fix(billing): restore default entitlement when a Stripe cancellation fails or is missed

### DIFF
--- a/apps/tradinggoose/lib/billing/core/subscription.test.ts
+++ b/apps/tradinggoose/lib/billing/core/subscription.test.ts
@@ -164,10 +164,53 @@ describe('subscription billing helpers', () => {
     expect(snapshot.currentPeriodCost).toBe(12.5)
   })
 
-  it('throws when billing is enabled but no active subscription exists', async () => {
+  it('restores the default subscription when a billed user has no entitled row', async () => {
+    // The reported failure: a missed Stripe cancellation leaves the user's only personal row
+    // non-entitled, so every billing read used to throw.
+    const restoredSubscription = {
+      id: 'sub_default_user_123',
+      referenceType: 'user',
+      referenceId: 'user_123',
+      status: 'active',
+      tier: { id: 'tier_default', isDefault: true },
+    }
+    mockGetResolvedBillingSettings.mockResolvedValue({ billingEnabled: true })
+    const selectResults: unknown[] = [[], [], [restoredSubscription]]
+    mockDb.select.mockImplementation(() =>
+      createSelectQueryMock(selectResults.shift() ?? [], 'where')
+    )
+    mockDb.insert.mockImplementation(() => ({
+      values: vi.fn(() => ({ onConflictDoUpdate: vi.fn(() => Promise.resolve()) })),
+    }))
+
+    const { getEffectiveSubscription } = await import('./subscription')
+
+    await expect(getEffectiveSubscription('user_123')).resolves.toBe(restoredSubscription)
+    expect(mockDb.insert).toHaveBeenCalled()
+  })
+
+  it('does not restore a subscription when billing is disabled', async () => {
+    mockGetResolvedBillingSettings.mockResolvedValue({ billingEnabled: false })
+    mockDb.select.mockImplementation(() => createSelectQueryMock([], 'where'))
+    mockDb.insert.mockImplementation(() => ({
+      values: vi.fn(() => ({ onConflictDoUpdate: vi.fn(() => Promise.resolve()) })),
+    }))
+
+    const { getEffectiveSubscription } = await import('./subscription')
+
+    await expect(getEffectiveSubscription('user_123')).resolves.toBeNull()
+    expect(mockDb.insert).not.toHaveBeenCalled()
+  })
+
+  it('throws when billing is enabled and entitlement cannot be restored', async () => {
     mockGetResolvedBillingSettings.mockResolvedValue({
       billingEnabled: true,
     })
+    // Recovery runs, fails to provision a default subscription, and the original billing
+    // error surfaces rather than a new one.
+    mockDb.insert.mockImplementation(() => ({
+      values: vi.fn(() => ({ onConflictDoUpdate: vi.fn(() => Promise.resolve()) })),
+    }))
     mockDb.select
       .mockImplementationOnce(() => createSelectQueryMock([], 'where'))
       .mockImplementationOnce(() =>

--- a/apps/tradinggoose/lib/billing/core/subscription.ts
+++ b/apps/tradinggoose/lib/billing/core/subscription.ts
@@ -85,6 +85,41 @@ export function getConfiguredPersonalUsageLimit(
  */
 
 /**
+ * Give a billed user back the default tier when they hold no entitled subscription.
+ *
+ * Personal Stripe subscriptions reuse the user's default subscription row, so a cancellation
+ * that Stripe reported but we failed to finish (a dropped `customer.subscription.deleted`,
+ * or a settlement error part-way through one) leaves that single row non-entitled and every
+ * billing read throwing. The local status is enough to act on: the row is not entitling
+ * anyone, and the default tier is the floor rather than a revocation.
+ *
+ * Never throws - callers use it behind a normal read, so a repair failure must surface as
+ * the original billing error rather than a new one.
+ */
+async function restorePersonalEntitlement(userId: string): Promise<SubscriptionWithTier | null> {
+  try {
+    // With billing disabled there is no default tier to grant, and callers already treat a
+    // missing subscription as unlimited.
+    const { billingEnabled } = await getResolvedBillingSettings()
+    if (!billingEnabled) {
+      return null
+    }
+
+    const restoredSubscription = await ensureDefaultUserSubscription(userId)
+
+    logger.warn('Restored default personal subscription for a user left without one', {
+      userId,
+      subscriptionId: restoredSubscription.id,
+    })
+
+    return restoredSubscription
+  } catch (error) {
+    logger.error('Failed to restore default personal subscription', { userId, error })
+    return null
+  }
+}
+
+/**
  * Get the active subscription that currently governs a billing reference.
  */
 export async function getActiveSubscriptionForReference(
@@ -102,7 +137,13 @@ export async function getActiveSubscriptionForReference(
     )
 
   const hydratedSubscriptions = await hydrateSubscriptionsWithTiers(rows)
-  return selectEffectiveSubscription(hydratedSubscriptions)
+  const effectiveSubscription = selectEffectiveSubscription(hydratedSubscriptions)
+
+  if (effectiveSubscription || reference.referenceType !== 'user') {
+    return effectiveSubscription
+  }
+
+  return restorePersonalEntitlement(reference.referenceId)
 }
 
 export async function requireActiveSubscriptionForReference(
@@ -135,7 +176,8 @@ export async function getSubscriptionByStripeSubscriptionId(
 export async function getEffectiveSubscription(
   userId: string
 ): Promise<SubscriptionWithTier | null> {
-  return getPersonalEffectiveSubscription(userId)
+  const personalSubscription = await getPersonalEffectiveSubscription(userId)
+  return personalSubscription ?? restorePersonalEntitlement(userId)
 }
 
 async function getActivePersonalSubscriptions(
@@ -287,7 +329,8 @@ export async function getPersonalBillingSnapshot(userId: string): Promise<Person
   try {
     const [{ billingEnabled }, subscription, statsRecords] = await Promise.all([
       getResolvedBillingSettings(),
-      getPersonalEffectiveSubscription(userId),
+      // Not the raw personal read: this one repairs a user left without an entitled row.
+      getEffectiveSubscription(userId),
       db
         .select({
           currentPeriodCost: userStats.currentPeriodCost,

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
@@ -390,6 +390,29 @@ describe('handleStripeSubscriptionDeleted', () => {
     expect(mockSyncSubscriptionUsageLimits).not.toHaveBeenCalled()
   })
 
+  it('restores default entitlement even when settlement fails, then rethrows', async () => {
+    const stripeBackedSubscription = createDefaultSubscription({
+      status: 'canceled',
+      stripeSubscriptionId: 'sub_stripe_123',
+    })
+    const defaultSubscription = createDefaultSubscription()
+    mockGetSubscriptionByStripeSubscriptionId
+      .mockResolvedValueOnce(stripeBackedSubscription)
+      .mockResolvedValueOnce(stripeBackedSubscription)
+    mockEnsureDefaultUserSubscription.mockResolvedValue(defaultSubscription)
+    mockCalculateSubscriptionOverage.mockRejectedValue(new Error('Stripe invoice failed'))
+
+    const { handleStripeSubscriptionDeleted } = await import('./subscription')
+    await expect(
+      handleStripeSubscriptionDeleted(createDeletedSubscriptionEvent() as any)
+    ).rejects.toThrow('Stripe invoice failed')
+
+    // Leaving the user with no entitled subscription is what breaks every billing read -
+    // a failed final invoice must not cost them their default tier.
+    expect(mockEnsureDefaultUserSubscription).toHaveBeenCalledWith('user-1', mockDb)
+    expect(mockSyncSubscriptionUsageLimits).toHaveBeenCalledWith(defaultSubscription)
+  })
+
   it('does not reset onboarding usage when another personal subscription remains entitled', async () => {
     const canceledSubscription = createDefaultSubscription({
       status: 'canceled',

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
@@ -12,7 +12,6 @@ const {
   mockEnsureDefaultUserSubscription,
   mockEq,
   mockGetBilledOverageForSubscription,
-  mockGetResolvedBillingSettings,
   mockGetSubscriptionByStripeSubscriptionId,
   mockIsPaidBillingTier,
   mockNe,
@@ -33,7 +32,6 @@ const {
   mockEnsureDefaultUserSubscription: vi.fn(),
   mockEq: vi.fn((field: unknown, value: unknown) => ({ field, value })),
   mockGetBilledOverageForSubscription: vi.fn(),
-  mockGetResolvedBillingSettings: vi.fn(),
   mockGetSubscriptionByStripeSubscriptionId: vi.fn(),
   mockIsPaidBillingTier: vi.fn(),
   mockNe: vi.fn((field: unknown, value: unknown) => ({ field, value })),
@@ -77,10 +75,6 @@ vi.mock('@/lib/billing/core/usage', () => ({
 vi.mock('@/lib/billing/core/subscription', () => ({
   ensureDefaultUserSubscription: mockEnsureDefaultUserSubscription,
   getSubscriptionByStripeSubscriptionId: mockGetSubscriptionByStripeSubscriptionId,
-}))
-
-vi.mock('@/lib/billing/settings', () => ({
-  getResolvedBillingSettings: mockGetResolvedBillingSettings,
 }))
 
 vi.mock('@/lib/billing/tiers', () => ({
@@ -211,7 +205,6 @@ describe('handleSubscriptionCreated', () => {
     mockDb.update.mockImplementation(() => createUpdateQueryMock())
     mockCalculateSubscriptionOverage.mockResolvedValue(0)
     mockGetBilledOverageForSubscription.mockResolvedValue(0)
-    mockGetResolvedBillingSettings.mockResolvedValue({ billingEnabled: true })
     mockRequireStripeClient.mockReturnValue({})
     mockIsPaidBillingTier.mockReturnValue(false)
   })
@@ -289,7 +282,6 @@ describe('handleStripeSubscriptionDeleted', () => {
     mockDb.update.mockImplementation(() => createUpdateQueryMock())
     mockCalculateSubscriptionOverage.mockResolvedValue(0)
     mockGetBilledOverageForSubscription.mockResolvedValue(0)
-    mockGetResolvedBillingSettings.mockResolvedValue({ billingEnabled: true })
     mockGetSubscriptionByStripeSubscriptionId.mockResolvedValue(null)
     mockRequireStripeClient.mockReturnValue({})
     mockSyncSubscriptionBillingTierFromStripeSubscription.mockResolvedValue(undefined)

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.ts
@@ -279,10 +279,25 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
     })
     .where(eq(subscription.stripeSubscriptionId, stripeSubscriptionId))
 
-  await syncSubscriptionBillingTierFromStripeSubscription(
-    resolvedSubscription.id,
-    stripeSubscription
-  )
+  // Settlement talks to Stripe and can fail. Entitlement restore below must not depend on it:
+  // personal Stripe subscriptions reuse the user's default subscription row, so bailing out
+  // here is exactly what leaves a user with no entitled subscription at all and breaks every
+  // billing read. Failures are rethrown once entitlement is safe.
+  let settlementError: unknown = null
+
+  try {
+    await syncSubscriptionBillingTierFromStripeSubscription(
+      resolvedSubscription.id,
+      stripeSubscription
+    )
+  } catch (error) {
+    settlementError = error
+    logger.error('Failed to sync billing tier for a cancelled subscription', {
+      subscriptionId: resolvedSubscription.id,
+      stripeSubscriptionId,
+      error,
+    })
+  }
 
   const hydratedSubscription = await getSubscriptionByStripeSubscriptionId(stripeSubscriptionId)
   if (!hydratedSubscription) {
@@ -298,7 +313,17 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
   }
   let subscriptionForUsageLimits: TieredSubscriptionLifecycleRecord = subscriptionToSettle
 
-  await handleSubscriptionDeleted(subscriptionToSettle)
+  try {
+    await handleSubscriptionDeleted(subscriptionToSettle)
+  } catch (error) {
+    settlementError ??= error
+    logger.error('Failed to settle a cancelled subscription; restoring entitlement anyway', {
+      subscriptionId: subscriptionToSettle.id,
+      referenceType: subscriptionToSettle.referenceType,
+      referenceId: subscriptionToSettle.referenceId,
+      error,
+    })
+  }
 
   if (subscriptionToSettle.referenceType === 'user') {
     const { billingEnabled } = await getResolvedBillingSettings()
@@ -330,5 +355,10 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
     referenceType: subscriptionToSettle.referenceType,
     referenceId: subscriptionToSettle.referenceId,
     stripeSubscriptionId,
+    settlementFailed: Boolean(settlementError),
   })
+
+  if (settlementError) {
+    throw settlementError
+  }
 }

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.ts
@@ -12,7 +12,6 @@ import {
   resetUserDefaultUsageToOnboardingAllowanceBalance,
 } from '@/lib/billing/core/usage'
 import { syncSubscriptionUsageLimits } from '@/lib/billing/organization'
-import { getResolvedBillingSettings } from '@/lib/billing/settings'
 import { requireStripeClient } from '@/lib/billing/stripe-client'
 import { type BillingTierRecord, isPaidBillingTier } from '@/lib/billing/tiers'
 import { syncSubscriptionBillingTierFromStripeSubscription } from '@/lib/billing/tiers/persistence'
@@ -325,26 +324,26 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
     })
   }
 
+  // No billing-enabled gate here: a signature-verified Stripe webhook resolving to a local row
+  // that carries a stripeSubscriptionId is only reachable while billing is configured and
+  // running. Re-deriving that from settings only added a fallible read that could skip the
+  // restore and leave the user unentitled.
   if (subscriptionToSettle.referenceType === 'user') {
-    const { billingEnabled } = await getResolvedBillingSettings()
+    subscriptionForUsageLimits = await db.transaction(async (tx) => {
+      const nextSubscription = await ensureDefaultUserSubscription(
+        subscriptionToSettle.referenceId,
+        tx
+      )
 
-    if (billingEnabled) {
-      subscriptionForUsageLimits = await db.transaction(async (tx) => {
-        const nextSubscription = await ensureDefaultUserSubscription(
+      if (nextSubscription.tier?.isDefault && !nextSubscription.stripeSubscriptionId) {
+        await resetUserDefaultUsageToOnboardingAllowanceBalance(
           subscriptionToSettle.referenceId,
           tx
         )
+      }
 
-        if (nextSubscription.tier?.isDefault && !nextSubscription.stripeSubscriptionId) {
-          await resetUserDefaultUsageToOnboardingAllowanceBalance(
-            subscriptionToSettle.referenceId,
-            tx
-          )
-        }
-
-        return nextSubscription
-      })
-    }
+      return nextSubscription
+    })
   }
 
   await syncSubscriptionUsageLimits(subscriptionForUsageLimits)


### PR DESCRIPTION
## Summary
Stops a failed or missed Stripe cancellation from leaving a user with no entitled subscription at all.

- `handleStripeSubscriptionDeleted()` no longer aborts before the entitlement restore. Both settlement steps — `syncSubscriptionBillingTierFromStripeSubscription()` and `handleSubscriptionDeleted()` — are wrapped so a failure is logged, the default-tier restore still runs, and the first error is rethrown afterwards. The settled log line now carries `settlementFailed`.
- Adds `restorePersonalEntitlement()` in `lib/billing/core/subscription.ts`: when a personal read finds no entitled row, it calls `ensureDefaultUserSubscription()` to put the user back on the default tier. It is a no-op when billing is disabled, and never throws — a repair failure falls through so the original billing error surfaces instead of a new one.
- Wires that repair into `getActiveSubscriptionForReference()` (user references only), `getEffectiveSubscription()`, and `getPersonalBillingSnapshot()`.
- Adds four tests covering restore-on-read, the billing-disabled no-op, the unrecoverable case still throwing the original error, and the webhook restoring entitlement before rethrowing a settlement failure.

## Why
Personal Stripe subscriptions reuse the user's default subscription row rather than creating a separate one. So if the `customer.subscription.deleted` webhook is dropped, or fails part-way through settlement, that single row is left cancelled and non-entitled — the user has no subscription at all, and every billing read throws for them.

The old handler made this worse: settlement talks to Stripe (overage calculation, final invoicing) and can fail, and an exception there aborted the handler *before* the code that restores the default tier. A transient Stripe error during cancellation therefore cost the user their default entitlement.

The fix separates the two concerns. Restoring the default tier depends only on local state — the row is not entitling anyone, and the default tier is the floor rather than a revocation — so it runs unconditionally, and settlement failures are surfaced afterwards instead of silently taking entitlement down with them. The read-path repair covers users already stranded by cancellations that failed before this change.

## Affected Areas
- [x] `apps/tradinggoose`
- [ ] `apps/docs`
- [ ] `packages/*`
- [ ] Workflows / execution
- [ ] Realtime / sockets
- [ ] Market data / charting
- [ ] Dev tooling / CI / infra
- [ ] Documentation only
- [x] Other: Billing / Stripe webhooks

## Issue Links( if any )
<!-- None. -->

## Validation
```bash
# from apps/tradinggoose
bun run vitest run lib/billing/core/subscription.test.ts lib/billing/webhooks/subscription.test.ts
#   Test Files  2 passed (2)
#   Tests  18 passed (18)

bun run type-check
#   ✓ Types generated successfully — tsc --noEmit clean

# from repo root
bunx biome check --unsafe apps/tradinggoose/lib/billing/core/subscription.ts \
  apps/tradinggoose/lib/billing/core/subscription.test.ts \
  apps/tradinggoose/lib/billing/webhooks/subscription.ts \
  apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
#   Checked 4 files in 45ms. No fixes applied.
```
Note: `bunx biome check apps/tradinggoose/lib/billing` reports 15 pre-existing formatting errors in files this PR does not touch; the four changed files are clean.

## Risk / Rollout Notes
Low risk, no schema or config changes, deploy normally. Two behavior changes worth knowing about:

- **`customer.subscription.deleted` now rethrows settlement failures**, so Stripe sees a failed webhook and retries where it previously saw a success. This is intentional — the failure is now visible instead of silent — but expect webhook error alerts for cases that used to pass quietly.
- **The Stripe retry is a no-op for personal subscriptions.** By the time the error is rethrown, entitlement restore has already cleared `stripeSubscriptionId` on the reused row, so the retry's `getSubscriptionByStripeSubscriptionId()` lookup finds nothing and the handler returns early. That is safe (no double settlement) but it means a failed *personal* overage settlement will not retry itself and needs manual follow-up from the logged `Failed to settle a cancelled subscription` / `settlementFailed: true` entries. Workspace subscriptions keep their `stripeSubscriptionId` and do retry normally.
- Entitlement repair performs a write on a read path. It is idempotent — `ensureDefaultUserSubscription()` uses a deterministic `default-<userId>` id with `onConflictDoUpdate` — and only fires when the user has no entitled subscription, so it is a one-shot per stranded user, not per request.
- Backout: revert the commit. Nothing persisted by this change needs unwinding; users restored to the default tier simply stay on it.

## Config / Data Changes
- Env vars added or changed: none
- Database schema or migration impact: none
- External services or provider behavior changed: Stripe `customer.subscription.deleted` handling only — no API surface change, but the handler's success/failure signal to Stripe is now accurate (see Risk notes)

## Screenshots / Video
<!-- No visible UI changes. -->

## Checklist
- [x] I kept the change focused and reviewed my own diff
- [x] I validated the change locally and documented the results above
- [x] I updated docs, examples, or copy if behavior/user-facing flows changed
- [x] I called out any env, schema, provider, or rollout impact
- [x] I did not include secrets, tokens, or private credentials in this PR
