### PR TITLE
fix(console): finalize entries on terminal execution events

### DIFF
--- a/apps/tradinggoose/lib/execution/workflow-execution-events.test.ts
+++ b/apps/tradinggoose/lib/execution/workflow-execution-events.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  pendingRows: [] as unknown[],
+  logRows: [] as unknown[],
+  select: vi.fn(),
+}))
+
+vi.mock('@tradinggoose/db', () => ({
+  db: {
+    select: (fields: Record<string, unknown>) => {
+      mocks.select(fields)
+      const rows = 'status' in fields ? mocks.pendingRows : mocks.logRows
+      return {
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn().mockResolvedValue(rows),
+          })),
+        })),
+      }
+    },
+  },
+}))
+
+vi.mock('@/lib/logs/console/logger', () => ({
+  createLogger: vi.fn(() => ({
+    error: vi.fn(),
+  })),
+}))
+
+vi.mock('@/lib/redis', () => ({
+  getRedisClient: vi.fn(() => null),
+  getRedisStorageMode: vi.fn(() => 'redis'),
+}))
+
+import { readWorkflowExecutionEventState } from './workflow-execution-events'
+
+const startedAt = new Date('2026-08-20T12:00:00.000Z')
+
+describe('readWorkflowExecutionEventState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.pendingRows.length = 0
+    mocks.logRows.length = 0
+  })
+
+  it('prefers a finalized error log over a stale processing row', async () => {
+    mocks.pendingRows.push({ status: 'processing' })
+    mocks.logRows.push({
+      level: 'error',
+      startedAt,
+      endedAt: new Date('2026-08-20T12:10:00.000Z'),
+      totalDurationMs: 600_000,
+      executionData: {
+        finalOutput: { error: 'Workflow execution time limit exceeded' },
+      },
+    })
+
+    const state = await readWorkflowExecutionEventState({
+      pendingExecutionId: 'execution-1',
+      workflowId: 'workflow-1',
+      afterEventId: 0,
+    })
+
+    expect(state).toMatchObject({
+      status: 'failed',
+      failureReason: 'Workflow execution time limit exceeded',
+      result: {
+        success: false,
+        error: 'Workflow execution time limit exceeded',
+      },
+      events: [],
+    })
+  })
+
+  it('uses pending state before a workflow log exists', async () => {
+    mocks.pendingRows.push({ status: 'pending' })
+
+    const state = await readWorkflowExecutionEventState({
+      pendingExecutionId: 'execution-1',
+      workflowId: 'workflow-1',
+      afterEventId: 0,
+    })
+
+    expect(state).toEqual({
+      status: 'pending',
+      result: null,
+      failureReason: null,
+      events: [],
+    })
+  })
+})

