### PR TITLE
fix(copilot): revert tool manifest version to v1 and restore verbatim AGPL text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,3 @@
-TradingGoose Studio
-Copyright 2025-2026 TradingGoose Studio
-Licensed under AGPL-3.0-only. The full license text follows.
-
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 

--- a/apps/tradinggoose/lib/copilot/runtime-tool-manifest.test.ts
+++ b/apps/tradinggoose/lib/copilot/runtime-tool-manifest.test.ts
@@ -7,7 +7,7 @@ describe('copilot runtime tool manifest', () => {
     const toolNames = manifest.tools.map((tool) => tool.name)
     const workflowLogsTool = manifest.tools.find((tool) => tool.name === 'read_workflow_logs')
 
-    expect(manifest.version).toBe('v2')
+    expect(manifest.version).toBe('v1')
     expect(manifest).not.toHaveProperty('instructions')
     expect(workflowLogsTool?.parameters?.properties).not.toHaveProperty('workspaceId')
     expect(manifest.tools).toEqual(

--- a/apps/tradinggoose/lib/copilot/runtime-tool-manifest.ts
+++ b/apps/tradinggoose/lib/copilot/runtime-tool-manifest.ts
@@ -6,7 +6,9 @@ import {
 } from '@/lib/copilot/runtime-tool-manifest-enrichment'
 import { TOOL_PROMPT_METADATA } from '@/lib/copilot/tool-prompt-metadata'
 
-export const COPILOT_RUNTIME_TOOL_MANIFEST_VERSION = 'v2' as const
+// Must match TOOL_MANIFEST_VERSION in the Copilot service, which validates this
+// field as a strict literal and rejects the whole chat request on a mismatch.
+export const COPILOT_RUNTIME_TOOL_MANIFEST_VERSION = 'v1' as const
 
 export interface CopilotRuntimeToolManifestTool {
   name: string


### PR DESCRIPTION
## Summary
Puts the Copilot runtime tool manifest back on the `v1` version literal the Copilot service accepts, and restores `LICENSE` to the verbatim AGPL-3.0 text.

- `COPILOT_RUNTIME_TOOL_MANIFEST_VERSION` in `lib/copilot/runtime-tool-manifest.ts` returns to `'v1'`, with a comment recording that it must match `TOOL_MANIFEST_VERSION` in the Copilot service, which validates the field as a strict literal and rejects the whole chat request on a mismatch.
- `lib/copilot/runtime-tool-manifest.test.ts` expects `'v1'` again, which realigns it with `app/api/copilot/chat/review-session-post.test.ts` — that suite asserts `toolManifest.version === 'v1'` in four places and has been failing on `staging` since the bump.
- Removes the four-line TradingGoose header prepended above the GNU AGPL text in `LICENSE`.

No manifest *shape* changes. The Zod 4 `z.toJSONSchema` emitter, the draft-7 tool parameter schemas, the `edit_workflow` graph validators, and the dropped `instructions` / `workspaceId` fields all stay exactly as they are on `staging`. Only the version string moves.

## Why
**Manifest version.** The manifest is sent to the external Copilot service as `toolManifest` in the `/api/copilot` request payload (`app/api/copilot/chat/route.ts:880`). That service pins the version as a strict literal, so `v2` fails validation and the entire chat request is rejected — not a degraded tool list, the whole call. The bump to `v2` landed with the Zod 4 / graph-workflow manifest rewrite in #173 without a matching service-side release, so the version string is describing a handshake that does not exist yet. Reverting the literal restores Copilot chat while keeping every improvement from that rewrite.

The stale route test is the corroborating signal: `review-session-post.test.ts` was never updated to `v2`, so `staging` currently ships a manifest the service rejects *and* a red test suite. Both come back green here.

**License.** The AGPL-3.0 text states that verbatim copies may be distributed but "changing it is not allowed", so prepending a project header modifies the license document itself and also defeats automated license detection (GitHub/licensee matches the file against the canonical text). The attribution is not lost — `NOTICE` already carries `TradingGoose Studio / Copyright 2025-2026 TradingGoose Studio` along with the AGPL-3.0-only distribution statement, and `README.md:186` states the same. `package.json` still declares `"license": "AGPL-3.0-only"`. This only removes a duplicate that did not belong in the license text.

## Affected Areas
- [x] `apps/tradinggoose`
- [ ] `apps/docs`
- [ ] `packages/*`
- [ ] Workflows / execution
- [ ] Realtime / sockets
- [ ] Market data / charting
- [ ] Dev tooling / CI / infra
- [ ] Documentation only
- [x] Other: Copilot runtime contract + repository licensing metadata

## Issue Links( if any )
Follows up on #173, which bumped the manifest version.

## Validation
```bash
# from apps/tradinggoose
bunx vitest run lib/copilot/runtime-tool-manifest.test.ts \
  app/api/copilot/chat/review-session-post.test.ts
#   Test Files  2 passed (2)
#   Tests  18 passed (18)
#   (the second suite fails on origin/staging: it expects version 'v1' in 4 places)

bun run type-check
#   next typegen -> ✓ Types generated successfully; tsc --noEmit clean

# from repo root
bunx biome check --unsafe apps/tradinggoose/lib/copilot/runtime-tool-manifest.ts \
  apps/tradinggoose/lib/copilot/runtime-tool-manifest.test.ts
#   Checked 2 files in 30ms. No fixes applied.
```

## Risk / Rollout Notes
Low risk, no schema or config changes, deploy normally.

- **The version literal is a coupling to a service outside this repo.** This PR assumes the deployed Copilot service still pins `v1`. If a `v2`-aware service release is already out or lands between now and merge, this revert is the wrong direction and the correct fix is to update `review-session-post.test.ts` to `v2` instead. Worth confirming the deployed service version before merging.
- **Follow-up:** the two version literals need to move together. Whenever the service adopts `v2`, this constant, `runtime-tool-manifest.test.ts`, and the four assertions in `review-session-post.test.ts` all have to change in the same release.
- The manifest payload the service receives is otherwise byte-identical to `staging`, so no tool behavior, parameter schema, or validator changes ship here.
- `LICENSE` is metadata only — no code, build, or runtime impact. Expect GitHub to start reporting the repository license as AGPL-3.0 rather than "Other".
- Backout: revert the commit. Nothing is persisted, and the license header can be restored as-is if maintainers prefer it there.

## Config / Data Changes
- Env vars added or changed: none
- Database schema or migration impact: none
- External services or provider behavior changed: the Copilot service now receives `toolManifest.version: 'v1'` again, which is what it validates against — this is the fix, not a side effect

## Screenshots / Video
<!-- No visible UI changes. -->

## Checklist
- [x] I kept the change focused and reviewed my own diff
- [x] I validated the change locally and documented the results above
- [x] I updated docs, examples, or copy if behavior/user-facing flows changed
- [x] I called out any env, schema, provider, or rollout impact
- [x] I did not include secrets, tokens, or private credentials in this PR
