### PR TITLE
fix(copilot): add workspaceId parameter to chat session requests

### DIFF
--- a/apps/tradinggoose/app/api/copilot/chat/review-session-post.test.ts
+++ b/apps/tradinggoose/app/api/copilot/chat/review-session-post.test.ts
@@ -365,6 +365,7 @@ describe('Copilot Chat POST Generic Sessions', () => {
           userId: 'collaborator-user',
           model: 'openai/gpt-5.6-terra',
           conversationId: 'conversation-1',
+          workspaceId: 'workspace-1',
           context: [],
           chatId: 'review-session-1',
           toolManifest: expect.objectContaining({
@@ -901,6 +902,7 @@ describe('Copilot Chat POST Generic Sessions', () => {
           message: 'Start a fresh generic copilot chat',
           userId: 'collaborator-user',
           model: 'anthropic/claude-fable-5',
+          workspaceId: 'workspace-1',
           chatId: 'review-session-channel-1',
           toolManifest: expect.objectContaining({
             version: 'v1',

--- a/apps/tradinggoose/app/api/copilot/chat/route.ts
+++ b/apps/tradinggoose/app/api/copilot/chat/route.ts
@@ -890,6 +890,7 @@ export async function POST(req: NextRequest) {
       messageId: userMessageIdToUse,
       ...(effectiveConversationId ? { conversationId: effectiveConversationId } : {}),
       ...(session?.user?.name && { userName: session.user.name }),
+      ...(activeWorkspaceId ? { workspaceId: activeWorkspaceId } : {}),
       context: agentContexts,
       ...(actualReviewSessionId ? { chatId: actualReviewSessionId } : {}),
       toolManifest: await getCopilotRuntimeToolManifest(),


### PR DESCRIPTION
## Summary

- Forward the resolved `workspaceId` to the upstream Copilot request.
- Preserve workspace context for both existing and newly created Copilot chat sessions.
- Add payload assertions covering both session paths.

## Why

Copilot chat-session requests omitted the active workspace ID when proxying upstream, preventing the Copilot service from receiving workspace context.

## Affected Areas

- [x] `apps/tradinggoose`
- [ ] `apps/docs`
- [ ] `packages/*`
- [ ] Workflows / execution
- [ ] Realtime / sockets
- [ ] Market data / charting
- [ ] Dev tooling / CI / infra
- [ ] Documentation only
- [ ] Other:

## Issue Links( if any )

None.

## Validation

```bash
cd apps/tradinggoose && bun run test -- app/api/copilot/chat/review-session-post.test.ts
# Passed: 1 test file, 20 tests

git diff --check origin/staging...HEAD
# Passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Copilot Chat requests now retain the active workspace context.
  - Improved consistency for both existing and newly created Copilot sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->