### PR TITLE
fix(copilot): restore v1 tool manifest compatibility

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,3 @@
-TradingGoose Studio
-Copyright 2025-2026 TradingGoose Studio
-Licensed under AGPL-3.0-only. The full license text follows.
-
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 

--- a/apps/tradinggoose/lib/copilot/runtime-tool-manifest.test.ts
+++ b/apps/tradinggoose/lib/copilot/runtime-tool-manifest.test.ts
@@ -7,7 +7,7 @@ describe('copilot runtime tool manifest', () => {
     const toolNames = manifest.tools.map((tool) => tool.name)
     const workflowLogsTool = manifest.tools.find((tool) => tool.name === 'read_workflow_logs')
 
-    expect(manifest.version).toBe('v2')
+    expect(manifest.version).toBe('v1')
     expect(manifest).not.toHaveProperty('instructions')
     expect(workflowLogsTool?.parameters?.properties).not.toHaveProperty('workspaceId')
     expect(manifest.tools).toEqual(

--- a/apps/tradinggoose/lib/copilot/runtime-tool-manifest.ts
+++ b/apps/tradinggoose/lib/copilot/runtime-tool-manifest.ts
@@ -6,7 +6,9 @@ import {
 } from '@/lib/copilot/runtime-tool-manifest-enrichment'
 import { TOOL_PROMPT_METADATA } from '@/lib/copilot/tool-prompt-metadata'
 
-export const COPILOT_RUNTIME_TOOL_MANIFEST_VERSION = 'v2' as const
+// Must match TOOL_MANIFEST_VERSION in the Copilot service, which validates this
+// field as a strict literal and rejects the whole chat request on a mismatch.
+export const COPILOT_RUNTIME_TOOL_MANIFEST_VERSION = 'v1' as const
 
 export interface CopilotRuntimeToolManifestTool {
   name: string


### PR DESCRIPTION
## Summary

- Restore the Copilot runtime tool manifest version to `v1`, matching the service’s strict contract.
- Update the manifest test to assert `v1`.
- Remove the project-specific header from the AGPL license text.

## Why

The Copilot service strictly validates the manifest version and rejects chat requests when Studio advertises a mismatched version. This restores compatibility.

## Affected Areas

- [x] `apps/tradinggoose`
- [ ] `apps/docs`
- [ ] `packages/*`
- [ ] Workflows / execution
- [ ] Realtime / sockets
- [ ] Market data / charting
- [ ] Dev tooling / CI / infra
- [ ] Documentation only
- [x] Other: Repository licensing text


## Validation

```bash
bun run test -- lib/copilot/runtime-tool-manifest.test.ts
git diff --check origin/main...staging