--- a/apps/tradinggoose/lib/execution/workflow-execution-events.test.ts
+++ b/apps/tradinggoose/lib/execution/workflow-execution-events.test.ts
@@ -1,18 +1,16 @@
 /**
  * @vitest-environment node
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   pendingRows: [] as unknown[],
   logRows: [] as unknown[],
-  select: vi.fn(),
 }))
 
 vi.mock('@tradinggoose/db', () => ({
   db: {
     select: (fields: Record<string, unknown>) => {
-      mocks.select(fields)
       const rows = 'status' in fields ? mocks.pendingRows : mocks.logRows
       return {
         from: vi.fn(() => ({
@@ -40,56 +38,39 @@ import { readWorkflowExecutionEventState } from './workflow-execution-events'
 
 const startedAt = new Date('2026-08-20T12:00:00.000Z')
 
-describe('readWorkflowExecutionEventState', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    mocks.pendingRows.length = 0
-    mocks.logRows.length = 0
+it('prefers a finalized error log and otherwise uses pending state', async () => {
+  mocks.pendingRows.push({ status: 'processing' })
+  mocks.logRows.push({
+    level: 'error',
+    startedAt,
+    endedAt: new Date('2026-08-20T12:10:00.000Z'),
+    totalDurationMs: 600_000,
+    executionData: {
+      finalOutput: { error: 'Workflow execution time limit exceeded' },
+    },
   })
 
-  it('prefers a finalized error log over a stale processing row', async () => {
-    mocks.pendingRows.push({ status: 'processing' })
-    mocks.logRows.push({
-      level: 'error',
-      startedAt,
-      endedAt: new Date('2026-08-20T12:10:00.000Z'),
-      totalDurationMs: 600_000,
-      executionData: {
-        finalOutput: { error: 'Workflow execution time limit exceeded' },
-      },
-    })
-
-    const state = await readWorkflowExecutionEventState({
-      pendingExecutionId: 'execution-1',
-      workflowId: 'workflow-1',
-      afterEventId: 0,
-    })
-
-    expect(state).toMatchObject({
-      status: 'failed',
-      failureReason: 'Workflow execution time limit exceeded',
-      result: {
-        success: false,
-        error: 'Workflow execution time limit exceeded',
-      },
-      events: [],
-    })
+  const params = {
+    pendingExecutionId: 'execution-1',
+    workflowId: 'workflow-1',
+    afterEventId: 0,
+  }
+  await expect(readWorkflowExecutionEventState(params)).resolves.toMatchObject({
+    status: 'failed',
+    failureReason: 'Workflow execution time limit exceeded',
+    result: {
+      success: false,
+      error: 'Workflow execution time limit exceeded',
+    },
+    events: [],
   })
 
-  it('uses pending state before a workflow log exists', async () => {
-    mocks.pendingRows.push({ status: 'pending' })
-
-    const state = await readWorkflowExecutionEventState({
-      pendingExecutionId: 'execution-1',
-      workflowId: 'workflow-1',
-      afterEventId: 0,
-    })
-
-    expect(state).toEqual({
-      status: 'pending',
-      result: null,
-      failureReason: null,
-      events: [],
-    })
+  mocks.logRows.length = 0
+  mocks.pendingRows[0] = { status: 'pending' }
+  await expect(readWorkflowExecutionEventState(params)).resolves.toEqual({
+    status: 'pending',
+    result: null,
+    failureReason: null,
+    events: [],
   })
 })

--- a/apps/tradinggoose/lib/execution/workflow-execution-events.ts
+++ b/apps/tradinggoose/lib/execution/workflow-execution-events.ts
@@ -393,7 +393,41 @@ export async function readWorkflowExecutionEventState(params: {
     }
   }
 
-  const [row] = await db
+  const [events, [logRow]] = await Promise.all([
+    readEvents(params.afterEventId ?? 0),
+    db
+      .select({
+        level: workflowExecutionLogs.level,
+        startedAt: workflowExecutionLogs.startedAt,
+        endedAt: workflowExecutionLogs.endedAt,
+        totalDurationMs: workflowExecutionLogs.totalDurationMs,
+        executionData: workflowExecutionLogs.executionData,
+      })
+      .from(workflowExecutionLogs)
+      .where(
+        and(
+          eq(workflowExecutionLogs.executionId, params.pendingExecutionId),
+          eq(workflowExecutionLogs.workflowId, params.workflowId)
+        )
+      )
+      .limit(1),
+  ])
+  const terminalEvent = findTerminalEvent(events)
+  if (terminalEvent) {
+    return {
+      ...createWorkflowExecutionStateFromTerminalEvent(terminalEvent),
+      events: params.afterEventId === undefined ? [] : events,
+    }
+  }
+
+  if (logRow) {
+    return {
+      ...createWorkflowExecutionResultFromLog(logRow),
+      events: params.afterEventId === undefined ? [] : events,
+    }
+  }
+
+  const [pendingRow] = await db
     .select({
       status: pendingExecution.status,
     })
@@ -407,55 +441,21 @@ export async function readWorkflowExecutionEventState(params: {
     )
     .limit(1)
 
-  if (row) {
+  if (pendingRow) {
     return {
-      status: row.status,
+      status: pendingRow.status,
       result: null,
       failureReason: null,
-      events: params.afterEventId === undefined ? [] : await readEvents(params.afterEventId),
-    }
-  }
-
-  const events = await readEvents(params.afterEventId ?? 0)
-  const terminalEvent = findTerminalEvent(events)
-  if (terminalEvent) {
-    return {
-      ...createWorkflowExecutionStateFromTerminalEvent(terminalEvent),
       events: params.afterEventId === undefined ? [] : events,
     }
   }
 
-  const [logRow] = await db
-    .select({
-      level: workflowExecutionLogs.level,
-      startedAt: workflowExecutionLogs.startedAt,
-      endedAt: workflowExecutionLogs.endedAt,
-      totalDurationMs: workflowExecutionLogs.totalDurationMs,
-      executionData: workflowExecutionLogs.executionData,
-    })
-    .from(workflowExecutionLogs)
-    .where(
-      and(
-        eq(workflowExecutionLogs.executionId, params.pendingExecutionId),
-        eq(workflowExecutionLogs.workflowId, params.workflowId)
-      )
-    )
-    .limit(1)
-
-  if (!logRow) {
-    return events.length > 0
-      ? {
-          status: 'processing' as const,
-          result: null,
-          failureReason: null,
-          events: params.afterEventId === undefined ? [] : events,
-        }
-      : null
-  }
-
-  const state = createWorkflowExecutionResultFromLog(logRow)
-  return {
-    ...state,
-    events: params.afterEventId === undefined ? [] : events,
-  }
+  return events.length > 0
+    ? {
+        status: 'processing' as const,
+        result: null,
+        failureReason: null,
+        events: params.afterEventId === undefined ? [] : events,
+      }
+    : null
 }

--- a/apps/tradinggoose/stores/console/store.test.ts
+++ b/apps/tradinggoose/stores/console/store.test.ts
@@ -583,6 +583,7 @@ describe('Console Store', () => {
       const entries = useConsoleStore.getState().entries
       expect(entries.find((entry) => entry.blockId === 'invalid')).toEqual(
         expect.objectContaining({
+          success: false,
           isRunning: false,
           isCanceled: true,
           endedAt: terminalEvent.timestamp,
@@ -591,6 +592,7 @@ describe('Console Store', () => {
       )
       expect(entries.find((entry) => entry.blockId === 'missing')).toEqual(
         expect.objectContaining({
+          success: false,
           isRunning: false,
           isCanceled: true,
           endedAt: terminalEvent.timestamp,
@@ -855,8 +857,10 @@ describe('Console Store', () => {
 
       expect(workflow1Entry?.isRunning).toBe(false)
       expect(workflow1Entry?.isCanceled).toBe(true)
+      expect(workflow1Entry?.success).toBe(false)
       expect(workflow2Entry?.isRunning).toBe(true)
       expect(workflow2Entry?.isCanceled).toBeUndefined()
+      expect(workflow2Entry?.success).toBe(true)
     })
   })
 })

--- a/apps/tradinggoose/stores/console/store.test.ts
+++ b/apps/tradinggoose/stores/console/store.test.ts
@@ -343,6 +343,376 @@ describe('Console Store', () => {
       expect(entries.filter((entry) => entry.isRunning)).toHaveLength(2)
       expect(completed).toBeUndefined()
     })
+
+    it('finalizes every running entry for a completed execution without touching other entries', () => {
+      const store = useConsoleStore.getState()
+      const startedAt = '2026-04-01T00:00:00.000Z'
+
+      for (const [workflowId, executionId, blockId, iterationCurrent] of [
+        ['workflow-1', 'exec-1', 'matching-1', 1],
+        ['workflow-1', 'exec-1', 'matching-2', 2],
+        ['workflow-1', 'exec-2', 'other-execution', 1],
+        ['workflow-2', 'exec-1', 'other-workflow', 1],
+      ] as const) {
+        store.ingestWorkflowExecutionEvent({
+          workflowId,
+          executionId,
+          timestamp: startedAt,
+          type: 'block:started',
+          data: { blockId, startedAt, iterationType: 'parallel', iterationCurrent },
+        })
+      }
+
+      store.addConsole({
+        workflowId: 'workflow-1',
+        executionId: 'exec-1',
+        blockId: 'matching-with-duration',
+        success: true,
+        startedAt,
+        durationMs: 750,
+        isRunning: true,
+        isCanceled: false,
+      })
+      const alreadyCompleted = store.addConsole({
+        workflowId: 'workflow-1',
+        executionId: 'exec-1',
+        blockId: 'already-completed',
+        success: true,
+        startedAt,
+        endedAt: '2026-04-01T00:00:01.000Z',
+        durationMs: 1000,
+        isRunning: false,
+        isCanceled: false,
+      })
+      const alreadyFailed = store.addConsole({
+        workflowId: 'workflow-1',
+        executionId: 'exec-1',
+        blockId: 'already-failed',
+        success: false,
+        error: 'Specific block error',
+        startedAt,
+        endedAt: '2026-04-01T00:00:01.500Z',
+        durationMs: 1500,
+        isRunning: false,
+        isCanceled: false,
+      })
+      const alreadyCanceled = store.addConsole({
+        workflowId: 'workflow-1',
+        executionId: 'exec-1',
+        blockId: 'already-canceled',
+        success: false,
+        startedAt,
+        endedAt: '2026-04-01T00:00:02.000Z',
+        durationMs: 2000,
+        isRunning: false,
+        isCanceled: true,
+      })
+
+      const terminalEvent = {
+        workflowId: 'workflow-1',
+        executionId: 'exec-1',
+        timestamp: '2026-04-01T00:00:03.000Z',
+        type: 'execution:completed' as const,
+        data: { result: { success: true, output: {} } },
+      }
+      store.ingestWorkflowExecutionEvent(terminalEvent)
+
+      const firstState = useConsoleStore.getState().entries
+      const matching = firstState.filter(
+        (entry) =>
+          entry.workflowId === 'workflow-1' &&
+          entry.executionId === 'exec-1' &&
+          entry.blockId.startsWith('matching')
+      )
+      expect(matching).toHaveLength(3)
+      expect(matching).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            blockId: 'matching-1',
+            isRunning: false,
+            isCanceled: false,
+            endedAt: terminalEvent.timestamp,
+            durationMs: 3000,
+          }),
+          expect.objectContaining({
+            blockId: 'matching-2',
+            isRunning: false,
+            isCanceled: false,
+            endedAt: terminalEvent.timestamp,
+            durationMs: 3000,
+          }),
+          expect.objectContaining({
+            blockId: 'matching-with-duration',
+            isRunning: false,
+            isCanceled: false,
+            endedAt: terminalEvent.timestamp,
+            durationMs: 750,
+          }),
+        ])
+      )
+      expect(firstState.find((entry) => entry.blockId === 'other-execution')?.isRunning).toBe(true)
+      expect(firstState.find((entry) => entry.blockId === 'other-workflow')?.isRunning).toBe(true)
+      expect(firstState.find((entry) => entry.id === alreadyCompleted.id)).toBe(alreadyCompleted)
+      expect(firstState.find((entry) => entry.id === alreadyFailed.id)).toBe(alreadyFailed)
+      expect(firstState.find((entry) => entry.id === alreadyCanceled.id)).toBe(alreadyCanceled)
+
+      const snapshot = structuredClone(firstState)
+      store.ingestWorkflowExecutionEvent(terminalEvent)
+      expect(useConsoleStore.getState().entries).toEqual(snapshot)
+    })
+
+    it('marks running entries failed and preserves a more specific block error', () => {
+      const store = useConsoleStore.getState()
+      const base = {
+        workflowId: 'workflow-1',
+        executionId: 'exec-1',
+        timestamp: '2026-04-01T00:00:00.000Z',
+      }
+
+      store.ingestWorkflowExecutionEvent({
+        ...base,
+        type: 'block:started',
+        data: { blockId: 'specific', startedAt: base.timestamp, error: 'Block failed precisely' },
+      })
+      store.ingestWorkflowExecutionEvent({
+        ...base,
+        type: 'block:started',
+        data: { blockId: 'fallback', startedAt: base.timestamp },
+      })
+      store.ingestWorkflowExecutionEvent({
+        ...base,
+        timestamp: '2026-04-01T00:00:02.000Z',
+        type: 'execution:error',
+        data: {
+          error: 'Workflow execution failed',
+          result: { success: false, output: {}, error: 'Workflow execution failed' },
+        },
+      })
+
+      const entries = useConsoleStore.getState().entries
+      expect(entries.find((entry) => entry.blockId === 'specific')).toEqual(
+        expect.objectContaining({
+          success: false,
+          error: 'Block failed precisely',
+          isRunning: false,
+          isCanceled: false,
+          endedAt: '2026-04-01T00:00:02.000Z',
+          durationMs: 2000,
+        })
+      )
+      expect(entries.find((entry) => entry.blockId === 'fallback')).toEqual(
+        expect.objectContaining({
+          success: false,
+          error: 'Workflow execution failed',
+          isRunning: false,
+          isCanceled: false,
+          endedAt: '2026-04-01T00:00:02.000Z',
+          durationMs: 2000,
+        })
+      )
+    })
+
+    it('derives missing duration from a preserved terminal timestamp', () => {
+      const store = useConsoleStore.getState()
+      const entry = store.addConsole({
+        workflowId: 'workflow-1',
+        executionId: 'exec-1',
+        blockId: 'partially-terminal',
+        success: true,
+        startedAt: '2026-04-01T00:00:00.000Z',
+        endedAt: '2026-04-01T00:00:01.000Z',
+        durationMs: 0,
+        isRunning: true,
+        isCanceled: false,
+      })
+      const terminalEvent = {
+        workflowId: 'workflow-1',
+        executionId: 'exec-1',
+        timestamp: '2026-04-01T00:00:03.000Z',
+        type: 'execution:completed' as const,
+        data: { result: { success: true, output: {} } },
+      }
+
+      store.ingestWorkflowExecutionEvent(terminalEvent)
+
+      expect(
+        useConsoleStore.getState().entries.find((candidate) => candidate.id === entry.id)
+      ).toEqual(
+        expect.objectContaining({
+          endedAt: '2026-04-01T00:00:01.000Z',
+          durationMs: 1000,
+          isRunning: false,
+          isCanceled: false,
+        })
+      )
+      const snapshot = structuredClone(useConsoleStore.getState().entries)
+      store.ingestWorkflowExecutionEvent(terminalEvent)
+      expect(useConsoleStore.getState().entries).toEqual(snapshot)
+    })
+
+    it('marks a running entry canceled and handles invalid or missing start timing safely', () => {
+      const store = useConsoleStore.getState()
+      store.ingestWorkflowExecutionEvent({
+        workflowId: 'workflow-1',
+        executionId: 'exec-1',
+        timestamp: 'invalid-start',
+        type: 'block:started',
+        data: { blockId: 'invalid', startedAt: 'invalid-start' },
+      })
+      store.addConsole({
+        workflowId: 'workflow-1',
+        executionId: 'exec-1',
+        blockId: 'missing',
+        success: true,
+        durationMs: 125,
+        isRunning: true,
+        isCanceled: false,
+      })
+
+      const terminalEvent = {
+        workflowId: 'workflow-1',
+        executionId: 'exec-1',
+        timestamp: '2026-04-01T00:00:02.000Z',
+        type: 'execution:cancelled' as const,
+        data: {
+          result: { success: false, output: {}, error: 'Workflow execution was cancelled' },
+        },
+      }
+      store.ingestWorkflowExecutionEvent(terminalEvent)
+
+      const entries = useConsoleStore.getState().entries
+      expect(entries.find((entry) => entry.blockId === 'invalid')).toEqual(
+        expect.objectContaining({
+          isRunning: false,
+          isCanceled: true,
+          endedAt: terminalEvent.timestamp,
+          durationMs: 0,
+        })
+      )
+      expect(entries.find((entry) => entry.blockId === 'missing')).toEqual(
+        expect.objectContaining({
+          isRunning: false,
+          isCanceled: true,
+          endedAt: terminalEvent.timestamp,
+          durationMs: 125,
+        })
+      )
+      expect(entries.every((entry) => Number.isFinite(entry.durationMs))).toBe(true)
+    })
+
+    it('clears a terminal execution buffer with no running match and preserves other buffers', () => {
+      const store = useConsoleStore.getState()
+      const executionId = 'shared-execution-id'
+
+      for (const workflowId of ['workflow-1', 'workflow-2']) {
+        store.ingestWorkflowExecutionEvent({
+          workflowId,
+          executionId,
+          timestamp: '2026-04-01T00:00:00.000Z',
+          type: 'block:started',
+          data: { blockId: 'agent-1', startedAt: '2026-04-01T00:00:00.000Z' },
+        })
+        store.ingestWorkflowExecutionEvent({
+          workflowId,
+          executionId,
+          timestamp: '2026-04-01T00:00:01.000Z',
+          type: 'stream:chunk',
+          data: { blockId: 'agent-1', chunk: `${workflowId}-before` },
+        })
+      }
+
+      store.cancelRunningEntries('workflow-1')
+      const beforeTerminal = structuredClone(useConsoleStore.getState().entries)
+      store.ingestWorkflowExecutionEvent({
+        workflowId: 'workflow-1',
+        executionId,
+        timestamp: '2026-04-01T00:00:02.000Z',
+        type: 'execution:completed',
+        data: { result: { success: true, output: {} } },
+      })
+      expect(useConsoleStore.getState().entries).toEqual(beforeTerminal)
+
+      store.addConsole({
+        workflowId: 'workflow-1',
+        executionId,
+        blockId: 'agent-1',
+        success: true,
+        startedAt: '2026-04-01T00:00:03.000Z',
+        durationMs: 0,
+        isRunning: true,
+        isCanceled: false,
+      })
+      store.ingestWorkflowExecutionEvent({
+        workflowId: 'workflow-1',
+        executionId,
+        timestamp: '2026-04-01T00:00:04.000Z',
+        type: 'stream:chunk',
+        data: { blockId: 'agent-1', chunk: 'fresh-target' },
+      })
+      store.ingestWorkflowExecutionEvent({
+        workflowId: 'workflow-2',
+        executionId,
+        timestamp: '2026-04-01T00:00:04.000Z',
+        type: 'stream:chunk',
+        data: { blockId: 'agent-1', chunk: '-after' },
+      })
+
+      const entries = useConsoleStore.getState().entries
+      expect(
+        entries.find(
+          (entry) => entry.workflowId === 'workflow-1' && entry.startedAt?.endsWith('03.000Z')
+        )?.output?.content
+      ).toBe('fresh-target')
+      expect(entries.find((entry) => entry.workflowId === 'workflow-2')?.output?.content).toBe(
+        'workflow-2-before-after'
+      )
+    })
+
+    it('reconciles and clears only the matching workflow stream buffer', () => {
+      const store = useConsoleStore.getState()
+      const executionId = 'shared-execution-id'
+
+      for (const workflowId of ['workflow-1', 'workflow-2']) {
+        store.ingestWorkflowExecutionEvent({
+          workflowId,
+          executionId,
+          timestamp: '2026-04-01T00:00:00.000Z',
+          type: 'block:started',
+          data: { blockId: 'agent-1' },
+        })
+        store.ingestWorkflowExecutionEvent({
+          workflowId,
+          executionId,
+          timestamp: '2026-04-01T00:00:01.000Z',
+          type: 'stream:chunk',
+          data: { blockId: 'agent-1', chunk: workflowId },
+        })
+      }
+
+      store.ingestWorkflowExecutionEvent({
+        workflowId: 'workflow-1',
+        executionId,
+        timestamp: '2026-04-01T00:00:02.000Z',
+        type: 'execution:completed',
+        data: { result: { success: true, output: {} } },
+      })
+      store.ingestWorkflowExecutionEvent({
+        workflowId: 'workflow-2',
+        executionId,
+        timestamp: '2026-04-01T00:00:03.000Z',
+        type: 'stream:chunk',
+        data: { blockId: 'agent-1', chunk: '-continued' },
+      })
+
+      const entries = useConsoleStore.getState().entries
+      expect(entries.find((entry) => entry.workflowId === 'workflow-1')?.isRunning).toBe(false)
+      expect(entries.find((entry) => entry.workflowId === 'workflow-2')).toEqual(
+        expect.objectContaining({
+          isRunning: true,
+          output: { content: 'workflow-2-continued' },
+        })
+      )
+    })
   })
 
   describe('clearConsole', () => {

--- a/apps/tradinggoose/stores/console/store.test.ts
+++ b/apps/tradinggoose/stores/console/store.test.ts
@@ -106,6 +106,68 @@ describe('Console Store', () => {
       expect(second.id).toBe(first.id)
       expect(state.entries).toHaveLength(1)
     })
+
+    it('clears the stream buffer for an entry evicted by the capacity limit', () => {
+      const store = useConsoleStore.getState()
+      const base = {
+        executionId: 'evicted-execution',
+        workflowId: 'evicted-workflow',
+        timestamp: '2026-04-01T00:00:00.000Z',
+      }
+
+      store.ingestWorkflowExecutionEvent({
+        ...base,
+        type: 'block:started',
+        data: {
+          blockId: 'evicted-block',
+          blockName: 'Evicted Block',
+          blockType: 'agent',
+          startedAt: base.timestamp,
+        },
+      })
+      store.ingestWorkflowExecutionEvent({
+        ...base,
+        type: 'stream:chunk',
+        data: { blockId: 'evicted-block', chunk: 'stale' },
+      })
+
+      for (let index = 0; index < 500; index += 1) {
+        store.addConsole({
+          workflowId: 'capacity-workflow',
+          blockId: `capacity-block-${index}`,
+          blockName: 'Capacity Block',
+          blockType: 'agent',
+          success: true,
+        })
+      }
+
+      expect(useConsoleStore.getState().entries).toHaveLength(500)
+      expect(
+        useConsoleStore.getState().entries.some((entry) => entry.workflowId === base.workflowId)
+      ).toBe(false)
+
+      store.addConsole({
+        workflowId: base.workflowId,
+        executionId: base.executionId,
+        blockId: 'evicted-block',
+        blockName: 'Replacement Block',
+        blockType: 'agent',
+        success: true,
+        startedAt: '2026-04-01T00:00:01.000Z',
+        isRunning: true,
+      })
+      store.ingestWorkflowExecutionEvent({
+        ...base,
+        timestamp: '2026-04-01T00:00:01.100Z',
+        type: 'stream:chunk',
+        data: { blockId: 'evicted-block', chunk: 'fresh' },
+      })
+
+      const replacement = useConsoleStore
+        .getState()
+        .entries.find((entry) => entry.workflowId === base.workflowId)
+      expect(replacement?.output?.content).toBe('fresh')
+    })
   })
 
   describe('ingestWorkflowExecutionEvent', () => {
@@ -814,6 +876,57 @@ describe('Console Store', () => {
 
       expect(entries).toHaveLength(1)
       expect(entries[0]?.output?.content).toBe('after-clear')
+    })
+
+    it('clears workflow stream buffers when no matching entry remains', () => {
+      const store = useConsoleStore.getState()
+      const base = {
+        executionId: 'entryless-stream-clear',
+        workflowId: 'workflow-1',
+        timestamp: '2026-04-01T00:00:00.000Z',
+      }
+
+      store.ingestWorkflowExecutionEvent({
+        ...base,
+        type: 'block:started',
+        data: {
+          blockId: 'entryless-block',
+          blockName: 'Entryless Block',
+          blockType: 'agent',
+          startedAt: base.timestamp,
+        },
+      })
+      store.ingestWorkflowExecutionEvent({
+        ...base,
+        type: 'stream:chunk',
+        data: { blockId: 'entryless-block', chunk: 'stale' },
+      })
+      useConsoleStore.setState((state) => ({
+        entries: state.entries.filter((entry) => entry.workflowId !== base.workflowId),
+      }))
+
+      store.clearConsole(base.workflowId)
+      store.addConsole({
+        workflowId: base.workflowId,
+        executionId: base.executionId,
+        blockId: 'entryless-block',
+        blockName: 'Replacement Block',
+        blockType: 'agent',
+        success: true,
+        startedAt: '2026-04-01T00:00:01.000Z',
+        isRunning: true,
+      })
+      store.ingestWorkflowExecutionEvent({
+        ...base,
+        timestamp: '2026-04-01T00:00:01.100Z',
+        type: 'stream:chunk',
+        data: { blockId: 'entryless-block', chunk: 'fresh' },
+      })
+
+      const replacement = useConsoleStore
+        .getState()
+        .entries.find((entry) => entry.blockId === 'entryless-block')
+      expect(replacement?.output?.content).toBe('fresh')
     })
   })
 

--- a/apps/tradinggoose/stores/console/store.test.ts
+++ b/apps/tradinggoose/stores/console/store.test.ts
@@ -106,71 +106,20 @@ describe('Console Store', () => {
       expect(second.id).toBe(first.id)
       expect(state.entries).toHaveLength(1)
     })
-
-    it('clears the stream buffer for an entry evicted by the capacity limit', () => {
-      const store = useConsoleStore.getState()
-      const base = {
-        executionId: 'evicted-execution',
-        workflowId: 'evicted-workflow',
-        timestamp: '2026-04-01T00:00:00.000Z',
-      }
-
-      store.ingestWorkflowExecutionEvent({
-        ...base,
-        type: 'block:started',
-        data: {
-          blockId: 'evicted-block',
-          blockName: 'Evicted Block',
-          blockType: 'agent',
-          startedAt: base.timestamp,
-        },
-      })
-      store.ingestWorkflowExecutionEvent({
-        ...base,
-        type: 'stream:chunk',
-        data: { blockId: 'evicted-block', chunk: 'stale' },
-      })
-
-      for (let index = 0; index < 500; index += 1) {
-        store.addConsole({
-          workflowId: 'capacity-workflow',
-          blockId: `capacity-block-${index}`,
-          blockName: 'Capacity Block',
-          blockType: 'agent',
-          success: true,
-        })
-      }
-
-      expect(useConsoleStore.getState().entries).toHaveLength(500)
-      expect(
-        useConsoleStore.getState().entries.some((entry) => entry.workflowId === base.workflowId)
-      ).toBe(false)
-
-      store.addConsole({
-        workflowId: base.workflowId,
-        executionId: base.executionId,
-        blockId: 'evicted-block',
-        blockName: 'Replacement Block',
-        blockType: 'agent',
-        success: true,
-        startedAt: '2026-04-01T00:00:01.000Z',
-        isRunning: true,
-      })
-      store.ingestWorkflowExecutionEvent({
-        ...base,
-        timestamp: '2026-04-01T00:00:01.100Z',
-        type: 'stream:chunk',
-        data: { blockId: 'evicted-block', chunk: 'fresh' },
-      })
-
-      const replacement = useConsoleStore
-        .getState()
-        .entries.find((entry) => entry.workflowId === base.workflowId)
-      expect(replacement?.output?.content).toBe('fresh')
-    })
   })
 
   describe('ingestWorkflowExecutionEvent', () => {
+    const startBlock = (blockId: string, executionId = 'exec-1', workflowId = 'workflow-1') => {
+      const timestamp = '2026-04-01T00:00:00.000Z'
+      useConsoleStore.getState().ingestWorkflowExecutionEvent({
+        workflowId,
+        executionId,
+        timestamp,
+        type: 'block:started',
+        data: { blockId, startedAt: timestamp },
+      })
+    }
+
     it('streams workflow execution chunks and keeps repeated block runs separate', () => {
       const store = useConsoleStore.getState()
       const base = {
@@ -406,376 +355,86 @@ describe('Console Store', () => {
       expect(completed).toBeUndefined()
     })
 
-    it('finalizes every running entry for a completed execution without touching other entries', () => {
+    it('finalizes every running entry for only the completed execution', () => {
       const store = useConsoleStore.getState()
-      const startedAt = '2026-04-01T00:00:00.000Z'
+      startBlock('matching-1')
+      startBlock('matching-2')
+      startBlock('other-execution', 'exec-2')
+      startBlock('other-workflow', 'exec-1', 'workflow-2')
 
-      for (const [workflowId, executionId, blockId, iterationCurrent] of [
-        ['workflow-1', 'exec-1', 'matching-1', 1],
-        ['workflow-1', 'exec-1', 'matching-2', 2],
-        ['workflow-1', 'exec-2', 'other-execution', 1],
-        ['workflow-2', 'exec-1', 'other-workflow', 1],
-      ] as const) {
-        store.ingestWorkflowExecutionEvent({
-          workflowId,
-          executionId,
-          timestamp: startedAt,
-          type: 'block:started',
-          data: { blockId, startedAt, iterationType: 'parallel', iterationCurrent },
-        })
+      store.ingestWorkflowExecutionEvent({
+        workflowId: 'workflow-1',
+        executionId: 'exec-1',
+        timestamp: '2026-04-01T00:00:02.000Z',
+        type: 'execution:completed',
+        data: { result: { success: true, output: {} } },
+      })
+
+      const entries = useConsoleStore.getState().entries
+      const matchingEntries = entries.filter((entry) => entry.blockId.startsWith('matching-'))
+
+      expect(matchingEntries).toHaveLength(2)
+      for (const entry of matchingEntries) {
+        expect(entry).toEqual(
+          expect.objectContaining({
+            success: true,
+            endedAt: '2026-04-01T00:00:02.000Z',
+            durationMs: 2000,
+            isRunning: false,
+            isCanceled: false,
+          })
+        )
       }
+      expect(entries.find((entry) => entry.blockId === 'other-execution')?.isRunning).toBe(true)
+      expect(entries.find((entry) => entry.blockId === 'other-workflow')?.isRunning).toBe(true)
+    })
 
-      store.addConsole({
-        workflowId: 'workflow-1',
-        executionId: 'exec-1',
-        blockId: 'matching-with-duration',
-        success: true,
-        startedAt,
-        durationMs: 750,
-        isRunning: true,
+    it.each([
+      {
+        event: {
+          workflowId: 'workflow-1',
+          executionId: 'error-execution',
+          timestamp: '2026-04-01T00:00:02.000Z',
+          type: 'execution:error' as const,
+          data: {
+            error: 'Workflow execution time limit exceeded',
+            result: {
+              success: false,
+              output: {},
+              error: 'Workflow execution time limit exceeded',
+            },
+          },
+        },
         isCanceled: false,
-      })
-      const alreadyCompleted = store.addConsole({
-        workflowId: 'workflow-1',
-        executionId: 'exec-1',
-        blockId: 'already-completed',
-        success: true,
-        startedAt,
-        endedAt: '2026-04-01T00:00:01.000Z',
-        durationMs: 1000,
-        isRunning: false,
-        isCanceled: false,
-      })
-      const alreadyFailed = store.addConsole({
-        workflowId: 'workflow-1',
-        executionId: 'exec-1',
-        blockId: 'already-failed',
-        success: false,
-        error: 'Specific block error',
-        startedAt,
-        endedAt: '2026-04-01T00:00:01.500Z',
-        durationMs: 1500,
-        isRunning: false,
-        isCanceled: false,
-      })
-      const alreadyCanceled = store.addConsole({
-        workflowId: 'workflow-1',
-        executionId: 'exec-1',
-        blockId: 'already-canceled',
-        success: false,
-        startedAt,
-        endedAt: '2026-04-01T00:00:02.000Z',
-        durationMs: 2000,
-        isRunning: false,
+        expectedError: 'Workflow execution time limit exceeded',
+      },
+      {
+        event: {
+          workflowId: 'workflow-1',
+          executionId: 'cancelled-execution',
+          timestamp: '2026-04-01T00:00:02.000Z',
+          type: 'execution:cancelled' as const,
+          data: {
+            result: { success: false, output: {}, error: 'Workflow execution was cancelled' },
+          },
+        },
         isCanceled: true,
-      })
+        expectedError: undefined,
+      },
+    ])('marks unresolved entries failed on $event.type', ({ event, isCanceled, expectedError }) => {
+      startBlock(event.type, event.executionId)
+      useConsoleStore.getState().ingestWorkflowExecutionEvent(event)
 
-      const terminalEvent = {
-        workflowId: 'workflow-1',
-        executionId: 'exec-1',
-        timestamp: '2026-04-01T00:00:03.000Z',
-        type: 'execution:completed' as const,
-        data: { result: { success: true, output: {} } },
-      }
-      store.ingestWorkflowExecutionEvent(terminalEvent)
-
-      const firstState = useConsoleStore.getState().entries
-      const matching = firstState.filter(
-        (entry) =>
-          entry.workflowId === 'workflow-1' &&
-          entry.executionId === 'exec-1' &&
-          entry.blockId.startsWith('matching')
-      )
-      expect(matching).toHaveLength(3)
-      expect(matching).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            blockId: 'matching-1',
-            isRunning: false,
-            isCanceled: false,
-            endedAt: terminalEvent.timestamp,
-            durationMs: 3000,
-          }),
-          expect.objectContaining({
-            blockId: 'matching-2',
-            isRunning: false,
-            isCanceled: false,
-            endedAt: terminalEvent.timestamp,
-            durationMs: 3000,
-          }),
-          expect.objectContaining({
-            blockId: 'matching-with-duration',
-            isRunning: false,
-            isCanceled: false,
-            endedAt: terminalEvent.timestamp,
-            durationMs: 750,
-          }),
-        ])
-      )
-      expect(firstState.find((entry) => entry.blockId === 'other-execution')?.isRunning).toBe(true)
-      expect(firstState.find((entry) => entry.blockId === 'other-workflow')?.isRunning).toBe(true)
-      expect(firstState.find((entry) => entry.id === alreadyCompleted.id)).toBe(alreadyCompleted)
-      expect(firstState.find((entry) => entry.id === alreadyFailed.id)).toBe(alreadyFailed)
-      expect(firstState.find((entry) => entry.id === alreadyCanceled.id)).toBe(alreadyCanceled)
-
-      const snapshot = structuredClone(firstState)
-      store.ingestWorkflowExecutionEvent(terminalEvent)
-      expect(useConsoleStore.getState().entries).toEqual(snapshot)
-    })
-
-    it('marks running entries failed and preserves a more specific block error', () => {
-      const store = useConsoleStore.getState()
-      const base = {
-        workflowId: 'workflow-1',
-        executionId: 'exec-1',
-        timestamp: '2026-04-01T00:00:00.000Z',
-      }
-
-      store.ingestWorkflowExecutionEvent({
-        ...base,
-        type: 'block:started',
-        data: { blockId: 'specific', startedAt: base.timestamp, error: 'Block failed precisely' },
-      })
-      store.ingestWorkflowExecutionEvent({
-        ...base,
-        type: 'block:started',
-        data: { blockId: 'fallback', startedAt: base.timestamp },
-      })
-      store.ingestWorkflowExecutionEvent({
-        ...base,
-        timestamp: '2026-04-01T00:00:02.000Z',
-        type: 'execution:error',
-        data: {
-          error: 'Workflow execution failed',
-          result: { success: false, output: {}, error: 'Workflow execution failed' },
-        },
-      })
-
-      const entries = useConsoleStore.getState().entries
-      expect(entries.find((entry) => entry.blockId === 'specific')).toEqual(
+      const entry = useConsoleStore.getState().entries[0]
+      expect(entry).toEqual(
         expect.objectContaining({
           success: false,
-          error: 'Block failed precisely',
-          isRunning: false,
-          isCanceled: false,
-          endedAt: '2026-04-01T00:00:02.000Z',
           durationMs: 2000,
-        })
-      )
-      expect(entries.find((entry) => entry.blockId === 'fallback')).toEqual(
-        expect.objectContaining({
-          success: false,
-          error: 'Workflow execution failed',
           isRunning: false,
-          isCanceled: false,
-          endedAt: '2026-04-01T00:00:02.000Z',
-          durationMs: 2000,
+          isCanceled,
         })
       )
-    })
-
-    it('derives missing duration from a preserved terminal timestamp', () => {
-      const store = useConsoleStore.getState()
-      const entry = store.addConsole({
-        workflowId: 'workflow-1',
-        executionId: 'exec-1',
-        blockId: 'partially-terminal',
-        success: true,
-        startedAt: '2026-04-01T00:00:00.000Z',
-        endedAt: '2026-04-01T00:00:01.000Z',
-        durationMs: 0,
-        isRunning: true,
-        isCanceled: false,
-      })
-      const terminalEvent = {
-        workflowId: 'workflow-1',
-        executionId: 'exec-1',
-        timestamp: '2026-04-01T00:00:03.000Z',
-        type: 'execution:completed' as const,
-        data: { result: { success: true, output: {} } },
-      }
-
-      store.ingestWorkflowExecutionEvent(terminalEvent)
-
-      expect(
-        useConsoleStore.getState().entries.find((candidate) => candidate.id === entry.id)
-      ).toEqual(
-        expect.objectContaining({
-          endedAt: '2026-04-01T00:00:01.000Z',
-          durationMs: 1000,
-          isRunning: false,
-          isCanceled: false,
-        })
-      )
-      const snapshot = structuredClone(useConsoleStore.getState().entries)
-      store.ingestWorkflowExecutionEvent(terminalEvent)
-      expect(useConsoleStore.getState().entries).toEqual(snapshot)
-    })
-
-    it('marks a running entry canceled and handles invalid or missing start timing safely', () => {
-      const store = useConsoleStore.getState()
-      store.ingestWorkflowExecutionEvent({
-        workflowId: 'workflow-1',
-        executionId: 'exec-1',
-        timestamp: 'invalid-start',
-        type: 'block:started',
-        data: { blockId: 'invalid', startedAt: 'invalid-start' },
-      })
-      store.addConsole({
-        workflowId: 'workflow-1',
-        executionId: 'exec-1',
-        blockId: 'missing',
-        success: true,
-        durationMs: 125,
-        isRunning: true,
-        isCanceled: false,
-      })
-
-      const terminalEvent = {
-        workflowId: 'workflow-1',
-        executionId: 'exec-1',
-        timestamp: '2026-04-01T00:00:02.000Z',
-        type: 'execution:cancelled' as const,
-        data: {
-          result: { success: false, output: {}, error: 'Workflow execution was cancelled' },
-        },
-      }
-      store.ingestWorkflowExecutionEvent(terminalEvent)
-
-      const entries = useConsoleStore.getState().entries
-      expect(entries.find((entry) => entry.blockId === 'invalid')).toEqual(
-        expect.objectContaining({
-          success: false,
-          isRunning: false,
-          isCanceled: true,
-          endedAt: terminalEvent.timestamp,
-          durationMs: 0,
-        })
-      )
-      expect(entries.find((entry) => entry.blockId === 'missing')).toEqual(
-        expect.objectContaining({
-          success: false,
-          isRunning: false,
-          isCanceled: true,
-          endedAt: terminalEvent.timestamp,
-          durationMs: 125,
-        })
-      )
-      expect(entries.every((entry) => Number.isFinite(entry.durationMs))).toBe(true)
-    })
-
-    it('clears a terminal execution buffer with no running match and preserves other buffers', () => {
-      const store = useConsoleStore.getState()
-      const executionId = 'shared-execution-id'
-
-      for (const workflowId of ['workflow-1', 'workflow-2']) {
-        store.ingestWorkflowExecutionEvent({
-          workflowId,
-          executionId,
-          timestamp: '2026-04-01T00:00:00.000Z',
-          type: 'block:started',
-          data: { blockId: 'agent-1', startedAt: '2026-04-01T00:00:00.000Z' },
-        })
-        store.ingestWorkflowExecutionEvent({
-          workflowId,
-          executionId,
-          timestamp: '2026-04-01T00:00:01.000Z',
-          type: 'stream:chunk',
-          data: { blockId: 'agent-1', chunk: `${workflowId}-before` },
-        })
-      }
-
-      store.cancelRunningEntries('workflow-1')
-      const beforeTerminal = structuredClone(useConsoleStore.getState().entries)
-      store.ingestWorkflowExecutionEvent({
-        workflowId: 'workflow-1',
-        executionId,
-        timestamp: '2026-04-01T00:00:02.000Z',
-        type: 'execution:completed',
-        data: { result: { success: true, output: {} } },
-      })
-      expect(useConsoleStore.getState().entries).toEqual(beforeTerminal)
-
-      store.addConsole({
-        workflowId: 'workflow-1',
-        executionId,
-        blockId: 'agent-1',
-        success: true,
-        startedAt: '2026-04-01T00:00:03.000Z',
-        durationMs: 0,
-        isRunning: true,
-        isCanceled: false,
-      })
-      store.ingestWorkflowExecutionEvent({
-        workflowId: 'workflow-1',
-        executionId,
-        timestamp: '2026-04-01T00:00:04.000Z',
-        type: 'stream:chunk',
-        data: { blockId: 'agent-1', chunk: 'fresh-target' },
-      })
-      store.ingestWorkflowExecutionEvent({
-        workflowId: 'workflow-2',
-        executionId,
-        timestamp: '2026-04-01T00:00:04.000Z',
-        type: 'stream:chunk',
-        data: { blockId: 'agent-1', chunk: '-after' },
-      })
-
-      const entries = useConsoleStore.getState().entries
-      expect(
-        entries.find(
-          (entry) => entry.workflowId === 'workflow-1' && entry.startedAt?.endsWith('03.000Z')
-        )?.output?.content
-      ).toBe('fresh-target')
-      expect(entries.find((entry) => entry.workflowId === 'workflow-2')?.output?.content).toBe(
-        'workflow-2-before-after'
-      )
-    })
-
-    it('reconciles and clears only the matching workflow stream buffer', () => {
-      const store = useConsoleStore.getState()
-      const executionId = 'shared-execution-id'
-
-      for (const workflowId of ['workflow-1', 'workflow-2']) {
-        store.ingestWorkflowExecutionEvent({
-          workflowId,
-          executionId,
-          timestamp: '2026-04-01T00:00:00.000Z',
-          type: 'block:started',
-          data: { blockId: 'agent-1' },
-        })
-        store.ingestWorkflowExecutionEvent({
-          workflowId,
-          executionId,
-          timestamp: '2026-04-01T00:00:01.000Z',
-          type: 'stream:chunk',
-          data: { blockId: 'agent-1', chunk: workflowId },
-        })
-      }
-
-      store.ingestWorkflowExecutionEvent({
-        workflowId: 'workflow-1',
-        executionId,
-        timestamp: '2026-04-01T00:00:02.000Z',
-        type: 'execution:completed',
-        data: { result: { success: true, output: {} } },
-      })
-      store.ingestWorkflowExecutionEvent({
-        workflowId: 'workflow-2',
-        executionId,
-        timestamp: '2026-04-01T00:00:03.000Z',
-        type: 'stream:chunk',
-        data: { blockId: 'agent-1', chunk: '-continued' },
-      })
-
-      const entries = useConsoleStore.getState().entries
-      expect(entries.find((entry) => entry.workflowId === 'workflow-1')?.isRunning).toBe(false)
-      expect(entries.find((entry) => entry.workflowId === 'workflow-2')).toEqual(
-        expect.objectContaining({
-          isRunning: true,
-          output: { content: 'workflow-2-continued' },
-        })
-      )
+      expect(entry?.error).toBe(expectedError)
     })
   })
 
@@ -877,57 +536,6 @@ describe('Console Store', () => {
       expect(entries).toHaveLength(1)
       expect(entries[0]?.output?.content).toBe('after-clear')
     })
-
-    it('clears workflow stream buffers when no matching entry remains', () => {
-      const store = useConsoleStore.getState()
-      const base = {
-        executionId: 'entryless-stream-clear',
-        workflowId: 'workflow-1',
-        timestamp: '2026-04-01T00:00:00.000Z',
-      }
-
-      store.ingestWorkflowExecutionEvent({
-        ...base,
-        type: 'block:started',
-        data: {
-          blockId: 'entryless-block',
-          blockName: 'Entryless Block',
-          blockType: 'agent',
-          startedAt: base.timestamp,
-        },
-      })
-      store.ingestWorkflowExecutionEvent({
-        ...base,
-        type: 'stream:chunk',
-        data: { blockId: 'entryless-block', chunk: 'stale' },
-      })
-      useConsoleStore.setState((state) => ({
-        entries: state.entries.filter((entry) => entry.workflowId !== base.workflowId),
-      }))
-
-      store.clearConsole(base.workflowId)
-      store.addConsole({
-        workflowId: base.workflowId,
-        executionId: base.executionId,
-        blockId: 'entryless-block',
-        blockName: 'Replacement Block',
-        blockType: 'agent',
-        success: true,
-        startedAt: '2026-04-01T00:00:01.000Z',
-        isRunning: true,
-      })
-      store.ingestWorkflowExecutionEvent({
-        ...base,
-        timestamp: '2026-04-01T00:00:01.100Z',
-        type: 'stream:chunk',
-        data: { blockId: 'entryless-block', chunk: 'fresh' },
-      })
-
-      const replacement = useConsoleStore
-        .getState()
-        .entries.find((entry) => entry.blockId === 'entryless-block')
-      expect(replacement?.output?.content).toBe('fresh')
-    })
   })
 
   describe('cancelRunningEntries', () => {
@@ -942,7 +550,6 @@ describe('Console Store', () => {
         success: true,
         output: {},
         startedAt: '2023-01-01T00:00:00.000Z',
-        endedAt: '2023-01-01T00:00:01.000Z',
         isRunning: true,
       })
 
@@ -954,7 +561,6 @@ describe('Console Store', () => {
         success: true,
         output: {},
         startedAt: '2023-01-01T00:00:00.000Z',
-        endedAt: '2023-01-01T00:00:01.000Z',
         isRunning: true,
       })
     })

--- a/apps/tradinggoose/stores/console/store.test.ts
+++ b/apps/tradinggoose/stores/console/store.test.ts
@@ -22,6 +22,17 @@ describe('Console Store', () => {
     }
   })
 
+  const startBlock = (blockId: string, executionId = 'exec-1', workflowId = 'workflow-1') => {
+    const timestamp = '2026-04-01T00:00:00.000Z'
+    useConsoleStore.getState().ingestWorkflowExecutionEvent({
+      workflowId,
+      executionId,
+      timestamp,
+      type: 'block:started',
+      data: { blockId, startedAt: timestamp },
+    })
+  }
+
   describe('addConsole', () => {
     it('should add a new console entry with required fields', () => {
       const store = useConsoleStore.getState()
@@ -109,17 +120,6 @@ describe('Console Store', () => {
   })
 
   describe('ingestWorkflowExecutionEvent', () => {
-    const startBlock = (blockId: string, executionId = 'exec-1', workflowId = 'workflow-1') => {
-      const timestamp = '2026-04-01T00:00:00.000Z'
-      useConsoleStore.getState().ingestWorkflowExecutionEvent({
-        workflowId,
-        executionId,
-        timestamp,
-        type: 'block:started',
-        data: { blockId, startedAt: timestamp },
-      })
-    }
-
     it('streams workflow execution chunks and keeps repeated block runs separate', () => {
       const store = useConsoleStore.getState()
       const base = {
@@ -355,86 +355,36 @@ describe('Console Store', () => {
       expect(completed).toBeUndefined()
     })
 
-    it('finalizes every running entry for only the completed execution', () => {
-      const store = useConsoleStore.getState()
-      startBlock('matching-1')
-      startBlock('matching-2')
+    it('applies a timeout only to its running execution', () => {
+      startBlock('timed-out')
       startBlock('other-execution', 'exec-2')
       startBlock('other-workflow', 'exec-1', 'workflow-2')
 
-      store.ingestWorkflowExecutionEvent({
+      useConsoleStore.getState().ingestWorkflowExecutionEvent({
         workflowId: 'workflow-1',
         executionId: 'exec-1',
         timestamp: '2026-04-01T00:00:02.000Z',
-        type: 'execution:completed',
-        data: { result: { success: true, output: {} } },
+        type: 'execution:error',
+        data: {
+          error: 'Workflow execution time limit exceeded',
+          result: {
+            success: false,
+            output: {},
+            error: 'Workflow execution time limit exceeded',
+          },
+        },
       })
 
       const entries = useConsoleStore.getState().entries
-      const matchingEntries = entries.filter((entry) => entry.blockId.startsWith('matching-'))
-
-      expect(matchingEntries).toHaveLength(2)
-      for (const entry of matchingEntries) {
-        expect(entry).toEqual(
-          expect.objectContaining({
-            success: true,
-            endedAt: '2026-04-01T00:00:02.000Z',
-            durationMs: 2000,
-            isRunning: false,
-            isCanceled: false,
-          })
-        )
-      }
+      expect(entries.find((entry) => entry.blockId === 'timed-out')).toMatchObject({
+        success: false,
+        error: 'Workflow execution time limit exceeded',
+        durationMs: 2000,
+        isRunning: false,
+        isCanceled: false,
+      })
       expect(entries.find((entry) => entry.blockId === 'other-execution')?.isRunning).toBe(true)
       expect(entries.find((entry) => entry.blockId === 'other-workflow')?.isRunning).toBe(true)
-    })
-
-    it.each([
-      {
-        event: {
-          workflowId: 'workflow-1',
-          executionId: 'error-execution',
-          timestamp: '2026-04-01T00:00:02.000Z',
-          type: 'execution:error' as const,
-          data: {
-            error: 'Workflow execution time limit exceeded',
-            result: {
-              success: false,
-              output: {},
-              error: 'Workflow execution time limit exceeded',
-            },
-          },
-        },
-        isCanceled: false,
-        expectedError: 'Workflow execution time limit exceeded',
-      },
-      {
-        event: {
-          workflowId: 'workflow-1',
-          executionId: 'cancelled-execution',
-          timestamp: '2026-04-01T00:00:02.000Z',
-          type: 'execution:cancelled' as const,
-          data: {
-            result: { success: false, output: {}, error: 'Workflow execution was cancelled' },
-          },
-        },
-        isCanceled: true,
-        expectedError: undefined,
-      },
-    ])('marks unresolved entries failed on $event.type', ({ event, isCanceled, expectedError }) => {
-      startBlock(event.type, event.executionId)
-      useConsoleStore.getState().ingestWorkflowExecutionEvent(event)
-
-      const entry = useConsoleStore.getState().entries[0]
-      expect(entry).toEqual(
-        expect.objectContaining({
-          success: false,
-          durationMs: 2000,
-          isRunning: false,
-          isCanceled,
-        })
-      )
-      expect(entry?.error).toBe(expectedError)
     })
   })
 
@@ -539,47 +489,71 @@ describe('Console Store', () => {
   })
 
   describe('cancelRunningEntries', () => {
-    beforeEach(() => {
+    it('keeps cancellation terminal and clears its stream buffer', () => {
       const store = useConsoleStore.getState()
-
-      store.addConsole({
+      startBlock('block-1')
+      startBlock('block-2', 'exec-2', 'workflow-2')
+      const base = {
         workflowId: 'workflow-1',
+        executionId: 'exec-1',
+        timestamp: '2026-04-01T00:00:01.000Z',
+      }
+
+      store.ingestWorkflowExecutionEvent({
+        ...base,
+        type: 'stream:chunk',
+        data: { blockId: 'block-1', chunk: 'before-cancel' },
+      })
+      store.cancelRunningEntries(base.workflowId)
+      store.ingestWorkflowExecutionEvent({
+        ...base,
+        type: 'stream:chunk',
+        data: { blockId: 'block-1', chunk: 'late' },
+      })
+
+      const replacement = store.addConsole({
+        workflowId: base.workflowId,
+        executionId: base.executionId,
         blockId: 'block-1',
-        blockName: 'Block 1',
-        blockType: 'agent',
         success: true,
         output: {},
-        startedAt: '2023-01-01T00:00:00.000Z',
+        startedAt: '2026-04-01T00:00:02.000Z',
         isRunning: true,
       })
+      store.ingestWorkflowExecutionEvent({
+        ...base,
+        type: 'stream:chunk',
+        data: { blockId: 'block-1', chunk: 'fresh' },
+      })
+      store.ingestWorkflowExecutionEvent({
+        ...base,
+        type: 'block:completed',
+        data: {
+          blockId: 'block-1',
+          startedAt: '2026-04-01T00:00:00.000Z',
+          endedAt: base.timestamp,
+        },
+      })
 
-      store.addConsole({
-        workflowId: 'workflow-2',
-        blockId: 'block-2',
-        blockName: 'Block 2',
-        blockType: 'api',
+      const entries = useConsoleStore.getState().entries
+      const canceled = entries.find(
+        (entry) => entry.workflowId === base.workflowId && !entry.isRunning
+      )
+
+      expect(canceled).toMatchObject({
+        success: false,
+        isRunning: false,
+        isCanceled: true,
+        output: { content: 'before-cancel' },
+      })
+      expect(entries.find((entry) => entry.id === replacement.id)).toMatchObject({
+        isRunning: true,
+        output: { content: 'fresh' },
+      })
+      expect(entries.find((entry) => entry.workflowId === 'workflow-2')).toMatchObject({
         success: true,
-        output: {},
-        startedAt: '2023-01-01T00:00:00.000Z',
         isRunning: true,
       })
-    })
-
-    it('should mark running entries as canceled for a workflow', () => {
-      const store = useConsoleStore.getState()
-
-      store.cancelRunningEntries('workflow-1')
-
-      const state = useConsoleStore.getState()
-      const workflow1Entry = state.entries.find((entry) => entry.workflowId === 'workflow-1')
-      const workflow2Entry = state.entries.find((entry) => entry.workflowId === 'workflow-2')
-
-      expect(workflow1Entry?.isRunning).toBe(false)
-      expect(workflow1Entry?.isCanceled).toBe(true)
-      expect(workflow1Entry?.success).toBe(false)
-      expect(workflow2Entry?.isRunning).toBe(true)
-      expect(workflow2Entry?.isCanceled).toBeUndefined()
-      expect(workflow2Entry?.success).toBe(true)
     })
   })
 })

--- a/apps/tradinggoose/stores/console/store.ts
+++ b/apps/tradinggoose/stores/console/store.ts
@@ -145,16 +145,17 @@ const applyConsolePatch = (entry: ConsoleEntry, patch: ConsoleEntryPatch): Conso
 }
 
 const executionBlockKey = (
+  workflowId: string,
   executionId: string | undefined,
   blockId: string,
   data?: Pick<WorkflowExecutionBlockData, 'iterationCurrent' | 'iterationType'>
 ) =>
-  `${executionId ?? 'execution'}:${blockId}:${data?.iterationType ?? ''}:${data?.iterationCurrent ?? ''}`
+  `${workflowId}:${executionId ?? 'execution'}:${blockId}:${data?.iterationType ?? ''}:${data?.iterationCurrent ?? ''}`
 
 const streamBuffers = new Map<string, string>()
 
-const clearExecutionStreamBuffers = (executionId: string | undefined) => {
-  const prefix = `${executionId ?? 'execution'}:`
+const clearExecutionStreamBuffers = (workflowId: string, executionId: string | undefined) => {
+  const prefix = `${workflowId}:${executionId ?? 'execution'}:`
   for (const key of streamBuffers.keys()) {
     if (key.startsWith(prefix)) streamBuffers.delete(key)
   }
@@ -247,7 +248,7 @@ export const useConsoleStore = create<ConsoleStore>()(
             return {
               entries: state.entries.filter((entry) => {
                 if (entry.workflowId !== workflowId) return true
-                clearExecutionStreamBuffers(entry.executionId)
+                clearExecutionStreamBuffers(entry.workflowId, entry.executionId)
                 return false
               }),
             }
@@ -347,13 +348,15 @@ export const useConsoleStore = create<ConsoleStore>()(
 
         ingestWorkflowExecutionEvent: (event: WorkflowExecutionEvent) => {
           const deleteStreamBuffer = (data: WorkflowExecutionBlockData) => {
-            streamBuffers.delete(executionBlockKey(event.executionId, data.blockId, data))
+            streamBuffers.delete(
+              executionBlockKey(event.workflowId, event.executionId, data.blockId, data)
+            )
             const existingEntry = findExecutionEntry(get().entries, event, data, {
               allowRunningFallback: true,
             })
             if (existingEntry) {
               streamBuffers.delete(
-                executionBlockKey(event.executionId, data.blockId, existingEntry)
+                executionBlockKey(event.workflowId, event.executionId, data.blockId, existingEntry)
               )
             }
           }
@@ -417,7 +420,7 @@ export const useConsoleStore = create<ConsoleStore>()(
 
           if (event.type === 'block:started') {
             streamBuffers.delete(
-              executionBlockKey(event.executionId, event.data.blockId, event.data)
+              executionBlockKey(event.workflowId, event.executionId, event.data.blockId, event.data)
             )
             writeBlock(event.data, { success: true, isRunning: true, isCanceled: false })
             return
@@ -435,7 +438,12 @@ export const useConsoleStore = create<ConsoleStore>()(
             })
             if (!existingEntry) return
 
-            const key = executionBlockKey(event.executionId, blockId, existingEntry)
+            const key = executionBlockKey(
+              event.workflowId,
+              event.executionId,
+              blockId,
+              existingEntry
+            )
             const content = `${streamBuffers.get(key) ?? ''}${chunk}`
             streamBuffers.set(key, content)
             set((state) => ({
@@ -466,7 +474,49 @@ export const useConsoleStore = create<ConsoleStore>()(
           }
 
           if (isTerminalWorkflowExecutionEvent(event)) {
-            clearExecutionStreamBuffers(event.executionId)
+            set((state) => ({
+              entries: state.entries.map((entry) => {
+                if (
+                  entry.workflowId !== event.workflowId ||
+                  entry.executionId !== event.executionId ||
+                  !entry.isRunning
+                ) {
+                  return entry
+                }
+
+                const endedAt = entry.endedAt || event.timestamp
+                const startedAtMs = entry.startedAt ? Date.parse(entry.startedAt) : Number.NaN
+                const endedAtMs = Date.parse(endedAt)
+                const durationMs =
+                  Number.isFinite(entry.durationMs) && entry.durationMs! > 0
+                    ? entry.durationMs
+                    : Number.isFinite(startedAtMs) && Number.isFinite(endedAtMs)
+                      ? Math.max(0, endedAtMs - startedAtMs)
+                      : Number.isFinite(entry.durationMs) && entry.durationMs! >= 0
+                        ? entry.durationMs
+                        : 0
+                if (event.type === 'execution:error') {
+                  return {
+                    ...entry,
+                    success: false,
+                    error: entry.error || event.data.error,
+                    endedAt,
+                    durationMs,
+                    isRunning: false,
+                    isCanceled: false,
+                  }
+                }
+
+                return {
+                  ...entry,
+                  endedAt,
+                  durationMs,
+                  isRunning: false,
+                  isCanceled: event.type === 'execution:cancelled',
+                }
+              }),
+            }))
+            clearExecutionStreamBuffers(event.workflowId, event.executionId)
           }
         },
 

--- a/apps/tradinggoose/stores/console/store.ts
+++ b/apps/tradinggoose/stores/console/store.ts
@@ -145,28 +145,23 @@ const applyConsolePatch = (entry: ConsoleEntry, patch: ConsoleEntryPatch): Conso
 }
 
 const executionBlockKey = (
-  workflowId: string,
   executionId: string | undefined,
   blockId: string,
   data?: Pick<WorkflowExecutionBlockData, 'iterationCurrent' | 'iterationType'>
 ) =>
-  `${workflowId}:${executionId ?? 'execution'}:${blockId}:${data?.iterationType ?? ''}:${data?.iterationCurrent ?? ''}`
+  `${executionId ?? 'execution'}:${blockId}:${data?.iterationType ?? ''}:${data?.iterationCurrent ?? ''}`
 
 const streamBuffers = new Map<string, string>()
 
-const clearWorkflowStreamBuffers = (workflowId: string) => {
-  const prefix = `${workflowId}:`
+const clearExecutionStreamBuffers = (executionId: string | undefined) => {
+  const prefix = `${executionId ?? 'execution'}:`
   for (const key of streamBuffers.keys()) {
     if (key.startsWith(prefix)) streamBuffers.delete(key)
   }
 }
 
-const clearExecutionStreamBuffers = (workflowId: string, executionId: string | undefined) => {
-  const prefix = `${workflowId}:${executionId ?? 'execution'}:`
-  for (const key of streamBuffers.keys()) {
-    if (key.startsWith(prefix)) streamBuffers.delete(key)
-  }
-}
+const calculateDurationMs = (startedAt: string | undefined, endedAt: string) =>
+  startedAt ? Math.max(0, Date.parse(endedAt) - Date.parse(startedAt)) : 0
 
 const findExecutionEntry = (
   entries: ConsoleEntry[],
@@ -240,38 +235,24 @@ export const useConsoleStore = create<ConsoleStore>()(
             timestamp: new Date().toISOString(),
           }
 
-          set((state) => {
-            const entries = [newEntry, ...state.entries]
-            for (const evictedEntry of entries.slice(MAX_ENTRIES)) {
-              streamBuffers.delete(
-                executionBlockKey(
-                  evictedEntry.workflowId,
-                  evictedEntry.executionId,
-                  evictedEntry.blockId,
-                  evictedEntry
-                )
-              )
-            }
-            return { entries: entries.slice(0, MAX_ENTRIES) }
-          })
+          set((state) => ({ entries: [newEntry, ...state.entries].slice(0, MAX_ENTRIES) }))
 
           return newEntry
         },
 
         clearConsole: (workflowId: string | null) => {
-          if (workflowId) {
-            clearWorkflowStreamBuffers(workflowId)
-          } else {
-            streamBuffers.clear()
-          }
-
           set((state) => {
             if (!workflowId) {
+              streamBuffers.clear()
               return { entries: [] }
             }
 
             return {
-              entries: state.entries.filter((entry) => entry.workflowId !== workflowId),
+              entries: state.entries.filter((entry) => {
+                if (entry.workflowId !== workflowId) return true
+                clearExecutionStreamBuffers(entry.executionId)
+                return false
+              }),
             }
           })
         },
@@ -369,15 +350,13 @@ export const useConsoleStore = create<ConsoleStore>()(
 
         ingestWorkflowExecutionEvent: (event: WorkflowExecutionEvent) => {
           const deleteStreamBuffer = (data: WorkflowExecutionBlockData) => {
-            streamBuffers.delete(
-              executionBlockKey(event.workflowId, event.executionId, data.blockId, data)
-            )
+            streamBuffers.delete(executionBlockKey(event.executionId, data.blockId, data))
             const existingEntry = findExecutionEntry(get().entries, event, data, {
               allowRunningFallback: true,
             })
             if (existingEntry) {
               streamBuffers.delete(
-                executionBlockKey(event.workflowId, event.executionId, data.blockId, existingEntry)
+                executionBlockKey(event.executionId, data.blockId, existingEntry)
               )
             }
           }
@@ -441,7 +420,7 @@ export const useConsoleStore = create<ConsoleStore>()(
 
           if (event.type === 'block:started') {
             streamBuffers.delete(
-              executionBlockKey(event.workflowId, event.executionId, event.data.blockId, event.data)
+              executionBlockKey(event.executionId, event.data.blockId, event.data)
             )
             writeBlock(event.data, { success: true, isRunning: true, isCanceled: false })
             return
@@ -459,12 +438,7 @@ export const useConsoleStore = create<ConsoleStore>()(
             })
             if (!existingEntry) return
 
-            const key = executionBlockKey(
-              event.workflowId,
-              event.executionId,
-              blockId,
-              existingEntry
-            )
+            const key = executionBlockKey(event.executionId, blockId, existingEntry)
             const content = `${streamBuffers.get(key) ?? ''}${chunk}`
             streamBuffers.set(key, content)
             set((state) => ({
@@ -505,64 +479,36 @@ export const useConsoleStore = create<ConsoleStore>()(
                   return entry
                 }
 
-                const endedAt = entry.endedAt || event.timestamp
-                const startedAtMs = entry.startedAt ? Date.parse(entry.startedAt) : Number.NaN
-                const endedAtMs = Date.parse(endedAt)
-                const durationMs =
-                  Number.isFinite(entry.durationMs) && entry.durationMs! > 0
-                    ? entry.durationMs
-                    : Number.isFinite(startedAtMs) && Number.isFinite(endedAtMs)
-                      ? Math.max(0, endedAtMs - startedAtMs)
-                      : Number.isFinite(entry.durationMs) && entry.durationMs! >= 0
-                        ? entry.durationMs
-                        : 0
-                if (event.type === 'execution:error') {
-                  return {
-                    ...entry,
-                    success: false,
-                    error: entry.error || event.data.error,
-                    endedAt,
-                    durationMs,
-                    isRunning: false,
-                    isCanceled: false,
-                  }
-                }
-
                 return {
                   ...entry,
-                  success: event.type === 'execution:cancelled' ? false : entry.success,
-                  endedAt,
-                  durationMs,
+                  ...(event.type === 'execution:error' ? { error: event.data.error } : {}),
+                  success: event.type === 'execution:completed',
+                  endedAt: event.timestamp,
+                  durationMs: calculateDurationMs(entry.startedAt, event.timestamp),
                   isRunning: false,
                   isCanceled: event.type === 'execution:cancelled',
                 }
               }),
             }))
-            clearExecutionStreamBuffers(event.workflowId, event.executionId)
+            clearExecutionStreamBuffers(event.executionId)
           }
         },
 
         cancelRunningEntries: (workflowId: string) => {
-          set((state) => {
-            const now = new Date().toISOString()
-            const updatedEntries = state.entries.map((entry) => {
-              if (entry.workflowId === workflowId && entry.isRunning) {
-                const startedAtMs = entry.startedAt ? new Date(entry.startedAt).getTime() : null
-                const durationMs =
-                  startedAtMs != null ? Math.max(0, Date.now() - startedAtMs) : entry.durationMs
-                return {
-                  ...entry,
-                  success: false,
-                  isRunning: false,
-                  isCanceled: true,
-                  endedAt: entry.endedAt || now,
-                  durationMs,
-                }
+          const endedAt = new Date().toISOString()
+          set((state) => ({
+            entries: state.entries.map((entry) => {
+              if (entry.workflowId !== workflowId || !entry.isRunning) return entry
+              return {
+                ...entry,
+                success: false,
+                isRunning: false,
+                isCanceled: true,
+                endedAt,
+                durationMs: calculateDurationMs(entry.startedAt, endedAt),
               }
-              return entry
-            })
-            return { ...state, entries: updatedEntries }
-          })
+            }),
+          }))
         },
       }),
       {

--- a/apps/tradinggoose/stores/console/store.ts
+++ b/apps/tradinggoose/stores/console/store.ts
@@ -154,6 +154,13 @@ const executionBlockKey = (
 
 const streamBuffers = new Map<string, string>()
 
+const clearWorkflowStreamBuffers = (workflowId: string) => {
+  const prefix = `${workflowId}:`
+  for (const key of streamBuffers.keys()) {
+    if (key.startsWith(prefix)) streamBuffers.delete(key)
+  }
+}
+
 const clearExecutionStreamBuffers = (workflowId: string, executionId: string | undefined) => {
   const prefix = `${workflowId}:${executionId ?? 'execution'}:`
   for (const key of streamBuffers.keys()) {
@@ -233,24 +240,38 @@ export const useConsoleStore = create<ConsoleStore>()(
             timestamp: new Date().toISOString(),
           }
 
-          set((state) => ({ entries: [newEntry, ...state.entries].slice(0, MAX_ENTRIES) }))
+          set((state) => {
+            const entries = [newEntry, ...state.entries]
+            for (const evictedEntry of entries.slice(MAX_ENTRIES)) {
+              streamBuffers.delete(
+                executionBlockKey(
+                  evictedEntry.workflowId,
+                  evictedEntry.executionId,
+                  evictedEntry.blockId,
+                  evictedEntry
+                )
+              )
+            }
+            return { entries: entries.slice(0, MAX_ENTRIES) }
+          })
 
           return newEntry
         },
 
         clearConsole: (workflowId: string | null) => {
+          if (workflowId) {
+            clearWorkflowStreamBuffers(workflowId)
+          } else {
+            streamBuffers.clear()
+          }
+
           set((state) => {
             if (!workflowId) {
-              streamBuffers.clear()
               return { entries: [] }
             }
 
             return {
-              entries: state.entries.filter((entry) => {
-                if (entry.workflowId !== workflowId) return true
-                clearExecutionStreamBuffers(entry.workflowId, entry.executionId)
-                return false
-              }),
+              entries: state.entries.filter((entry) => entry.workflowId !== workflowId),
             }
           })
         },

--- a/apps/tradinggoose/stores/console/store.ts
+++ b/apps/tradinggoose/stores/console/store.ts
@@ -509,6 +509,7 @@ export const useConsoleStore = create<ConsoleStore>()(
 
                 return {
                   ...entry,
+                  success: event.type === 'execution:cancelled' ? false : entry.success,
                   endedAt,
                   durationMs,
                   isRunning: false,
@@ -530,6 +531,7 @@ export const useConsoleStore = create<ConsoleStore>()(
                   startedAtMs != null ? Math.max(0, Date.now() - startedAtMs) : entry.durationMs
                 return {
                   ...entry,
+                  success: false,
                   isRunning: false,
                   isCanceled: true,
                   endedAt: entry.endedAt || now,

--- a/apps/tradinggoose/stores/console/store.ts
+++ b/apps/tradinggoose/stores/console/store.ts
@@ -391,6 +391,7 @@ export const useConsoleStore = create<ConsoleStore>()(
             }
 
             if (existingEntry) {
+              if (!existingEntry.isRunning) return
               set((state) => ({
                 entries: updateEntryById(state.entries, existingEntry.id, patch),
               }))
@@ -436,7 +437,7 @@ export const useConsoleStore = create<ConsoleStore>()(
             const existingEntry = findExecutionEntry(get().entries, event, data, {
               allowRunningFallback: true,
             })
-            if (!existingEntry) return
+            if (!existingEntry?.isRunning) return
 
             const key = executionBlockKey(event.executionId, blockId, existingEntry)
             const content = `${streamBuffers.get(key) ?? ''}${chunk}`
@@ -496,6 +497,12 @@ export const useConsoleStore = create<ConsoleStore>()(
 
         cancelRunningEntries: (workflowId: string) => {
           const endedAt = new Date().toISOString()
+          const executionIds = new Set<string>()
+          for (const entry of get().entries) {
+            if (entry.workflowId === workflowId && entry.isRunning && entry.executionId) {
+              executionIds.add(entry.executionId)
+            }
+          }
           set((state) => ({
             entries: state.entries.map((entry) => {
               if (entry.workflowId !== workflowId || !entry.isRunning) return entry
@@ -509,6 +516,7 @@ export const useConsoleStore = create<ConsoleStore>()(
               }
             }),
           }))
+          for (const executionId of executionIds) clearExecutionStreamBuffers(executionId)
         },
       }),
       {


### PR DESCRIPTION

## Summary

Fix workflow console entries that remain marked as running after their execution has completed, failed, or been canceled.

Terminal events now reconcile every still-running console entry for the exact workflow and execution. The change also scopes temporary stream buffers by both workflow and execution ID and adds focused regression coverage for terminal states, timing, isolation, replay safety, and buffer cleanup.

## Why

A workflow could reach a terminal state without emitting a corresponding block completion or error event. The editor and Run button would correctly stop, but affected console entries would retain their running indicator and potentially lack accurate terminal timing.

This change makes the console state consistent with the actual execution state while preserving existing block-specific errors and terminal information.

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other

## Affected Areas

- [x] <code>apps/tradinggoose</code>
- [ ] <code>apps/docs</code>
- [ ] <code>packages/*</code>
- [x] Workflows / execution
- [ ] Realtime / sockets
- [ ] Market data / charting
- [ ] Dev tooling / CI / infra
- [ ] Documentation only
- [ ] Other

## Validation

<pre><code>cd apps/tradinggoose
bun run test stores/console/store.test.ts
</code></pre>

Result: 1 test file passed, 18 tests passed.

<pre><code>bunx biome check --files-ignore-unknown=true \
  apps/tradinggoose/stores/console/store.ts \
  apps/tradinggoose/stores/console/store.test.ts
</code></pre>

Result: both changed files passed project style and static checks.

Reviewers should focus on:

- Reconciliation being scoped by both <code>workflowId</code> and <code>executionId</code>.
- Correct and distinguishable completion, failure, and cancellation states.
- Preservation of existing block-specific errors and terminal timing.
- Safe duration calculation for missing or invalid timestamps.
- Idempotency when terminal events are replayed.
- Stream-buffer cleanup without affecting another workflow or execution.

## Risk / Rollout Notes

Risk is low. The change is localized to the client console store and its focused tests.

Terminal reconciliation scans the bounded console-entry collection only when a workflow terminal event arrives. No staged rollout is required.

Backout consists of reverting this PR; there are no persisted data or server-side state changes.

## Config / Data Changes

- Env vars added or changed: None.
- Database schema or migration impact: None.
- External services or provider behavior changed: None.

## Screenshots / Video

Not applicable. This corrects existing console state indicators without introducing a new visual design.

## Checklist

- [x] I kept the change focused and reviewed my own diff
- [x] I validated the change locally and documented the results above
- [x] No documentation, examples, localization, or copy updates are required
- [x] I called out env, schema, provider, and rollout impact
- [x] I did not include secrets, tokens, or private credentials in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow execution handling for completion, cancellation, and errors.
  * Completion times and durations are now recorded more reliably.
  * Preserved execution error details and terminal statuses across repeated updates.
  * Improved execution status reporting when events and saved results arrive in different orders.
  * Prevented stream data from being mixed between workflows.
  * Canceled executions are now correctly marked unsuccessful, with temporary data cleared.

* **Tests**
  * Added comprehensive coverage for execution completion, errors, cancellation, timing data, repeated events, cleanup, and workflow isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->