### PR TITLE
fix(triggers): scope editor fields to selected event

### DIFF
--- a/apps/tradinggoose/triggers/index.test.ts
+++ b/apps/tradinggoose/triggers/index.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { buildTriggerSubBlocks } from '@/triggers'
+
+describe('buildTriggerSubBlocks', () => {
+  it('keeps generated shell fields owned by sibling trigger definitions', () => {
+    const triggerId = 'provider_sibling_event'
+    const subBlocks = buildTriggerSubBlocks({
+      triggerId,
+      triggerOptions: [],
+      includeDropdown: false,
+      includeWebhookUrl: true,
+    })
+
+    expect(subBlocks.some((subBlock) => subBlock.id === 'selectedTriggerId')).toBe(false)
+
+    for (const subBlockId of ['webhookUrlDisplay', 'triggerSave', 'triggerInstructions']) {
+      expect(subBlocks.find((subBlock) => subBlock.id === subBlockId)?.condition).toEqual({
+        field: 'selectedTriggerId',
+        value: triggerId,
+      })
+    }
+  })
+})

--- a/apps/tradinggoose/triggers/index.ts
+++ b/apps/tradinggoose/triggers/index.ts
@@ -179,9 +179,7 @@ export function buildTriggerSubBlocks(options: BuildTriggerSubBlocksOptions): Su
   } = options
 
   const blocks: SubBlockConfig[] = []
