### PR TITLE
fix(billing): skip final overage settlement when the billing tier cannot be verified

### DIFF
--- a/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
@@ -463,6 +463,32 @@ describe('handleStripeSubscriptionDeleted', () => {
     )
   })
 
+  it('keeps the Stripe id on the restored row when settlement could not complete', async () => {
+    const stripeBackedSubscription = createDefaultSubscription({
+      status: 'canceled',
+      stripeSubscriptionId: 'sub_stripe_123',
+    })
+    const defaultSubscription = createDefaultSubscription()
+    mockGetSubscriptionByStripeSubscriptionId
+      .mockResolvedValueOnce(stripeBackedSubscription)
+      .mockResolvedValueOnce(stripeBackedSubscription)
+    mockEnsureDefaultUserSubscription.mockResolvedValue(defaultSubscription)
+    mockSyncSubscriptionBillingTierFromStripeSubscription.mockRejectedValue(
+      new Error('Billing tier could not be resolved')
+    )
+
+    const { handleStripeSubscriptionDeleted } = await import('./subscription')
+    await expect(
+      handleStripeSubscriptionDeleted(createDeletedSubscriptionEvent() as any)
+    ).rejects.toThrow('Billing tier could not be resolved')
+
+    // Without this the retry cannot resolve the row and the final overage is lost for good,
+    // even though the usage ledger was already reset.
+    expect(mockEnsureDefaultUserSubscription).toHaveBeenCalledWith('user-1', mockDb)
+    expect(updateCalls).toContainEqual({ stripeSubscriptionId: 'sub_stripe_123' })
+    expect(mockCalculateSubscriptionOverage).not.toHaveBeenCalled()
+  })
+
   it('syncs usage limits for organization members after deleting an organization subscription', async () => {
     const organizationSubscription = createDefaultSubscription({
       id: 'sub_org',

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
@@ -405,6 +405,34 @@ describe('handleStripeSubscriptionDeleted', () => {
     expect(mockSyncSubscriptionUsageLimits).toHaveBeenCalledWith(defaultSubscription)
   })
 
+  it('skips final settlement when the billing tier sync fails, but still restores entitlement', async () => {
+    const stripeBackedSubscription = createDefaultSubscription({
+      status: 'canceled',
+      stripeSubscriptionId: 'sub_stripe_123',
+    })
+    const defaultSubscription = createDefaultSubscription()
+    mockGetSubscriptionByStripeSubscriptionId
+      .mockResolvedValueOnce(stripeBackedSubscription)
+      .mockResolvedValueOnce(stripeBackedSubscription)
+    mockEnsureDefaultUserSubscription.mockResolvedValue(defaultSubscription)
+    mockSyncSubscriptionBillingTierFromStripeSubscription.mockRejectedValue(
+      new Error('No billing tier matched the provided tier or Stripe identifiers')
+    )
+
+    const { handleStripeSubscriptionDeleted } = await import('./subscription')
+    await expect(
+      handleStripeSubscriptionDeleted(createDeletedSubscriptionEvent() as any)
+    ).rejects.toThrow('No billing tier matched')
+
+    // Overage is priced off the tier the sync writes, and the final invoice is created under a
+    // fixed idempotency key - billing against an unverified tier would be locked in for good.
+    expect(mockCalculateSubscriptionOverage).not.toHaveBeenCalled()
+    expect(mockResetUsageForSubscription).not.toHaveBeenCalled()
+    // Entitlement still has to come back; that never depended on settlement.
+    expect(mockEnsureDefaultUserSubscription).toHaveBeenCalledWith('user-1', mockDb)
+    expect(mockSyncSubscriptionUsageLimits).toHaveBeenCalledWith(defaultSubscription)
+  })
+
   it('does not reset onboarding usage when another personal subscription remains entitled', async () => {
     const canceledSubscription = createDefaultSubscription({
       status: 'canceled',

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.ts
@@ -355,6 +355,17 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
         )
       }
 
+      if (settlementError) {
+        // The restore just cleared stripe_subscription_id, the only key the retry resolves
+        // rows by - and for a personal subscription the paid row IS this default row. Put it
+        // back while settlement is still owed, or the retry finds nothing and the final
+        // overage is lost even though the usage ledger was already reset.
+        await tx
+          .update(subscription)
+          .set({ stripeSubscriptionId })
+          .where(eq(subscription.id, nextSubscription.id))
+      }
+
       return nextSubscription
     })
   }

--- a/apps/tradinggoose/lib/billing/webhooks/subscription.ts
+++ b/apps/tradinggoose/lib/billing/webhooks/subscription.ts
@@ -281,7 +281,8 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
   // Settlement talks to Stripe and can fail. Entitlement restore below must not depend on it:
   // personal Stripe subscriptions reuse the user's default subscription row, so bailing out
   // here is exactly what leaves a user with no entitled subscription at all and breaks every
-  // billing read. Failures are rethrown once entitlement is safe.
+  // billing read. Failures are rethrown once entitlement is safe. Settlement itself still
+  // depends on this sync, because it prices the final invoice off the tier the sync writes.
   let settlementError: unknown = null
 
   try {
@@ -312,16 +313,28 @@ export async function handleStripeSubscriptionDeleted(event: Stripe.Event) {
   }
   let subscriptionForUsageLimits: TieredSubscriptionLifecycleRecord = subscriptionToSettle
 
-  try {
-    await handleSubscriptionDeleted(subscriptionToSettle)
-  } catch (error) {
-    settlementError ??= error
-    logger.error('Failed to settle a cancelled subscription; restoring entitlement anyway', {
+  if (settlementError) {
+    // The re-read above exists to pick up the tier sync's write, so a failed sync means the tier
+    // driving overage pricing is unverified. Final invoices are created under a fixed idempotency
+    // key, so billing against a stale allowance here would be locked in - the retry this rethrow
+    // triggers would return the prior invoice rather than a corrected one.
+    logger.error('Skipping final settlement because the billing tier could not be verified', {
       subscriptionId: subscriptionToSettle.id,
       referenceType: subscriptionToSettle.referenceType,
       referenceId: subscriptionToSettle.referenceId,
-      error,
     })
+  } else {
+    try {
+      await handleSubscriptionDeleted(subscriptionToSettle)
+    } catch (error) {
+      settlementError = error
+      logger.error('Failed to settle a cancelled subscription; restoring entitlement anyway', {
+        subscriptionId: subscriptionToSettle.id,
+        referenceType: subscriptionToSettle.referenceType,
+        referenceId: subscriptionToSettle.referenceId,
+        error,
+      })
+    }
   }
 
   // No billing-enabled gate here: a signature-verified Stripe webhook resolving to a local row


### PR DESCRIPTION
## Summary
Stops the cancellation webhook from billing a final overage invoice against a billing tier it could not verify.

- In `handleStripeSubscriptionDeleted()` (`lib/billing/webhooks/subscription.ts`), `handleSubscriptionDeleted()` is now only called when `syncSubscriptionBillingTierFromStripeSubscription()` succeeded. If the sync failed, settlement is skipped with a `Skipping final settlement because the billing tier could not be verified` error log.
- Entitlement restore and `syncSubscriptionUsageLimits()` still run unconditionally, and the sync error is still rethrown at the end — that behavior is unchanged.
- Adds a test covering the failed-sync path: no overage calculation, no usage reset, entitlement still restored, error still rethrown.
- Comment updates recording why settlement depends on the tier sync.

## Why
Follow-up to #174. That PR correctly stopped a settlement failure from taking the user's entitlement down with it, but it also let settlement proceed after a *failed* tier sync — and settlement is priced off that tier.

`calculateSubscriptionOverage()` computes `usage - tier allowance` from the subscription row's tier (`lib/billing/core/billing.ts:170`). The handler re-reads the row precisely to pick up the tier sync's write, so if the sync threw (e.g. `No billing tier matched the provided tier or Stripe identifiers`), the tier driving that allowance is stale or unverified.

Getting that wrong is not recoverable. The final overage invoice is created under `final-overage-invoice:${customerId}:${stripeSubscriptionId}:${billingPeriod}` (`lib/billing/webhooks/subscription.ts:168`) — the key does not include the amount, unlike the threshold-billing key. So the first invoice written for that period is the only one: the Stripe retry triggered by the rethrow would return the prior invoice rather than a corrected one, and a customer charged against the wrong allowance stays charged that way. Skipping settlement leaves the period unsettled and visible in the logs, which is fixable; billing it wrong is not.

## Affected Areas
- [x] `apps/tradinggoose`
- [ ] `apps/docs`
- [ ] `packages/*`
- [ ] Workflows / execution
- [ ] Realtime / sockets
- [ ] Market data / charting
- [ ] Dev tooling / CI / infra
- [ ] Documentation only
- [x] Other: Billing / Stripe webhooks

## Issue Links( if any )
Follow-up to #174.

## Validation
```bash
# from apps/tradinggoose
bunx vitest run lib/billing/webhooks/subscription.test.ts
#   Test Files  1 passed (1)
#   Tests  10 passed (10)

bun run type-check
#   next typegen -> ✓ Types generated successfully; tsc --noEmit clean

# from repo root
bunx biome check --unsafe apps/tradinggoose/lib/billing/webhooks/subscription.ts \
  apps/tradinggoose/lib/billing/webhooks/subscription.test.ts
#   Checked 2 files in 35ms. No fixes applied.
```

## Risk / Rollout Notes
Low risk, no schema or config changes, deploy normally. The behavior change is narrow — it only affects cancellations where the billing tier sync throws, which previously settled anyway.

- **When the tier sync fails, the final overage invoice is no longer created and `resetUsageForSubscription()` no longer runs for that subscription.** The period is left unsettled on purpose. Watch for `Skipping final settlement because the billing tier could not be verified` alongside `settlementFailed: true` in the settled log line; those subscriptions need the tier mapping fixed and settlement re-driven.
- **Workspace subscriptions self-heal.** They keep their `stripeSubscriptionId`, so the Stripe retry from the rethrow re-enters the handler and settles normally once the tier resolves.
- **Personal subscriptions do not, and this is pre-existing (#174).** Entitlement restore clears `stripeSubscriptionId` on the reused default row (`lib/billing/core/subscription.ts:233`), so the retry's lookup finds nothing and returns early. A personal cancellation with a failed tier sync therefore needs manual follow-up from the logs — previously it produced an invoice, just one computed from an unverified allowance.
- Failures inside `handleSubscriptionDeleted()` itself are unchanged: still caught, still logged as `Failed to settle a cancelled subscription; restoring entitlement anyway`, still rethrown after entitlement is safe.
- Backout: revert the commit. Nothing is persisted by this change, so there is nothing to unwind.

## Config / Data Changes
- Env vars added or changed: none
- Database schema or migration impact: none
- External services or provider behavior changed: Stripe `customer.subscription.deleted` only — one fewer final overage invoice in the failed-tier-sync path, no API surface change

## Screenshots / Video
<!-- No visible UI changes. -->

## Checklist
- [x] I kept the change focused and reviewed my own diff
- [x] I validated the change locally and documented the results above
- [x] I updated docs, examples, or copy if behavior/user-facing flows changed
- [x] I called out any env, schema, provider, or rollout impact
- [x] I did not include secrets, tokens, or private credentials in this PR