-  const triggerCondition = includeDropdown
-    ? { field: 'selectedTriggerId', value: triggerId }
-    : undefined
+  const triggerCondition = { field: 'selectedTriggerId', value: triggerId }
 
   if (includeDropdown) {
     blocks.push({

--- a/apps/tradinggoose/triggers/webflow/collection_item_created.ts
+++ b/apps/tradinggoose/triggers/webflow/collection_item_created.ts
@@ -20,6 +20,7 @@ export const webflowCollectionItemCreatedTrigger: TriggerConfig = {
         { label: 'Collection Item Created', id: 'webflow_collection_item_created' },
         { label: 'Collection Item Changed', id: 'webflow_collection_item_changed' },
         { label: 'Collection Item Deleted', id: 'webflow_collection_item_deleted' },
+        { label: 'Form Submission', id: 'webflow_form_submission' },
       ],
       value: () => 'webflow_collection_item_created',
       required: true,

--- a/apps/tradinggoose/triggers/webflow/form_submission.ts
+++ b/apps/tradinggoose/triggers/webflow/form_submission.ts
@@ -21,6 +21,10 @@ export const webflowFormSubmissionTrigger: TriggerConfig = {
       requiredScopes: [],
       required: true,
       mode: 'trigger',
+      condition: {
+        field: 'selectedTriggerId',
+        value: 'webflow_form_submission',
+      },
     },
     {
       id: 'siteId',
@@ -31,6 +35,10 @@ export const webflowFormSubmissionTrigger: TriggerConfig = {
       required: true,
       options: [],
       mode: 'trigger',
+      condition: {
+        field: 'selectedTriggerId',
+        value: 'webflow_form_submission',
+      },
     },
     {
       id: 'formId',
@@ -40,6 +48,10 @@ export const webflowFormSubmissionTrigger: TriggerConfig = {
       description: 'The ID of the specific form to monitor (optional - leave empty for all forms)',
       required: false,
       mode: 'trigger',
+      condition: {
+        field: 'selectedTriggerId',
+        value: 'webflow_form_submission',
+      },
     },
     {
       id: 'triggerSave',

--- a/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-block/components/sub-block/sub-block-layout.test.ts
+++ b/apps/tradinggoose/widgets/widgets/editor_workflow/components/workflow-block/components/sub-block/sub-block-layout.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.unmock('@/blocks/registry')
+
 import { buildSubBlockRows } from '@/lib/workflows/sub-block-rows'
+import { getAllBlocks } from '@/blocks'
+import type { BlockConfig } from '@/blocks/types'
+
+const multiTriggerBlocks = getAllBlocks().filter(
+  (blockConfig) => (blockConfig.triggers?.available?.length ?? 0) > 1
+)
+const webflowBlock = multiTriggerBlocks.find((blockConfig) => blockConfig.type === 'webflow')!
 
 describe('buildSubBlockRows', () => {
   const triggerSubBlocks = [
@@ -49,6 +59,21 @@ describe('buildSubBlockRows', () => {
     return buildSubBlockRows({
       ...baseArgs,
       triggerSubBlockOwner,
+    })
+      .flat()
+      .map((subBlock) => subBlock.id)
+  }
+
+  function getVisibleTriggerIds(blockConfig: BlockConfig, selectedTriggerId: string) {
+    return buildSubBlockRows({
+      subBlocks: blockConfig.subBlocks,
+      stateToUse: { selectedTriggerId: { value: selectedTriggerId } },
+      isAdvancedMode: false,
+      isTriggerMode: true,
+      isPureTriggerBlock: blockConfig.category === 'triggers',
+      availableTriggerIds: blockConfig.triggers?.available,
+      hideFromPreview: false,
+      triggerSubBlockOwner: 'all',
     })
       .flat()
       .map((subBlock) => subBlock.id)
@@ -145,5 +170,41 @@ describe('buildSubBlockRows', () => {
     })
 
     expect(rows.flat().map((subBlock) => subBlock.id)).toEqual(['files'])
+  })
+
+  it.each(multiTriggerBlocks)(
+    'renders one field instance per selected $type trigger',
+    (blockConfig) => {
+      for (const triggerId of blockConfig.triggers?.available ?? []) {
+        const visibleIds = getVisibleTriggerIds(blockConfig, triggerId)
+
+        expect(visibleIds, `${blockConfig.type}:${triggerId}`).toEqual([...new Set(visibleIds)])
+      }
+    }
+  )
+
+  it.each(multiTriggerBlocks)(
+    'lists every available $type trigger in its selector',
+    (blockConfig) => {
+      const selector = blockConfig.subBlocks.find(
+        (subBlock) => subBlock.id === 'selectedTriggerId' && !subBlock.hidden
+      )
+      const options =
+        typeof selector?.options === 'function' ? selector.options() : (selector?.options ?? [])
+
+      expect(new Set(options.map((option) => option.id))).toEqual(
+        new Set(blockConfig.triggers?.available)
+      )
+    }
+  )
+
+  it('keeps Webflow fields scoped to the selected trigger variant', () => {
+    const collectionFields = getVisibleTriggerIds(webflowBlock, 'webflow_collection_item_created')
+    const formFields = getVisibleTriggerIds(webflowBlock, 'webflow_form_submission')
+
+    expect(collectionFields).toContain('collectionId')
+    expect(collectionFields).not.toContain('formId')
+    expect(formFields).toContain('formId')
+    expect(formFields).not.toContain('collectionId')
   })
 })


### PR DESCRIPTION
## Summary

- Scope generated trigger editor controls to their selected trigger, preventing sibling trigger fields from rendering together.
- Add **Form Submission** to the Webflow trigger selector.
- Scope Webflow form-submission fields to that event and add regression coverage for multi-trigger editor layouts.

## Why

Multi-trigger editors could render fields belonging to sibling trigger variants simultaneously. This made Webflow trigger configuration unclear and could surface duplicate controls. The change keeps each event’s fields isolated to the active selection.

## Affected Areas

- [x] `apps/tradinggoose`
- [ ] `apps/docs`
- [ ] `packages/*`
- [ ] Workflows / execution
- [ ] Realtime / sockets
- [ ] Market data / charting
- [ ] Dev tooling / CI / infra
- [ ] Documentation only
- [ ] Other:

## Issue
fix #199 issue

None.

## Validation

```bash
cd apps/tradinggoose
bun run test -- triggers/index.test.ts widgets/widgets/editor_workflow/components/workflow-block/components/sub-block/sub-block-layout.test.ts
```

Passed: 2 test files, 21 tests.

## Risk / Rollout Notes

Low risk. This only changes trigger-field visibility and selector options in the editor; it has no schema, API, or webhook-provider behavior changes.

Backout: revert commit `bad98753c`.

## Config / Data Changes

- Env vars added or changed: None.
- Database schema or migration impact: None.
- External services or provider behavior changed: None.



## Checklist

- [x] I kept the change focused and reviewed my own diff
- [x] I validated the change locally and documented the results above
- [x] I updated docs, examples, or copy if behavior/user-facing flows changed
- [x] I called out any env, schema, provider, or rollout impact
- [x] I did not include secrets, tokens, or private credentials in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Webflow **Form Submission** trigger option.
  - Added configuration fields for Webflow credentials, site, and form selection when using the Form Submission trigger.

- **Bug Fixes**
  - Trigger-specific settings now remain correctly associated with the selected trigger, including webhook display, save, and instruction options.
  - Improved field visibility so settings for one trigger type do not appear for another.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->