### PR TITLE
Fix/copilot local feat(copilot): run self-hosted models on a local agent loopruntime

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ This is the build kit already included in TradingGoose-Studio. Canvas types and 
 | **254 agent-callable actions across 71 integrations** | Give agents market research, data, communications, storage, web access, and configured trading actions. |
 | **86 built-in PineTS studies** | Use them in charts, Copilot, and Function blocks; author or import a trigger-enabled indicator when a market monitor should start a workflow. |
 | **4 market-data providers** | Alpaca, Finnhub, Alpha Vantage and Yahoo Finance. All support series; Alpaca and Finnhub also provide live data. |
-| **2 trading providers** | Alpaca and Tradier provide portfolio context and configured order actions. |
+| **3 trading providers** | Alpaca, Tradier, and IBKR provide portfolio context and configured order actions. |
 | **16 AI providers** | Choose from direct, cloud, and local model-provider options for agents. |
 
 Connect the credentials, endpoint, or broker account required by each provider. Custom tools and connected MCP servers are workspace-specific, so they are deliberately not included in the fixed counts above.

--- a/apps/docs/content/docs/en/connections/ibkr.mdx
+++ b/apps/docs/content/docs/en/connections/ibkr.mdx
@@ -1,0 +1,66 @@
+---
+title: IBKR
+---
+
+import { Callout } from 'fumadocs-ui/components/callout'
+
+# Interactive Brokers (IBKR)
+
+Connect an Interactive Brokers account to TradingGoose for portfolio context,
+portfolio-state monitors, and configured order actions.
+
+<Callout type="info">
+  The IBKR provider uses the Interactive Brokers <strong>Client Portal Web
+  API</strong> (REST/JSON). It expects an OAuth 2.0 access token and a base URL
+  for the API, which is normally served by a local <strong>IB Gateway</strong>
+  on port <code>5000</code>.
+</Callout>
+
+## Prerequisites
+
+1. An Interactive Brokers account (paper or live) with the Client Portal Web
+   API enabled, and API access enabled in Account Settings → Settings → API.
+2. A reachable IB Gateway (or hosted Client Portal Web API endpoint). The
+   gateway must be running and authenticated for the account you want to use.
+
+## Configuration
+
+Set these environment variables for the app:
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `IBKR_API_BASE_URL` | Base URL of the Client Portal Web API | `http://127.0.0.1:5000/v1/api` |
+| `IBKR_TOKEN_ENDPOINT` | OAuth2 token endpoint for the access token | `https://api.ibkr.com/v1/api/oauth2/token` |
+| `IBKR_API_IP` | IP header sent with requests (gateway allowlist) | `127.0.0.1` |
+
+For a local gateway, the default base URL works out of the box. For a hosted
+API (IBKR Web API Gateway), set `IBKR_API_BASE_URL` to the hosted endpoint.
+
+## Connecting an account
+
+1. Open **Connections** in the workspace.
+2. Choose **IBKR Live** or **IBKR Paper**.
+3. Complete the OAuth flow with your IBKR credentials.
+4. The connected account becomes available as a trading provider for order
+   actions, portfolio detail, and portfolio-state monitors.
+
+## Supported capabilities
+
+- **Asset classes**: stocks, ETFs, futures, currencies, indices, mutual funds
+- **Order types**: market, limit, stop, stop-limit, trailing stop
+- **Time in force**: day, GTC, IOC, FOK, GTD
+- **Sizing**: quantity only
+- **Portfolio detail**: account summary, positions, cash balances, performance
+
+<Callout type="warning">
+  IBKR order submissions are asynchronous. A submitted order may still be
+  pending at the broker after the initial response; order status updates are
+  reflected in run history as they arrive from the gateway.
+</Callout>
+
+## Notes
+
+- The provider registers for a workspace only when the gateway is reachable
+  and an account has been connected through the OAuth flow.
+- Paper and live environments are separate services; use the paper account for
+  testing.

--- a/apps/docs/content/docs/en/connections/meta.json
+++ b/apps/docs/content/docs/en/connections/meta.json
@@ -1,3 +1,3 @@
 {
-  "pages": ["index", "basics", "data-structure", "tags"]
+  "pages": ["index", "basics", "data-structure", "ibkr", "tags"]
 }

--- a/apps/tradinggoose/.env.example
+++ b/apps/tradinggoose/.env.example
@@ -58,6 +58,14 @@ REDIS_URL="redis://localhost:6379"
 
 # Recommended for `bun run dev:full`: Socket server origin and public client URL.
 SOCKET_SERVER_URL="http://localhost:3002"
+
+# Optional: IBKR trading provider configuration.
+# The IBKR provider talks to the Interactive Brokers Client Portal Web API,
+# usually served by a local IB Gateway (default base URL below). Override with
+# a hosted or remote gateway/API base URL when needed.
+# IBKR_API_BASE_URL="http://127.0.0.1:5000/v1/api"
+# IBKR_TOKEN_ENDPOINT="https://api.ibkr.com/v1/api/oauth2/token"
+# IBKR_API_IP="127.0.0.1"
 NEXT_PUBLIC_SOCKET_URL="http://localhost:3002"
 
 # Required by the browser Yjs/socket bootstrap path.

--- a/apps/tradinggoose/app/api/copilot/chat/route.ts
+++ b/apps/tradinggoose/app/api/copilot/chat/route.ts
@@ -41,6 +41,14 @@ import {
   type CopilotRuntimeModel,
   DEFAULT_COPILOT_RUNTIME_MODEL,
 } from '@/lib/copilot/runtime-models'
+
+import { isCopilotLocalRuntimeModel as isLocalCopilotModel } from '@/lib/copilot/local-runtime/runtime-models'
+import {
+  isLocalWorkingItem,
+  loadLocalWorkingMessages,
+} from '@/lib/copilot/local-runtime/persistence'
+import { handleLocalCopilotChat } from '@/lib/copilot/local-runtime/chat-handler'
+
 import {
   COPILOT_RUNTIME_CONFIG_PLACEHOLDER,
   COPILOT_SESSION_KIND,
@@ -718,7 +726,7 @@ const ChatMessageSchema = z.object({
   message: z.string().min(1, 'Message is required'),
   userMessageId: z.string().optional(), // ID from frontend for the user message
   reviewSessionId: z.string().optional(),
-  model: z.enum(COPILOT_RUNTIME_MODELS).optional().default(DEFAULT_COPILOT_RUNTIME_MODEL),
+  model: z.string().optional().default(DEFAULT_COPILOT_RUNTIME_MODEL),
   stream: z.boolean().optional().default(true),
   fileAttachments: z.array(FileAttachmentSchema).optional(),
   conversationId: z.string().optional(),
@@ -820,7 +828,9 @@ export async function POST(req: NextRequest) {
         )
         .orderBy(asc(copilotReviewItems.sequence))
 
-      conversationHistory = existingMessages.map(mapReviewItemToApi)
+      conversationHistory = existingMessages
+        .filter((item) => !isLocalWorkingItem(item))
+        .map(mapReviewItemToApi)
     }
 
     let agentContexts: Array<{ type: string; tag?: string; content: string }> = []
@@ -906,6 +916,25 @@ export async function POST(req: NextRequest) {
         messageLength: modelMessage.length,
       })
     } catch {}
+
+    if (isLocalCopilotModel(model)) {
+      return handleLocalCopilotChat({
+        model,
+        message,
+        modelMessage,
+        userMessageId: userMessageIdToUse,
+        reviewSessionId: actualReviewSessionId!,
+        conversationId: effectiveConversationId,
+        workspaceId: activeWorkspaceId,
+        userId: authenticatedUserId,
+        contexts: agentContexts,
+        fileContents: processedFileContents,
+        fileAttachments,
+        contextsInput: contexts,
+        requestId: tracker.requestId,
+        sessionCreatedThisRequest,
+      })
+    }
 
     const copilotResponse = await proxyCopilotRequest({
       endpoint: '/api/copilot',

--- a/apps/tradinggoose/app/api/copilot/tools/mark-complete/route.ts
+++ b/apps/tradinggoose/app/api/copilot/tools/mark-complete/route.ts
@@ -11,6 +11,15 @@ import { mirrorLocalCopilotCompletionUsageReports } from '@/lib/copilot/completi
 import { createLogger } from '@/lib/logs/console/logger'
 import { encodeSSE, SSE_HEADERS } from '@/lib/utils'
 import { getCopilotApiUrl, proxyCopilotRequest } from '@/app/api/copilot/proxy'
+import {
+  persistLocalContinuation,
+  readLocalSessionModelFromMessage,
+} from '@/lib/copilot/local-runtime/persistence'
+import { isCopilotLocalRuntimeModel } from '@/lib/copilot/local-runtime/runtime-models'
+import { handleLocalCopilotContinuation } from '@/lib/copilot/local-runtime/chat-handler'
+import { db } from '@tradinggoose/db'
+import { copilotReviewItems } from '@tradinggoose/db'
+import { eq } from 'drizzle-orm'
 
 const logger = createLogger('CopilotMarkToolCompleteAPI')
 const DATA_PREFIX = 'data: '
@@ -163,6 +172,53 @@ export async function POST(req: NextRequest) {
       agentUrl: await getCopilotApiUrl('/api/tools/mark-complete'),
     })
 
+    if (!parsed.data?.local) {
+      // Hosted runtime: unchanged proxy behaviour.
+    } else {
+      logger.info(`[${tracker.requestId}] Local runtime mark-complete`, {
+        toolCallId: parsed.id,
+        toolName: parsed.name,
+        status: parsed.status,
+      })
+
+      const reviewSessionId =
+        typeof parsed.data?.reviewSessionId === 'string' ? parsed.data.reviewSessionId : undefined
+
+      const sessionModel =
+        reviewSessionId && (await isLocalReviewSession(reviewSessionId))
+          ? await readLocalSessionModel(reviewSessionId)
+          : null
+
+      if (reviewSessionId && sessionModel && isCopilotLocalRuntimeModel(sessionModel)) {
+        await persistLocalContinuation({
+          reviewSessionId,
+          toolCallId: parsed.id,
+          toolName: parsed.name,
+          status: parsed.status,
+          message: parsed.message,
+          data: parsed.data,
+        })
+
+        const stream = await handleLocalCopilotContinuation({
+          model: sessionModel,
+          reviewSessionId,
+          userId,
+          requestId: tracker.requestId,
+          continuation: {
+            toolCallId: parsed.id,
+            toolName: parsed.name,
+            status: parsed.status,
+            message: parsed.message,
+            data: parsed.data,
+          },
+        })
+
+        return new NextResponse(stream, {
+          headers: { ...SSE_HEADERS, 'Cache-Control': 'no-cache, no-transform' },
+        })
+      }
+    }
+
     const agentRes = await proxyCopilotRequest({
       endpoint: '/api/tools/mark-complete',
       body: parsed,
@@ -239,4 +295,23 @@ export async function POST(req: NextRequest) {
   } finally {
     req.signal.removeEventListener('abort', abortUpstream)
   }
+}
+
+
+/** True when the session belongs to the local runtime (working-state rows exist). */
+async function isLocalReviewSession(reviewSessionId: string): Promise<boolean> {
+  const rows = await db
+    .select({ itemId: copilotReviewItems.itemId })
+    .from(copilotReviewItems)
+    .where(eq(copilotReviewItems.sessionId, reviewSessionId))
+    .limit(200)
+  return rows.some((row) => typeof row.itemId === 'string' && row.itemId.startsWith('local_'))
+}
+
+/**
+ * Recovers the model for the conversation. The client does not send a model on
+ * mark-complete, so the value persisted for the session is used.
+ */
+async function readLocalSessionModel(reviewSessionId: string): Promise<string | null> {
+  return readLocalSessionModelFromMessage(reviewSessionId)
 }

--- a/apps/tradinggoose/app/api/copilot/usage/route.ts
+++ b/apps/tradinggoose/app/api/copilot/usage/route.ts
@@ -19,7 +19,7 @@ const logger = createLogger('CopilotUsageAPI')
 const ContextUsageRequestSchema = z.object({
   kind: z.literal('context'),
   conversationId: z.string(),
-  model: z.enum(COPILOT_RUNTIME_MODELS),
+  model: z.string(),
   workflowId: z.string().optional(),
   workspaceId: z.string().optional(),
 })

--- a/apps/tradinggoose/app/api/providers/kronos/forecast/route.ts
+++ b/apps/tradinggoose/app/api/providers/kronos/forecast/route.ts
@@ -1,0 +1,100 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { AuthType, checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
+import { createLogger } from '@/lib/logs/console/logger'
+import { generateRequestId } from '@/lib/utils'
+import { isKronosEnabled, callKronosForecast, KronosError, KronosErrorCode } from '@/lib/kronos'
+import { ForecastRequest } from '@/lib/kronos/types'
+
+const logger = createLogger('KronosForecastRoute')
+
+const nonEmptyStringSchema = z.string().trim().min(1)
+
+const forecastRequestSchema = z
+  .object({
+    workspaceId: nonEmptyStringSchema,
+    idempotencyKey: nonEmptyStringSchema,
+    listing: z.unknown(),
+    marketSeries: z.unknown(),
+    interval: nonEmptyStringSchema,
+    timezone: nonEmptyStringSchema,
+    normalizationMode: nonEmptyStringSchema.optional(),
+    horizonBars: z.number().int().positive().finite(),
+    parameters: z
+      .object({
+        temperature: z.number().positive().max(5).optional(),
+        topP: z.number().positive().max(1).optional(),
+        sampleCount: z.number().int().positive().optional(),
+      })
+      .optional(),
+  })
+  .strict()
+
+const parseRequestBody = async (
+  request: NextRequest
+): Promise<z.infer<typeof forecastRequestSchema> | Response> => {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid request data' }, { status: 400 })
+  }
+
+  const parsed = forecastRequestSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid request data', details: parsed.error.issues },
+      { status: 400 }
+    )
+  }
+  return parsed.data
+}
+
+const mapKronosError = (error: KronosError): Response => {
+  switch (error.code) {
+    case KronosErrorCode.DISABLED:
+      return NextResponse.json({ error: error.message }, { status: 404 })
+    case KronosErrorCode.UNAVAILABLE:
+      return NextResponse.json({ error: error.message }, { status: 503 })
+    case KronosErrorCode.TIMEOUT:
+      return NextResponse.json({ error: error.message }, { status: 504 })
+    case KronosErrorCode.HORIZON_EXCEEDED:
+    case KronosErrorCode.TOO_FEW_BARS:
+    case KronosErrorCode.TOO_MANY_BARS:
+      return NextResponse.json({ error: error.message }, { status: 422 })
+    default:
+      return NextResponse.json({ error: error.message }, { status: 502 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  if (!isKronosEnabled()) {
+    return NextResponse.json(
+      { error: 'Kronos forecasting is not enabled' },
+      { status: 404 }
+    )
+  }
+
+  const requestId = generateRequestId('kronos-forecast')
+  const requestData = await parseRequestBody(request)
+  if (requestData instanceof Response) return requestData
+
+  const auth = await checkSessionOrInternalAuth(request, {
+    requireWorkflowId: false,
+  })
+  if (!auth.success || !auth.userId) {
+    return NextResponse.json({ error: auth.error || 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const response = await callKronosForecast(requestData as unknown as ForecastRequest)
+
+    return NextResponse.json(response)
+  } catch (error) {
+    if (error instanceof KronosError) {
+      return mapKronosError(error)
+    }
+    logger.error('Kronos forecast failed', { requestId, error })
+    return NextResponse.json({ error: 'Kronos forecast failed' }, { status: 502 })
+  }
+}

--- a/apps/tradinggoose/app/api/providers/kronos/forecast/route.ts
+++ b/apps/tradinggoose/app/api/providers/kronos/forecast/route.ts
@@ -1,0 +1,115 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { AuthType, checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
+import { createLogger } from '@/lib/logs/console/logger'
+import { generateRequestId } from '@/lib/utils'
+import {
+  isKronosEnabled,
+  callKronosForecast,
+  KronosError,
+  KronosErrorCode,
+  type KronosCallContext,
+} from '@/lib/kronos'
+import { ForecastRequest } from '@/lib/kronos/types'
+
+const logger = createLogger('KronosForecastRoute')
+
+const nonEmptyStringSchema = z.string().trim().min(1)
+
+const forecastRequestSchema = z
+  .object({
+    workspaceId: nonEmptyStringSchema,
+    idempotencyKey: nonEmptyStringSchema,
+    listing: z.unknown(),
+    marketSeries: z.unknown(),
+    interval: nonEmptyStringSchema,
+    timezone: nonEmptyStringSchema,
+    normalizationMode: nonEmptyStringSchema.optional(),
+    horizonBars: z.number().int().positive().finite(),
+    parameters: z
+      .object({
+        temperature: z.number().positive().max(5).optional(),
+        topP: z.number().positive().max(1).optional(),
+        sampleCount: z.number().int().positive().optional(),
+      })
+      .optional(),
+  })
+  .strict()
+
+const parseRequestBody = async (
+  request: NextRequest
+): Promise<z.infer<typeof forecastRequestSchema> | Response> => {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid request data' }, { status: 400 })
+  }
+
+  const parsed = forecastRequestSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid request data', details: parsed.error.issues },
+      { status: 400 }
+    )
+  }
+  return parsed.data
+}
+
+const mapKronosError = (error: KronosError): Response => {
+  switch (error.code) {
+    case KronosErrorCode.DISABLED:
+      return NextResponse.json({ error: error.message }, { status: 404 })
+    case KronosErrorCode.UNAVAILABLE:
+      return NextResponse.json({ error: error.message }, { status: 503 })
+    case KronosErrorCode.TIMEOUT:
+      return NextResponse.json({ error: error.message }, { status: 504 })
+    case KronosErrorCode.HORIZON_EXCEEDED:
+    case KronosErrorCode.TOO_FEW_BARS:
+    case KronosErrorCode.TOO_MANY_BARS:
+      return NextResponse.json({ error: error.message }, { status: 422 })
+    default:
+      return NextResponse.json({ error: error.message }, { status: 502 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  if (!isKronosEnabled()) {
+    return NextResponse.json(
+      { error: 'Kronos forecasting is not enabled' },
+      { status: 404 }
+    )
+  }
+
+  const requestId = generateRequestId('kronos-forecast')
+  const requestData = await parseRequestBody(request)
+  if (requestData instanceof Response) return requestData
+
+  const auth = await checkSessionOrInternalAuth(request, {
+    requireWorkflowId: false,
+  })
+  if (!auth.success || !auth.userId) {
+    return NextResponse.json({ error: auth.error || 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const context: KronosCallContext = {
+      workflowId: new URL(request.url).searchParams.get('workflowId')?.trim() || undefined,
+      executionId: new URL(request.url).searchParams.get('executionId')?.trim() || undefined,
+      workspaceId: requestData.workspaceId,
+      userId: auth.userId,
+    }
+    const response = await callKronosForecast(
+      requestData as unknown as ForecastRequest,
+      context
+    )
+
+    return NextResponse.json(response)
+  } catch (error) {
+    if (error instanceof KronosError) {
+      return mapKronosError(error)
+    }
+    logger.error('Kronos forecast failed', { requestId, error })
+    return NextResponse.json({ error: 'Kronos forecast failed' }, { status: 502 })
+  }
+}

--- a/apps/tradinggoose/app/api/providers/kronos/forecast/route.ts
+++ b/apps/tradinggoose/app/api/providers/kronos/forecast/route.ts
@@ -3,7 +3,13 @@ import { z } from 'zod'
 import { AuthType, checkSessionOrInternalAuth } from '@/lib/auth/hybrid'
 import { createLogger } from '@/lib/logs/console/logger'
 import { generateRequestId } from '@/lib/utils'
-import { isKronosEnabled, callKronosForecast, KronosError, KronosErrorCode } from '@/lib/kronos'
+import {
+  isKronosEnabled,
+  callKronosForecast,
+  KronosError,
+  KronosErrorCode,
+  type KronosCallContext,
+} from '@/lib/kronos'
 import { ForecastRequest } from '@/lib/kronos/types'
 
 const logger = createLogger('KronosForecastRoute')
@@ -87,7 +93,16 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const response = await callKronosForecast(requestData as unknown as ForecastRequest)
+    const context: KronosCallContext = {
+      workflowId: new URL(request.url).searchParams.get('workflowId')?.trim() || undefined,
+      executionId: new URL(request.url).searchParams.get('executionId')?.trim() || undefined,
+      workspaceId: requestData.workspaceId,
+      userId: auth.userId,
+    }
+    const response = await callKronosForecast(
+      requestData as unknown as ForecastRequest,
+      context
+    )
 
     return NextResponse.json(response)
   } catch (error) {

--- a/apps/tradinggoose/app/api/providers/market/handler.ts
+++ b/apps/tradinggoose/app/api/providers/market/handler.ts
@@ -26,6 +26,7 @@ export interface MarketProviderRouteBody {
   auth?: {
     apiKey?: string
     apiSecret?: string
+    accessToken?: string
   }
   interval?: string
   windows?: MarketSeriesWindow[]
@@ -79,6 +80,7 @@ export async function handleMarketProviderRequest({
         .object({
           apiKey: z.string().optional(),
           apiSecret: z.string().optional(),
+          accessToken: z.string().optional(),
         })
         .optional(),
       interval: z.string().optional(),

--- a/apps/tradinggoose/blocks/blocks/kronos_forecast.ts
+++ b/apps/tradinggoose/blocks/blocks/kronos_forecast.ts
@@ -1,0 +1,148 @@
+import { ChartBarIcon } from '@/components/icons/icons'
+import type { BlockConfig, SubBlockConfig } from '@/blocks/types'
+import { AuthMode } from '@/blocks/types'
+import type { MarketSeriesOutput } from '@/tools/market_data'
+import type { ToolResponse } from '@/tools/types'
+import {
+  LISTING_IDENTITY_VALUE_TYPE,
+  parseListingIdentityValueStrict,
+} from '@/lib/listing/identity'
+import { kronosForecastTool } from '@/tools/kronos'
+import type { ForecastResponse } from '@/lib/kronos/types'
+
+interface KronosForecastResponse extends ToolResponse {
+  output: ForecastResponse
+}
+
+const MAX_HORIZON = 32
+const MIN_HORIZON = 1
+
+export const KronosForecastBlock: BlockConfig<KronosForecastResponse> = {
+  type: 'kronos_forecast',
+  name: 'Kronos Forecast',
+  description: 'Generate a Kronos financial market forecast.',
+  longDescription:
+    'Feed historical market series into the Kronos foundation model and return a forecast for the next bars. This block does not place orders or access broker credentials.',
+  category: 'tools',
+  authMode: AuthMode.ApiKey,
+  bgColor: '#7c3aed',
+  icon: ChartBarIcon,
+  subBlocks: [
+    {
+      id: 'listing',
+      title: 'Listing',
+      type: 'market-selector',
+      layout: 'full',
+      providerType: 'market',
+      required: true,
+    },
+    {
+      id: 'marketSeries',
+      title: 'Market Series',
+      type: 'code',
+      layout: 'full',
+      language: 'json',
+      required: true,
+      placeholder: 'Paste the output of the Historical Data block.',
+      description: 'Normalized market series payload from the Historical Data block.',
+    },
+    {
+      id: 'interval',
+      title: 'Interval',
+      type: 'short-input',
+      layout: 'half',
+      required: true,
+      placeholder: 'e.g. 5m, 1h, 1d',
+    },
+    {
+      id: 'timezone',
+      title: 'Timezone',
+      type: 'short-input',
+      layout: 'half',
+      required: true,
+      placeholder: 'e.g. America/New_York',
+    },
+    {
+      id: 'normalizationMode',
+      title: 'Normalization',
+      type: 'short-input',
+      layout: 'half',
+      required: false,
+      placeholder: 'raw',
+    },
+    {
+      id: 'horizonBars',
+      title: 'Horizon (bars)',
+      type: 'short-input',
+      layout: 'half',
+      inputType: 'number',
+      required: true,
+      placeholder: '12',
+      min: MIN_HORIZON,
+      max: MAX_HORIZON,
+      integer: true,
+    },
+    {
+      id: 'temperature',
+      title: 'Temperature',
+      type: 'short-input',
+      layout: 'half',
+      inputType: 'number',
+      required: false,
+      placeholder: '1.0',
+    },
+    {
+      id: 'topP',
+      title: 'Top P',
+      type: 'short-input',
+      layout: 'half',
+      inputType: 'number',
+      required: false,
+      placeholder: '0.9',
+    },
+  ],
+  tools: {
+    access: ['kronos_forecast'],
+    config: {
+      tool: () => 'kronos_forecast',
+      params: (params) => {
+        const marketSeries =
+          typeof params.marketSeries === 'string'
+            ? (JSON.parse(params.marketSeries) as MarketSeriesOutput)
+            : (params.marketSeries as MarketSeriesOutput)
+
+        return {
+          listing: parseListingIdentityValueStrict(params.listing),
+          marketSeries,
+          interval: params.interval,
+          timezone: params.timezone,
+          normalizationMode: params.normalizationMode,
+          horizonBars: Number(params.horizonBars),
+          parameters: {
+            temperature: params.temperature ? Number(params.temperature) : undefined,
+            topP: params.topP ? Number(params.topP) : undefined,
+          },
+        }
+      },
+    },
+  },
+  inputs: {
+    listing: {
+      type: LISTING_IDENTITY_VALUE_TYPE,
+      description: 'Canonical listing payload.',
+    },
+    marketSeries: { type: 'json', description: 'Normalized market series payload.' },
+    interval: { type: 'string', description: 'Series interval/timeframe.' },
+    timezone: { type: 'string', description: 'IANA timezone for the listing.' },
+    normalizationMode: { type: 'string', description: 'Optional normalization mode.' },
+    horizonBars: { type: 'number', description: 'Number of future bars to forecast.' },
+    temperature: { type: 'number', description: 'Optional sampling temperature.' },
+    topP: { type: 'number', description: 'Optional nucleus sampling probability.' },
+  },
+  outputs: {
+    forecast: { type: 'json', description: 'Forecasted OHLCV points.' },
+    model: { type: 'json', description: 'Model provenance metadata.' },
+    diagnostics: { type: 'json', description: 'Forecast diagnostics and warnings.' },
+    timingMs: { type: 'json', description: 'Request timing in milliseconds.' },
+  },
+}

--- a/apps/tradinggoose/blocks/registry.ts
+++ b/apps/tradinggoose/blocks/registry.ts
@@ -55,6 +55,7 @@ import { JiraBlock } from '@/blocks/blocks/jira'
 import { JiraServiceManagementBlock } from '@/blocks/blocks/jira_service_management'
 import { KalshiBlock } from '@/blocks/blocks/kalshi'
 import { KnowledgeBlock } from '@/blocks/blocks/knowledge'
+import { KronosForecastBlock } from '@/blocks/blocks/kronos_forecast'
 import { LinearBlock } from '@/blocks/blocks/linear'
 import { LinkedInBlock } from '@/blocks/blocks/linkedin'
 import { LinkupBlock } from '@/blocks/blocks/linkup'
@@ -186,6 +187,7 @@ export const registry: Record<string, BlockConfig> = {
   jina: JinaBlock,
   jira: JiraBlock,
   knowledge: KnowledgeBlock,
+  kronos_forecast: KronosForecastBlock,
   linear: LinearBlock,
   linkup: LinkupBlock,
   mcp: McpBlock,

--- a/apps/tradinggoose/lib/copilot/agent/utils.ts
+++ b/apps/tradinggoose/lib/copilot/agent/utils.ts
@@ -26,42 +26,6 @@ export async function requestCopilotTitle({
     return requestLocalCopilotTitle({ message, userId, model })
   }
 
-  if (isCopilotLocalRuntimeModel(model)) {
-    return requestLocalCopilotTitle({ message, userId, model })
-  }
-
-  if (isCopilotLocalRuntimeModel(model)) {
-    return requestLocalCopilotTitle({ message, userId, model })
-  }
-
-  if (isCopilotLocalRuntimeModel(model)) {
-    return requestLocalCopilotTitle({ message, userId, model })
-  }
-
-  if (isCopilotLocalRuntimeModel(model)) {
-    return requestLocalCopilotTitle({ message, userId, model })
-  }
-
-  if (isCopilotLocalRuntimeModel(model)) {
-    return requestLocalCopilotTitle({ message, userId, model })
-  }
-
-  if (isCopilotLocalRuntimeModel(model)) {
-    return requestLocalCopilotTitle({ message, userId, model })
-  }
-
-  if (isCopilotLocalRuntimeModel(model)) {
-    return requestLocalCopilotTitle({ message, userId, model })
-  }
-
-  if (isCopilotLocalRuntimeModel(model)) {
-    return requestLocalCopilotTitle({ message, userId, model })
-  }
-
-  if (isCopilotLocalRuntimeModel(model)) {
-    return requestLocalCopilotTitle({ message, userId, model })
-  }
-
   try {
     const response = await proxyCopilotCompletionRequest({
       body: {

--- a/apps/tradinggoose/lib/copilot/agent/utils.ts
+++ b/apps/tradinggoose/lib/copilot/agent/utils.ts
@@ -10,6 +10,9 @@ const logger = createLogger('CopilotTitle')
  * Generates a short title for a chat based on the first message
  * @returns A short title or null if the request fails
  */
+import { isCopilotLocalRuntimeModel } from '@/lib/copilot/local-runtime/runtime-models'
+import { requestLocalCopilotTitle } from '@/lib/copilot/local-runtime/title'
+
 export async function requestCopilotTitle({
   message,
   userId,
@@ -19,6 +22,18 @@ export async function requestCopilotTitle({
   userId: string
   model: CopilotRuntimeModel
 }): Promise<string | null> {
+  if (isCopilotLocalRuntimeModel(model)) {
+    return requestLocalCopilotTitle({ message, userId, model })
+  }
+
+  if (isCopilotLocalRuntimeModel(model)) {
+    return requestLocalCopilotTitle({ message, userId, model })
+  }
+
+  if (isCopilotLocalRuntimeModel(model)) {
+    return requestLocalCopilotTitle({ message, userId, model })
+  }
+
   try {
     const response = await proxyCopilotCompletionRequest({
       body: {

--- a/apps/tradinggoose/lib/copilot/agent/utils.ts
+++ b/apps/tradinggoose/lib/copilot/agent/utils.ts
@@ -34,6 +34,34 @@ export async function requestCopilotTitle({
     return requestLocalCopilotTitle({ message, userId, model })
   }
 
+  if (isCopilotLocalRuntimeModel(model)) {
+    return requestLocalCopilotTitle({ message, userId, model })
+  }
+
+  if (isCopilotLocalRuntimeModel(model)) {
+    return requestLocalCopilotTitle({ message, userId, model })
+  }
+
+  if (isCopilotLocalRuntimeModel(model)) {
+    return requestLocalCopilotTitle({ message, userId, model })
+  }
+
+  if (isCopilotLocalRuntimeModel(model)) {
+    return requestLocalCopilotTitle({ message, userId, model })
+  }
+
+  if (isCopilotLocalRuntimeModel(model)) {
+    return requestLocalCopilotTitle({ message, userId, model })
+  }
+
+  if (isCopilotLocalRuntimeModel(model)) {
+    return requestLocalCopilotTitle({ message, userId, model })
+  }
+
+  if (isCopilotLocalRuntimeModel(model)) {
+    return requestLocalCopilotTitle({ message, userId, model })
+  }
+
   try {
     const response = await proxyCopilotCompletionRequest({
       body: {

--- a/apps/tradinggoose/lib/copilot/components/user-input/components/model-selector.tsx
+++ b/apps/tradinggoose/lib/copilot/components/user-input/components/model-selector.tsx
@@ -10,6 +10,8 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui'
 import { COPILOT_RUNTIME_MODELS } from '@/lib/copilot/runtime-models'
+import { isCopilotLocalRuntimeModel } from '@/lib/copilot/local-runtime/runtime-models'
+import { useProviderModels } from '@/hooks/queries/providers'
 import { cn } from '@/lib/utils'
 import { getProviderIcon } from '@/providers/ai/models'
 import { useCopilotStore } from '@/stores/copilot/store'
@@ -43,6 +45,14 @@ export function ModelSelector({ isNearTop, panelWidth }: ModelSelectorProps) {
     }))
   )
 
+  // Self-hosted models are discovered from the vLLM provider at runtime, so a
+  // newly deployed model shows up without an app rebuild. The endpoint already
+  // returns `vllm/<name>` ids, but normalise in case it ever returns bare names.
+  const { data: vllmModels } = useProviderModels('vllm')
+  const localModels = (vllmModels ?? [])
+    .map((model) => (isCopilotLocalRuntimeModel(model) ? model : `vllm/${model}`))
+    .filter((model) => model !== selectedModel)
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
@@ -61,7 +71,7 @@ export function ModelSelector({ isNearTop, panelWidth }: ModelSelectorProps) {
       </DropdownMenuTrigger>
       <DropdownMenuContent align='start' side={isNearTop ? 'bottom' : 'top'} className='p-0'>
         <div className='w-[160px] p-1'>
-          {COPILOT_RUNTIME_MODELS.map((model) => (
+          {[...COPILOT_RUNTIME_MODELS, ...localModels].map((model) => (
             <DropdownMenuItem
               key={model}
               onClick={() => void setSelectedModel(model)}

--- a/apps/tradinggoose/lib/copilot/local-runtime/agent.ts
+++ b/apps/tradinggoose/lib/copilot/local-runtime/agent.ts
@@ -1,0 +1,358 @@
+import OpenAI from 'openai'
+import { createLogger } from '@/lib/logs/console/logger'
+import { resolveVllmServiceConfig } from '@/lib/system-services/runtime'
+import { LOCAL_COPILOT_MODEL_PREFIX } from '@/lib/copilot/local-runtime/runtime-models'
+import {
+  DEFAULT_LOCAL_CONTEXT_WINDOW,
+  buildLocalWorkingMessages,
+  type LocalWorkingMessage,
+} from '@/lib/copilot/local-runtime/working-messages'
+import { getLocalCopilotSystemPrompt } from '@/lib/copilot/local-runtime/prompt'
+import type { LocalAgentTurnParams } from '@/lib/copilot/local-runtime/types'
+
+const logger = createLogger('LocalCopilotAgent')
+
+/**
+ * Tools whose implementation only exists in the browser. When the model calls
+ * one of these the local loop halts and hands control back to the client, which
+ * executes the tool and resumes via `/api/copilot/tools/mark-complete`.
+ *
+ * Must stay in sync with the `clientTool(...)` entries in
+ * `stores/copilot/tool-registry.ts` — they are the only tools with no server
+ * implementation, so offering them to the model is safe.
+ */
+export const LOCAL_CLIENT_ONLY_TOOLS = new Set([
+  'run_workflow',
+  'plan',
+  'checkoff_todo',
+  'mark_todo_in_progress',
+  'gdrive_request_access',
+  'oauth_request_access',
+  'deploy_workflow',
+  'sleep',
+])
+
+const MAX_TOOL_ITERATIONS = 20
+/** Hard cap on assistant text before truncation, to bound the SSE payload. */
+const MAX_ASSISTANT_TEXT_CHARS = 200_000
+
+type OpenAiTool = {
+  type: 'function'
+  function: {
+    name: string
+    description: string
+    parameters: Record<string, unknown>
+  }
+}
+
+type ToolCallAccumulator = {
+  id: string
+  name: string
+  arguments: string
+  index: number
+}
+
+export interface LocalAgentRunResult {
+  /** Assistant text produced across every iteration of the turn. */
+  text: string
+  /** Working messages to persist for the next turn to resume from. */
+  workingMessages: LocalWorkingMessage[]
+  /** Set when the loop stopped so the browser could execute a client-only tool. */
+  awaiting: { toolCallId: string; toolName: string } | null
+}
+
+function stripModelPrefix(model: string): string {
+  return model.startsWith(LOCAL_COPILOT_MODEL_PREFIX)
+    ? model.slice(LOCAL_COPILOT_MODEL_PREFIX.length)
+    : model
+}
+
+function buildOpenAiTools(
+  manifestTools: Array<{ name: string; description?: string; parameters?: unknown }>
+): OpenAiTool[] {
+  return manifestTools
+    .filter((tool) => tool?.name && !LOCAL_CLIENT_ONLY_TOOLS.has(tool.name))
+    .map((tool) => ({
+      type: 'function' as const,
+      function: {
+        name: tool.name,
+        description: tool.description ?? '',
+        parameters:
+          tool.parameters && typeof tool.parameters === 'object'
+            ? (tool.parameters as Record<string, unknown>)
+            : { type: 'object', properties: {} },
+      },
+    }))
+}
+
+async function createLocalClient() {
+  const vllmConfig = await resolveVllmServiceConfig()
+  const baseUrl = (vllmConfig.baseUrl || '').replace(/\/$/, '')
+  if (!baseUrl) {
+    throw new Error('vLLM service is not configured (missing baseUrl)')
+  }
+  return new OpenAI({
+    baseURL: `${baseUrl}/v1`,
+    apiKey: vllmConfig.apiKey || 'empty',
+    timeout: 10 * 60 * 1000,
+  })
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}\n…[truncated]` : value
+}
+
+function formatContextBlock(file: { filename?: string; mediaType?: string; content?: string }) {
+  return `<attached_file name="${file.filename ?? 'attachment'}" media_type="${file.mediaType ?? 'text/plain'}">\n${file.content}\n</attached_file>`
+}
+
+/** Builds the user message for this turn, folding in any processed contexts. */
+function buildUserContent(params: LocalAgentTurnParams, forModel: boolean): string {
+  const parts = (params.contexts ?? [])
+    .filter((context) => context?.content)
+    .map(
+      (context) =>
+        `<context type="${context.type}" tag="${context.tag || context.type}">\n${context.content}\n</context>`
+    )
+  for (const file of params.fileContents ?? []) {
+    if (file?.content) parts.push(formatContextBlock(file))
+  }
+  const userContent = parts.length
+    ? `${parts.join('\n\n')}\n\n${params.userMessage}`
+    : params.userMessage
+  return forModel ? truncate(userContent, MAX_ASSISTANT_TEXT_CHARS) : userContent
+}
+
+/**
+ * Runs the local Copilot agent loop against the self-hosted vLLM model.
+ *
+ * On the first iteration of a turn the loop starts from the caller-supplied
+ * history and streams text deltas into `sink`; every server tool call is
+ * executed in-process. When the model calls a client-only tool (or finishes
+ * with plain text) the run returns the working messages so the caller can
+ * persist them for the next turn.
+ *
+ * `onAssistantText` / `onToolItem` expose incremental state to the caller for
+ * persistence without buffering the whole turn.
+ */
+export async function runLocalCopilotTurn(
+  params: LocalAgentTurnParams,
+  hooks: {
+    /** Called once per iteration with the tool_calls message before execution. */
+    onAssistantToolCalls?: (message: LocalWorkingMessage) => void | Promise<void>
+    /** Called with each tool result message, for durable persistence. */
+    onToolResult?: (message: LocalWorkingMessage) => void | Promise<void>
+  } = {}
+): Promise<LocalAgentRunResult> {
+  const { sink, ctx } = params
+  const modelId = stripModelPrefix(params.model)
+  const client = await createLocalClient()
+
+  const { getCopilotRuntimeToolManifest } = await import('@/lib/copilot/runtime-tool-manifest')
+  const manifest = await getCopilotRuntimeToolManifest()
+  const openAiTools = buildOpenAiTools(manifest.tools)
+
+  const systemPrompt = getLocalCopilotSystemPrompt()
+  const workingMessages: LocalWorkingMessage[] = buildLocalWorkingMessages({
+    systemPrompt,
+    priorWorkingMessages: params.priorWorkingMessages ?? [],
+    userContent: buildUserContent(params, false),
+    continuation: params.continuation,
+    defaultContextWindow: DEFAULT_LOCAL_CONTEXT_WINDOW,
+  })
+
+  let fullText = ''
+
+  for (let iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration++) {
+    if (ctx.signal?.aborted) {
+      throw new Error('Request aborted')
+    }
+
+    const stream = await client.chat.completions.create(
+      {
+        model: modelId,
+        // buildLocalWorkingMessages already trimmed this list and prepended the
+        // system prompt; re-trimming here would prepend a second copy.
+        messages: workingMessages as never,
+        tools: openAiTools as never,
+        stream: true,
+      },
+      { signal: ctx.signal }
+    )
+
+    let textBuffer = ''
+    const toolCalls = new Map<number, ToolCallAccumulator>()
+
+    for await (const chunk of stream) {
+      const delta = chunk.choices?.[0]?.delta
+      if (!delta) continue
+
+      if (delta.content) {
+        textBuffer += delta.content
+        fullText += delta.content
+        sink.send({
+          event: 'response.output_text.delta',
+          data: { item_id: 'local_assistant_text', delta: delta.content },
+        })
+      }
+
+      if (delta.tool_calls) {
+        for (const call of delta.tool_calls) {
+          const index = call.index ?? 0
+          const existing = toolCalls.get(index) ?? { id: '', name: '', arguments: '', index }
+          if (call.id) existing.id = call.id
+          if (call.function?.name) existing.name = call.function.name
+          if (call.function?.arguments) existing.arguments += call.function.arguments
+          toolCalls.set(index, existing)
+        }
+      }
+    }
+
+    const orderedCalls = [...toolCalls.values()]
+      .sort((a, b) => a.index - b.index)
+      .filter((call) => call.name)
+
+    // No tool calls -> the turn is complete.
+    if (orderedCalls.length === 0) {
+      if (textBuffer.trim()) {
+        workingMessages.push({ role: 'assistant', content: textBuffer })
+      }
+      return { text: fullText, workingMessages, awaiting: null }
+    }
+
+    const toolCallsMessage: LocalWorkingMessage = {
+      role: 'assistant',
+      content: textBuffer || null,
+      tool_calls: orderedCalls.map((call, position) => ({
+        id: call.id || `call_${call.index}_${position}`,
+        type: 'function',
+        function: { name: call.name, arguments: call.arguments || '{}' },
+      })),
+    }
+    workingMessages.push(toolCallsMessage)
+    await hooks.onAssistantToolCalls?.(toolCallsMessage)
+
+    // Client-only tool -> stop and let the browser run it.
+    const clientOnly = orderedCalls.find((call) => LOCAL_CLIENT_ONLY_TOOLS.has(call.name))
+    if (clientOnly) {
+      return {
+        text: fullText,
+        workingMessages,
+        awaiting: {
+          toolCallId: clientOnly.id || `call_${clientOnly.index}`,
+          toolName: clientOnly.name,
+        },
+      }
+    }
+
+    for (const call of orderedCalls) {
+      const toolCallId = call.id || `call_${call.index}`
+
+      sink.send({
+        event: 'response.output_item.done',
+        data: {
+          item: {
+            type: 'function_call',
+            id: toolCallId,
+            call_id: toolCallId,
+            name: call.name,
+            arguments: call.arguments || '{}',
+          },
+        },
+      })
+
+      let payload: unknown = {}
+      try {
+        payload = call.arguments ? JSON.parse(call.arguments) : {}
+      } catch {
+        payload = {}
+      }
+
+      const {
+        executeLocalCopilotServerTool,
+      } = await import('@/lib/copilot/local-runtime/tool-execution')
+
+      const result = await executeLocalCopilotServerTool({
+        toolName: call.name,
+        payload,
+        context: {
+          userId: ctx.userId,
+          accessLevel: ctx.accessLevel,
+          ...(ctx.contextEntityKind ? { contextEntityKind: ctx.contextEntityKind } : {}),
+          ...(ctx.contextEntityId ? { contextEntityId: ctx.contextEntityId } : {}),
+          ...(ctx.workspaceId ? { workspaceId: ctx.workspaceId } : {}),
+          signal: ctx.signal,
+        },
+      })
+
+      logger.info('Local copilot tool executed', {
+        conversationId: params.conversationId,
+        toolName: call.name,
+        success: result.success,
+        stagedForReview: !!result.review,
+      })
+
+      if (result.success) {
+        sink.send({
+          event: 'tool_result',
+          data: {
+            toolCallId,
+            success: true,
+            result: result.result ?? null,
+          },
+        })
+      } else {
+        sink.send({
+          event: 'tool_error',
+          data: {
+            toolCallId,
+            success: false,
+            error: result.errorMessage ?? 'Tool execution failed',
+          },
+        })
+      }
+
+      const toolMessage: LocalWorkingMessage = {
+        role: 'tool',
+        tool_call_id: toolCallId,
+        content: buildToolResultContent(result),
+      }
+      workingMessages.push(toolMessage)
+      await hooks.onToolResult?.(toolMessage)
+    }
+  }
+
+  logger.warn('Local copilot agent hit max tool iterations', {
+    conversationId: params.conversationId,
+    model: modelId,
+  })
+  return { text: fullText, workingMessages, awaiting: null }
+}
+
+/** Serializes a tool result into the compact JSON the model sees. */
+function buildToolResultContent(result: {
+  success: boolean
+  result?: unknown
+  errorMessage?: string
+  errorStatus?: number
+  errorDetails?: unknown
+  review?: unknown
+}): string {
+  if (!result.success) {
+    return truncate(
+      JSON.stringify({
+        ok: false,
+        error: result.errorMessage ?? 'Tool execution failed',
+        ...(result.errorStatus ? { status: result.errorStatus } : {}),
+        ...(result.errorDetails ? { details: result.errorDetails } : {}),
+      }),
+      20_000
+    )
+  }
+
+  try {
+    return truncate(JSON.stringify({ ok: true, result: result.result ?? null }), 200_000)
+  } catch {
+    return JSON.stringify({ ok: true, result: String(result.result) })
+  }
+}

--- a/apps/tradinggoose/lib/copilot/local-runtime/chat-handler.ts
+++ b/apps/tradinggoose/lib/copilot/local-runtime/chat-handler.ts
@@ -1,0 +1,328 @@
+import OpenAI from 'openai'
+import { db } from '@tradinggoose/db'
+import { copilotReviewSessions } from '@tradinggoose/db'
+import { eq } from 'drizzle-orm'
+import { createLogger } from '@/lib/logs/console/logger'
+import { resolveVllmServiceConfig } from '@/lib/system-services/runtime'
+import { SSE_HEADERS, encodeSSE } from '@/lib/utils'
+import { runLocalCopilotTurn } from '@/lib/copilot/local-runtime/agent'
+import {
+  persistLocalWorkingMessage,
+  persistLocalContinuation,
+} from '@/lib/copilot/local-runtime/persistence'
+import { LOCAL_COPILOT_MODEL_PREFIX } from '@/lib/copilot/local-runtime/runtime-models'
+import type { LocalWorkingMessage } from '@/lib/copilot/local-runtime/working-messages'
+
+const logger = createLogger('LocalCopilotChatHandler')
+
+export interface LocalChatHandlerParams {
+  model: string
+  /** Raw user text, persisted as the user transcript item. */
+  message: string
+  /** Message after workspace entity mentions were resolved, sent to the model. */
+  modelMessage: string
+  userMessageId: string
+  reviewSessionId: string
+  conversationId?: string
+  workspaceId?: string
+  userId: string
+  contexts?: Array<{ type: string; tag?: string; content: string }>
+  fileContents?: Array<{ filename?: string; mediaType?: string; content?: string }>
+  fileAttachments?: unknown
+  contextsInput?: unknown
+  requestId: string
+  /**
+   * Server tools run in-process here, so there is no approval round-trip: the
+   * route does not carry an access level or review-entity context. Local turns
+   * therefore execute as 'limited', the same level the managed runtime uses for
+   * auto-accepted reviews.
+   */
+  sessionCreatedThisRequest?: boolean
+}
+
+export interface LocalContinuationHandlerParams {
+  model: string
+  reviewSessionId: string
+  userId: string
+  requestId: string
+  continuation: {
+    toolCallId: string
+    toolName: string
+    status: number
+    message?: unknown
+    data?: unknown
+  }
+}
+
+function parseAssistantText(messages: LocalWorkingMessage[]): string {
+  return messages
+    .filter((message) => message.role === 'assistant' && typeof message.content === 'string')
+    .map((message) => message.content as string)
+    .join('')
+}
+
+/**
+ * Persists the assistant transcript item for a completed turn. Uses the same
+ * review-item shape the managed runtime writes, so the client renders local
+ * turns identically.
+ */
+async function persistAssistantTranscript(params: {
+  reviewSessionId: string
+  assistantMessageId: string
+  content: string
+}): Promise<void> {
+  const { persistLocalReviewMessage } = await import('@/lib/copilot/local-runtime/persistence')
+  await persistLocalReviewMessage({
+    reviewSessionId: params.reviewSessionId,
+    itemId: params.assistantMessageId,
+    role: 'assistant',
+    content: params.content,
+  })
+}
+
+/**
+ * Streams a full local Copilot turn (inference + tool execution + review
+ * staging) to the client using the same SSE contract as the managed runtime.
+ */
+export async function handleLocalCopilotChat(
+  params: LocalChatHandlerParams
+): Promise<Response> {
+  const conversationId = params.conversationId || params.reviewSessionId
+  const assistantMessageId = `local_assistant_${crypto.randomUUID()}`
+  const bareModel = params.model.startsWith(LOCAL_COPILOT_MODEL_PREFIX)
+    ? params.model.slice(LOCAL_COPILOT_MODEL_PREFIX.length)
+    : params.model
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      let closed = false
+      const send = (event: string, data: Record<string, unknown> = {}) => {
+        if (closed) return
+        controller.enqueue(encodeSSE({ type: event, ...data }))
+      }
+
+      try {
+        send('review_session_id', { reviewSessionId: params.reviewSessionId })
+        send('start', { data: { conversationId } })
+        send('turn_state', { status: 'in_progress', phase: 'streaming' })
+
+        await db
+          .update(copilotReviewSessions)
+          .set({
+            model: `${LOCAL_COPILOT_MODEL_PREFIX}${bareModel}`,
+            conversationId,
+            updatedAt: new Date(),
+          })
+          .where(eq(copilotReviewSessions.id, params.reviewSessionId))
+
+        const priorWorkingMessages = await loadLocalWorkingHistory(params.reviewSessionId)
+
+        // Record the user's turn in the working history first, so a later turn
+        // (or a crash mid-turn) still replays this exchange. Without this the
+        // model would only ever see the most recent message.
+        const { persistLocalWorkingUserMessage, persistLocalWorkingAssistantMessage } =
+          await import('@/lib/copilot/local-runtime/persistence')
+        await persistLocalWorkingUserMessage({
+          reviewSessionId: params.reviewSessionId,
+          itemId: params.userMessageId,
+          text: params.message,
+        })
+
+        const result = await runLocalCopilotTurn(
+          {
+            model: bareModel,
+            conversationId,
+            userMessage: params.modelMessage,
+            contexts: params.contexts ?? [],
+            fileContents: params.fileContents ?? [],
+            priorWorkingMessages,
+            requestId: params.requestId,
+            ctx: {
+              userId: params.userId,
+              accessLevel: 'limited',
+              ...(params.workspaceId ? { workspaceId: params.workspaceId } : {}),
+            },
+            sink: {
+              send: (payload: Record<string, unknown>) => {
+                const { event, ...rest } = payload as { event: string } & Record<string, unknown>
+                send(event, rest)
+              },
+              close: () => {},
+              error: () => {},
+            },
+          },
+          {
+            onAssistantToolCalls: async (message) => {
+              await persistLocalWorkingMessage({
+                reviewSessionId: params.reviewSessionId,
+                message,
+              })
+            },
+            onToolResult: async (message) => {
+              await persistLocalWorkingMessage({
+                reviewSessionId: params.reviewSessionId,
+                message,
+              })
+            },
+          }
+        )
+
+        if (result.awaiting) {
+          send('awaiting_tools', {
+            toolCallId: result.awaiting.toolCallId,
+            toolName: result.awaiting.toolName,
+          })
+          send('turn_state', { status: 'in_progress', phase: 'waiting_for_tools' })
+        } else {
+          send('response.completed', {})
+          send('turn_state', { status: 'completed', phase: 'completed' })
+        }
+
+        await persistAssistantTranscript({
+          reviewSessionId: params.reviewSessionId,
+          assistantMessageId,
+          content: result.text,
+        })
+
+        // Mirror the assistant reply into the working history so the next turn
+        // replays both sides of the exchange.
+        await persistLocalWorkingAssistantMessage({
+          reviewSessionId: params.reviewSessionId,
+          itemId: assistantMessageId,
+          text: result.text,
+        })
+
+        send('stream_end', {})
+      } catch (error) {
+        logger.error(`[${params.requestId}] Local copilot turn failed`, { error })
+        send('error', {
+          message: error instanceof Error ? error.message : 'Local copilot request failed',
+        })
+        send('turn_state', { status: 'error', phase: 'error' })
+      } finally {
+        closed = true
+        controller.close()
+      }
+    },
+  })
+
+  return new Response(stream, { headers: SSE_HEADERS })
+}
+
+/**
+ * Resumes a local turn after the browser executed a client-only tool.
+ */
+export async function handleLocalCopilotContinuation(
+  params: LocalContinuationHandlerParams
+): Promise<ReadableStream<Uint8Array>> {
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      let closed = false
+      const send = (event: string, data: Record<string, unknown> = {}) => {
+        if (closed) return
+        controller.enqueue(encodeSSE({ type: event, ...data }))
+      }
+
+      try {
+        send('turn_state', { status: 'in_progress', phase: 'streaming' })
+
+        const priorWorkingMessages = await loadLocalWorkingHistory(params.reviewSessionId)
+        if (!priorWorkingMessages) {
+          logger.warn('Local continuation without stored working history', {
+            reviewSessionId: params.reviewSessionId,
+          })
+          send('response.completed', {})
+          send('turn_state', { status: 'completed', phase: 'completed' })
+          send('stream_end', {})
+          return
+        }
+
+        const result = await runLocalCopilotTurn(
+          {
+            model: params.model,
+            conversationId: params.reviewSessionId,
+            userMessage: '',
+            contexts: [],
+            priorWorkingMessages,
+            continuation: params.continuation,
+            requestId: params.requestId,
+            ctx: {
+              userId: params.userId,
+              accessLevel: 'limited',
+            },
+            sink: {
+              send: (payload: Record<string, unknown>) => {
+                const { event, ...rest } = payload as { event: string } & Record<string, unknown>
+                send(event, rest)
+              },
+              close: () => {},
+              error: () => {},
+            },
+          },
+          {
+            onAssistantToolCalls: async (message) => {
+              await persistLocalWorkingMessage({
+                reviewSessionId: params.reviewSessionId,
+                message,
+              })
+            },
+            onToolResult: async (message) => {
+              await persistLocalWorkingMessage({
+                reviewSessionId: params.reviewSessionId,
+                message,
+              })
+            },
+          }
+        )
+
+        if (result.awaiting) {
+          send('awaiting_tools', {
+            toolCallId: result.awaiting.toolCallId,
+            toolName: result.awaiting.toolName,
+          })
+          send('turn_state', { status: 'in_progress', phase: 'waiting_for_tools' })
+        } else {
+          send('response.completed', {})
+          send('turn_state', { status: 'completed', phase: 'completed' })
+        }
+
+        await persistLocalContinuationText(params.reviewSessionId, result.text)
+
+        send('stream_end', {})
+      } catch (error) {
+        logger.error(`[${params.requestId}] Local copilot continuation failed`, { error })
+        send('error', {
+          message: error instanceof Error ? error.message : 'Local copilot continuation failed',
+        })
+        send('turn_state', { status: 'error', phase: 'error' })
+      } finally {
+        closed = true
+        controller.close()
+      }
+    },
+  })
+}
+
+/**
+ * Appends streamed assistant text to the turn's assistant transcript item, and
+ * mirrors it into the working history so the next turn replays it.
+ */
+async function persistLocalContinuationText(reviewSessionId: string, text: string) {
+  if (!text.trim()) return
+  const { appendLocalAssistantText, persistLocalWorkingAssistantMessage } = await import(
+    '@/lib/copilot/local-runtime/persistence'
+  )
+  await appendLocalAssistantText(reviewSessionId, text)
+  await persistLocalWorkingAssistantMessage({
+    reviewSessionId,
+    itemId: `continuation_${crypto.randomUUID()}`,
+    text,
+  })
+}
+
+async function loadLocalWorkingHistory(
+  reviewSessionId: string
+): Promise<LocalWorkingMessage[] | null> {
+  const { loadLocalWorkingMessages } = await import('@/lib/copilot/local-runtime/persistence')
+  return loadLocalWorkingMessages(reviewSessionId)
+}

--- a/apps/tradinggoose/lib/copilot/local-runtime/check-syntax.ts
+++ b/apps/tradinggoose/lib/copilot/local-runtime/check-syntax.ts
@@ -24,6 +24,7 @@ const PATCHED_FILES = [
   'app/api/copilot/chat/route.ts',
   'app/api/copilot/usage/route.ts',
   'app/api/copilot/tools/mark-complete/route.ts',
+  'lib/copilot/components/user-input/components/model-selector.tsx',
 ]
 
 function listTs(dir: string): string[] {
@@ -36,13 +37,13 @@ function listTs(dir: string): string[] {
   return entries.flatMap((entry) => {
     const full = join(dir, entry)
     if (statSync(full).isDirectory()) return listTs(full)
-    return full.endsWith('.ts') && !full.endsWith('.test.ts') ? [full] : []
+    const isSource = full.endsWith('.ts') || full.endsWith('.tsx')
+    return isSource && !full.endsWith('.test.ts') && !full.endsWith('.test.tsx') ? [full] : []
   })
 }
 
 const targets = [...listTs(join(appDir, RUNTIME_DIR)), ...PATCHED_FILES.map((f) => join(appDir, f))]
 
-const transpiler = new Bun.Transpiler({ loader: 'ts' })
 let failed = 0
 
 for (const file of targets) {
@@ -55,6 +56,7 @@ for (const file of targets) {
     continue
   }
   try {
+    const transpiler = new Bun.Transpiler({ loader: file.endsWith('.tsx') ? 'tsx' : 'ts' })
     transpiler.transformSync(source)
     console.log(`ok   ${file.slice(appDir.length + 1)}`)
   } catch (error) {

--- a/apps/tradinggoose/lib/copilot/local-runtime/check-syntax.ts
+++ b/apps/tradinggoose/lib/copilot/local-runtime/check-syntax.ts
@@ -1,0 +1,76 @@
+// Parser-only syntax gate for the local Copilot runtime and its patched routes.
+//
+// `next build` runs under Turbopack with TS errors ignored (DOCKER_BUILD=1), so a
+// syntax error - an unescaped backtick inside a template literal, say - would only
+// surface after the full image build. Bun.Transpiler parses without resolving
+// imports, so this catches that class of error in milliseconds.
+//
+// Usage: bun check-syntax.ts <app-dir>
+// Exits non-zero and prints the offending files on failure.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+const appDir = process.argv[2]
+if (!appDir) {
+  console.error('usage: bun check-syntax.ts <app-dir>')
+  process.exit(2)
+}
+
+const RUNTIME_DIR = 'lib/copilot/local-runtime'
+const PATCHED_FILES = [
+  'lib/copilot/runtime-models.ts',
+  'lib/copilot/agent/utils.ts',
+  'app/api/copilot/chat/route.ts',
+  'app/api/copilot/usage/route.ts',
+  'app/api/copilot/tools/mark-complete/route.ts',
+]
+
+function listTs(dir: string): string[] {
+  let entries: string[]
+  try {
+    entries = readdirSync(dir)
+  } catch {
+    return []
+  }
+  return entries.flatMap((entry) => {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) return listTs(full)
+    return full.endsWith('.ts') && !full.endsWith('.test.ts') ? [full] : []
+  })
+}
+
+const targets = [...listTs(join(appDir, RUNTIME_DIR)), ...PATCHED_FILES.map((f) => join(appDir, f))]
+
+const transpiler = new Bun.Transpiler({ loader: 'ts' })
+let failed = 0
+
+for (const file of targets) {
+  let source: string
+  try {
+    source = readFileSync(file, 'utf8')
+  } catch {
+    console.error(`MISSING ${file}`)
+    failed++
+    continue
+  }
+  try {
+    transpiler.transformSync(source)
+    console.log(`ok   ${file.slice(appDir.length + 1)}`)
+  } catch (error) {
+    failed++
+    console.error(`FAIL ${file.slice(appDir.length + 1)}`)
+    console.error(
+      String((error as Error).message)
+        .split('\n')
+        .slice(0, 14)
+        .join('\n')
+    )
+  }
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} file(s) failed to parse`)
+  process.exit(1)
+}
+console.log(`\nall ${targets.length} files parse cleanly`)

--- a/apps/tradinggoose/lib/copilot/local-runtime/persistence.ts
+++ b/apps/tradinggoose/lib/copilot/local-runtime/persistence.ts
@@ -1,0 +1,414 @@
+import { db } from '@tradinggoose/db'
+import { and, asc, desc, eq, like, notLike } from 'drizzle-orm'
+import { copilotReviewItems, copilotReviewSessions } from '@tradinggoose/db'
+import type { LocalWorkingMessage } from '@/lib/copilot/local-runtime/working-messages'
+import { LOCAL_COPILOT_MODEL_PREFIX } from '@/lib/copilot/local-runtime/runtime-models'
+
+/**
+ * Persistence for the local Copilot runtime's model working history.
+ *
+ * Rows live in the existing Copilot review tables so no schema migration is
+ * needed:
+ * - the assistant `tool_calls` message is stored as a `function_call` review
+ *   item (`content` holds the call JSON), preserving transcript fidelity;
+ * - each tool result is stored as a synthetic `tool_result` review item whose
+ *   content is namespaced with `LOCAL_WORKING_PREFIX` and filtered out of the
+ *   user-visible transcript and of the model's own conversation history.
+ */
+const LOCAL_WORKING_PREFIX = '[[local-working]]'
+const TOOL_RESULT_ITEM_PREFIX = 'local_tool_result_'
+const LOCAL_USER_ITEM_PREFIX = 'local_user_'
+const LOCAL_ASSISTANT_ITEM_PREFIX = 'local_working_assistant_'
+const FUNCTION_CALL_KIND = 'function_call'
+
+type WorkingRow = { itemId: string; content: string }
+
+function encodeWorkingValue(value: unknown): string {
+  return `${LOCAL_WORKING_PREFIX}${JSON.stringify(value)}`
+}
+
+function decodeWorkingValue(content: string): unknown | null {
+  if (!content?.startsWith(LOCAL_WORKING_PREFIX)) return null
+  try {
+    return JSON.parse(content.slice(LOCAL_WORKING_PREFIX.length))
+  } catch {
+    return null
+  }
+}
+
+export function isLocalWorkingContent(content: string | null | undefined): boolean {
+  return typeof content === 'string' && content.startsWith(LOCAL_WORKING_PREFIX)
+}
+
+export function isLocalWorkingItemId(itemId: string | null | undefined): boolean {
+  if (typeof itemId !== 'string') return false
+  return (
+    itemId.startsWith(TOOL_RESULT_ITEM_PREFIX) ||
+    itemId.startsWith(LOCAL_USER_ITEM_PREFIX) ||
+    itemId.startsWith(LOCAL_ASSISTANT_ITEM_PREFIX)
+  )
+}
+/**
+ * Review items synthesised for the local working state. These must be excluded
+ * from the transcript handed to the model and from the user-visible thread.
+ */
+export function isLocalWorkingItem(row: {
+  itemId?: string | null
+  content?: string | null
+}): boolean {
+  return isLocalWorkingItemId(row.itemId) || isLocalWorkingContent(row.content)
+}
+
+/** Persists a single working message (assistant tool_calls or tool result). */
+export async function persistLocalWorkingMessage(params: {
+  reviewSessionId: string
+  message: LocalWorkingMessage
+}): Promise<void> {
+  const { reviewSessionId, message } = params
+
+  const [lastRow] = await db
+    .select({ sequence: copilotReviewItems.sequence })
+    .from(copilotReviewItems)
+    .where(eq(copilotReviewItems.sessionId, reviewSessionId))
+    .orderBy(desc(copilotReviewItems.sequence))
+    .limit(1)
+
+  const nextSequence =
+    typeof lastRow?.sequence === 'number' ? lastRow.sequence + 1 : Date.now() % 1_000_000_000
+
+  const isToolMessage = typeof message.tool_call_id === 'string' && !!message.tool_call_id
+  const timestamp = new Date().toISOString()
+
+  await db
+    .insert(copilotReviewItems)
+    .values({
+      sessionId: reviewSessionId,
+      turnId: null,
+      sequence: nextSequence,
+      itemId: isToolMessage
+        ? `${TOOL_RESULT_ITEM_PREFIX}${message.tool_call_id}`
+        : `local_tool_calls_${crypto.randomUUID()}`,
+      kind: isToolMessage ? 'tool_result' : FUNCTION_CALL_KIND,
+      messageRole: isToolMessage ? 'tool' : 'assistant',
+      content: isToolMessage
+        ? encodeWorkingValue({
+            content: message.content ?? '',
+            toolCallId: message.tool_call_id,
+            ...(message.name ? { name: message.name } : {}),
+          })
+        : encodeWorkingValue({ tool_calls: message.tool_calls ?? [] }),
+      timestamp,
+      contentBlocks: [],
+      contexts: [],
+      fileAttachments: [],
+      citations: [],
+    })
+    .onConflictDoNothing()
+}
+
+/**
+ * Loads the working history for a session in insertion order, skipping the
+ * user-authored transcript rows (those are rebuilt from the turn history).
+ *
+ * Returns `null` when nothing has been persisted yet.
+ */
+export async function loadLocalWorkingMessages(
+  reviewSessionId: string
+): Promise<LocalWorkingMessage[] | null> {
+  const rows = await db
+    .select({ itemId: copilotReviewItems.itemId, content: copilotReviewItems.content })
+    .from(copilotReviewItems)
+    .where(
+      and(
+        eq(copilotReviewItems.sessionId, reviewSessionId),
+        like(copilotReviewItems.content, `${LOCAL_WORKING_PREFIX}%`)
+      )
+    )
+    .orderBy(asc(copilotReviewItems.sequence))
+
+  if (rows.length === 0) return null
+
+  const messages: LocalWorkingMessage[] = []
+  for (const row of rows as WorkingRow[]) {
+    const decoded = decodeWorkingValue(row.content)
+    if (!decoded || typeof decoded !== 'object') continue
+    const record = decoded as Record<string, unknown>
+
+    if (Array.isArray(record.tool_calls)) {
+      messages.push({
+        role: 'assistant',
+        content: null,
+        tool_calls: record.tool_calls as LocalWorkingMessage['tool_calls'],
+      })
+      continue
+    }
+
+    if (typeof record.toolCallId === 'string') {
+      messages.push({
+        role: 'tool',
+        tool_call_id: record.toolCallId,
+        ...(typeof record.name === 'string' ? { name: record.name } : {}),
+        content: typeof record.content === 'string' ? record.content : '',
+      })
+      continue
+    }
+
+    // Plain user/assistant text turns, written by persistLocalWorkingUserMessage
+    // and persistLocalWorkingAssistantMessage. Without these the model would
+    // only ever see the current turn.
+    if (typeof record.text === 'string' && (record.role === 'user' || record.role === 'assistant')) {
+      messages.push({ role: record.role, content: record.text })
+    }
+  }
+
+  return messages.length > 0 ? messages : null
+}
+
+/**
+ * Records the user's turn in the working history so later turns can replay it.
+ * Idempotent per itemId, so a retried request cannot duplicate the turn.
+ */
+export async function persistLocalWorkingUserMessage(params: {
+  reviewSessionId: string
+  itemId: string
+  text: string
+}): Promise<void> {
+  await appendWorkingRow(params.reviewSessionId, `${LOCAL_USER_ITEM_PREFIX}${params.itemId}`, {
+    text: params.text,
+    role: 'user',
+  })
+}
+
+/**
+ * Records the assistant's reply text in the working history. Called once per
+ * completed turn; tool-call iterations are recorded separately.
+ */
+export async function persistLocalWorkingAssistantMessage(params: {
+  reviewSessionId: string
+  itemId: string
+  text: string
+}): Promise<void> {
+  if (!params.text.trim()) return
+  await appendWorkingRow(
+    params.reviewSessionId,
+    `${LOCAL_ASSISTANT_ITEM_PREFIX}${params.itemId}`,
+    { text: params.text, role: 'assistant' }
+  )
+}
+
+/** Inserts one namespaced working-history row at the end of the session. */
+async function appendWorkingRow(
+  reviewSessionId: string,
+  itemId: string,
+  payload: Record<string, unknown>
+): Promise<void> {
+  const [lastRow] = await db
+    .select({ sequence: copilotReviewItems.sequence })
+    .from(copilotReviewItems)
+    .where(eq(copilotReviewItems.sessionId, reviewSessionId))
+    .orderBy(desc(copilotReviewItems.sequence))
+    .limit(1)
+
+  const nextSequence =
+    typeof lastRow?.sequence === 'number' ? lastRow.sequence + 1 : Date.now() % 1_000_000_000
+
+  await db
+    .insert(copilotReviewItems)
+    .values({
+      sessionId: reviewSessionId,
+      turnId: null,
+      sequence: nextSequence,
+      itemId,
+      kind: 'message',
+      messageRole: typeof payload.role === 'string' ? payload.role : 'assistant',
+      content: encodeWorkingValue(payload),
+      timestamp: new Date().toISOString(),
+      contentBlocks: [],
+      contexts: [],
+      fileAttachments: [],
+      citations: [],
+    })
+    .onConflictDoNothing()
+}
+
+/**
+ * Appends the continuation tool result to the persisted working history.
+ * Idempotent: a tool result for the same call id is never written twice.
+ */
+export async function persistLocalContinuation(params: {
+  reviewSessionId: string
+  toolCallId: string
+  toolName: string
+  status: number
+  message?: unknown
+  data?: unknown
+}): Promise<void> {
+  const existing = await db
+    .select({ itemId: copilotReviewItems.itemId })
+    .from(copilotReviewItems)
+    .where(
+      and(
+        eq(copilotReviewItems.sessionId, params.reviewSessionId),
+        eq(copilotReviewItems.itemId, `${TOOL_RESULT_ITEM_PREFIX}${params.toolCallId}`)
+      )
+    )
+    .limit(1)
+
+  if (existing.length > 0) return
+
+  await persistLocalWorkingMessage({
+    reviewSessionId: params.reviewSessionId,
+    message: {
+      role: 'tool',
+      tool_call_id: params.toolCallId,
+      name: params.toolName,
+      content: JSON.stringify({
+        ok: params.status >= 200 && params.status < 300,
+        status: params.status,
+        ...(params.message !== undefined ? { message: params.message } : {}),
+        ...(params.data !== undefined ? { data: params.data } : {}),
+      }),
+    },
+  })
+}
+
+/** Deletes the assistant tool_calls row for a turn that ended without tools. */
+export async function deleteLocalWorkingMessage(
+  reviewSessionId: string,
+  itemId: string
+): Promise<void> {
+  await db
+    .delete(copilotReviewItems)
+    .where(
+      and(eq(copilotReviewItems.sessionId, reviewSessionId), eq(copilotReviewItems.itemId, itemId))
+    )
+}
+
+export async function clearLocalWorkingState(reviewSessionId: string): Promise<void> {
+  await db
+    .delete(copilotReviewItems)
+    .where(
+      and(
+        eq(copilotReviewItems.sessionId, reviewSessionId),
+        like(copilotReviewItems.content, `${LOCAL_WORKING_PREFIX}%`)
+      )
+    )
+}
+
+// ---------------------------------------------------------------- transcript --
+// The user-visible assistant message is stored as a normal review item so the
+// client renders local turns with the same code path as hosted ones.
+
+/** Persists (or replaces) the assistant transcript item for a local turn. */
+export async function persistLocalReviewMessage(params: {
+  reviewSessionId: string
+  itemId: string
+  role: 'assistant' | 'user'
+  content: string
+}): Promise<void> {
+  if (!params.content.trim()) return
+
+  const existing = await db
+    .select({ id: copilotReviewItems.id })
+    .from(copilotReviewItems)
+    .where(
+      and(
+        eq(copilotReviewItems.sessionId, params.reviewSessionId),
+        eq(copilotReviewItems.itemId, params.itemId)
+      )
+    )
+    .limit(1)
+
+  if (existing.length > 0) {
+    await db
+      .update(copilotReviewItems)
+      .set({ content: params.content })
+      .where(eq(copilotReviewItems.id, existing[0].id))
+    return
+  }
+
+  const [lastRow] = await db
+    .select({ sequence: copilotReviewItems.sequence })
+    .from(copilotReviewItems)
+    .where(eq(copilotReviewItems.sessionId, params.reviewSessionId))
+    .orderBy(desc(copilotReviewItems.sequence))
+    .limit(1)
+
+  const nextSequence =
+    typeof lastRow?.sequence === 'number' ? lastRow.sequence + 1 : Date.now() % 1_000_000_000
+
+  await db.insert(copilotReviewItems).values({
+    sessionId: params.reviewSessionId,
+    turnId: null,
+    sequence: nextSequence,
+    itemId: params.itemId,
+    kind: 'message',
+    messageRole: params.role,
+    content: params.content,
+    timestamp: new Date().toISOString(),
+    contentBlocks: [],
+    contexts: [],
+    fileAttachments: [],
+    citations: [],
+  })
+}
+
+/**
+ * Appends text to the most recent assistant transcript item of a session,
+ * creating one when the continuation produced text before any was stored.
+ */
+export async function appendLocalAssistantText(
+  reviewSessionId: string,
+  text: string
+): Promise<void> {
+  if (!text.trim()) return
+
+  const [latest] = await db
+    .select({ id: copilotReviewItems.id, content: copilotReviewItems.content })
+    .from(copilotReviewItems)
+    .where(
+      and(
+        eq(copilotReviewItems.sessionId, reviewSessionId),
+        eq(copilotReviewItems.messageRole, 'assistant'),
+        eq(copilotReviewItems.kind, 'message'),
+        notLike(copilotReviewItems.content, `${LOCAL_WORKING_PREFIX}%`)
+      )
+    )
+    .orderBy(desc(copilotReviewItems.sequence))
+    .limit(1)
+
+  if (latest) {
+    await db
+      .update(copilotReviewItems)
+      .set({ content: `${latest.content}${text}` })
+      .where(eq(copilotReviewItems.id, latest.id))
+    return
+  }
+
+  await persistLocalReviewMessage({
+    reviewSessionId,
+    itemId: `local_assistant_${crypto.randomUUID()}`,
+    role: 'assistant',
+    content: text,
+  })
+}
+
+/**
+ * Recovers the runtime model for a session from the stored item/session state.
+ * Used by mark-complete, which the client sends without a model.
+ */
+export async function readLocalSessionModelFromMessage(
+  reviewSessionId: string
+): Promise<string | null> {
+  const [session] = await db
+    .select({ model: copilotReviewSessions.model })
+    .from(copilotReviewSessions)
+    .where(eq(copilotReviewSessions.id, reviewSessionId))
+    .limit(1)
+
+  const model = session?.model
+  if (!model) return null
+  return model.startsWith(LOCAL_COPILOT_MODEL_PREFIX)
+    ? model.slice(LOCAL_COPILOT_MODEL_PREFIX.length)
+    : model
+}

--- a/apps/tradinggoose/lib/copilot/local-runtime/prompt.ts
+++ b/apps/tradinggoose/lib/copilot/local-runtime/prompt.ts
@@ -1,0 +1,16 @@
+export const LOCAL_COPILOT_SYSTEM_PROMPT = `You are the Copilot assistant inside a self-hosted TradingGoose Studio workspace. You help the user build and operate trading workflows, dashboards, watchlists, knowledge bases, custom tools and monitors.
+
+Operating rules:
+- You have tools. Prefer calling a tool over describing what you would do.
+- Read before you write: inspect existing entities with the read/grep tools before editing them.
+- Never invent entity ids, workflow ids, listing identities or document schemas. Discover them with tools.
+- Mutating tools may be staged for user review. When a tool result says \`requiresReview: true\`, the change is pending approval in the UI: tell the user what will change and wait. Do not retry it.
+- Some tools only run in the browser (\`plan\`, \`run_workflow\`, \`deploy_workflow\`, todo checkoff, access requests). Calling one hands control back to the user; keep the surrounding message short.
+- Keep responses tight and concrete. Use GitHub-flavored markdown. No emojis unless the user uses them first.
+- You are powered by a small self-hosted model: keep tool arguments minimal and avoid very long prose.
+- When the user's request is ambiguous, call the tool that gathers the missing information instead of guessing.
+`
+
+export function getLocalCopilotSystemPrompt(): string {
+  return LOCAL_COPILOT_SYSTEM_PROMPT
+}

--- a/apps/tradinggoose/lib/copilot/local-runtime/runtime-models.ts
+++ b/apps/tradinggoose/lib/copilot/local-runtime/runtime-models.ts
@@ -1,0 +1,28 @@
+export const LOCAL_COPILOT_MODEL_PREFIX = 'vllm/'
+
+/**
+ * Locally-hosted models that the Copilot widget can talk to directly, with
+ * full agentic (server tool-calling) support. These are the same self-hosted
+ * vLLM/SGLang models configured in Studio's AI providers.
+ *
+ * The widget's model list is built dynamically at runtime by fetching
+ * `/api/providers/ai/vllm/models` (the vLLM provider's model discovery route)
+ * and exposing any model whose id starts with the `vllm/` prefix.
+ */
+export async function getCopilotLocalRuntimeModels(): Promise<string[]> {
+  try {
+    const res = await fetch('/api/providers/ai/vllm/models', { cache: 'no-store' })
+    if (!res.ok) return []
+    const data = (await res.json()) as { models?: unknown }
+    if (!Array.isArray(data.models)) return []
+    return data.models
+      .filter((m): m is string => typeof m === 'string' && m.startsWith(LOCAL_COPILOT_MODEL_PREFIX))
+      .sort()
+  } catch {
+    return []
+  }
+}
+
+export function isCopilotLocalRuntimeModel(model: string): boolean {
+  return typeof model === 'string' && model.startsWith(LOCAL_COPILOT_MODEL_PREFIX)
+}

--- a/apps/tradinggoose/lib/copilot/local-runtime/title.ts
+++ b/apps/tradinggoose/lib/copilot/local-runtime/title.ts
@@ -1,0 +1,68 @@
+import OpenAI from 'openai'
+import { createLogger } from '@/lib/logs/console/logger'
+import { resolveVllmServiceConfig } from '@/lib/system-services/runtime'
+import { LOCAL_COPILOT_MODEL_PREFIX } from '@/lib/copilot/local-runtime/runtime-models'
+import {
+  TITLE_GENERATION_SYSTEM_PROMPT,
+  TITLE_GENERATION_USER_PROMPT,
+} from '@/lib/copilot/prompts'
+
+const logger = createLogger('LocalCopilotTitle')
+
+const TITLE_TIMEOUT_MS = 20_000
+const MAX_TITLE_LENGTH = 80
+
+function normalizeTitle(raw: string): string | null {
+  const title = raw
+    .trim()
+    .replace(/^["'`]+|["'`]+$/g, '')
+    .replace(/\s+/g, ' ')
+    .split('\n')[0]
+    .trim()
+  if (!title) return null
+  return title.length > MAX_TITLE_LENGTH ? `${title.slice(0, MAX_TITLE_LENGTH - 1)}…` : title
+}
+
+/**
+ * Generates a chat title with the self-hosted model. Mirrors the hosted
+ * implementation in `lib/copilot/agent/utils.ts`.
+ */
+export async function requestLocalCopilotTitle(params: {
+  message: string
+  userId: string
+  model: string
+}): Promise<string | null> {
+  try {
+    const vllmConfig = await resolveVllmServiceConfig()
+    const baseUrl = (vllmConfig.baseUrl || '').replace(/\/$/, '')
+    if (!baseUrl) return null
+
+    const modelId = params.model.startsWith(LOCAL_COPILOT_MODEL_PREFIX)
+      ? params.model.slice(LOCAL_COPILOT_MODEL_PREFIX.length)
+      : params.model
+
+    const client = new OpenAI({
+      baseURL: `${baseUrl}/v1`,
+      apiKey: vllmConfig.apiKey || 'empty',
+      timeout: TITLE_TIMEOUT_MS,
+      maxRetries: 0,
+    })
+
+    const completion = await client.chat.completions.create({
+      model: modelId,
+      messages: [
+        { role: 'system', content: TITLE_GENERATION_SYSTEM_PROMPT },
+        { role: 'user', content: TITLE_GENERATION_USER_PROMPT(params.message) },
+      ],
+      max_tokens: 32,
+      stream: false,
+    })
+
+    const raw = completion.choices?.[0]?.message?.content
+    if (typeof raw !== 'string') return null
+    return normalizeTitle(raw)
+  } catch (error) {
+    logger.warn('Local copilot title generation failed', { error })
+    return null
+  }
+}

--- a/apps/tradinggoose/lib/copilot/local-runtime/tool-execution.ts
+++ b/apps/tradinggoose/lib/copilot/local-runtime/tool-execution.ts
@@ -1,0 +1,111 @@
+import {
+  type CopilotServerToolErrorDetails,
+  getCopilotServerToolErrorDetails,
+  getCopilotServerToolErrorStatus,
+} from '@/lib/copilot/tools/client/server-tool-response'
+import { createLogger } from '@/lib/logs/console/logger'
+
+const logger = createLogger('LocalCopilotToolExecution')
+
+export interface LocalCopilotToolResult {
+  success: boolean
+  result?: unknown
+  errorMessage?: string
+  errorStatus?: number
+  errorDetails?: CopilotServerToolErrorDetails
+  /** Present when the mutation was staged for review and needs user approval. */
+  review?: { reviewToken: string; preview?: unknown }
+}
+
+export interface LocalCopilotToolExecutionContext {
+  userId: string
+  accessLevel?: 'limited' | 'full'
+  contextEntityKind?: string
+  contextEntityId?: string
+  workspaceId?: string
+  signal?: AbortSignal
+}
+
+/**
+ * Executes a server-side Copilot tool from the local runtime, reusing the same
+ * execution + review-staging path as the `/api/copilot/execute-copilot-server-tool`
+ * route so behavior (review staging, tokens, workspace context) matches.
+ *
+ * `accepting`/`reviewToken` are used when the client reports it approved a
+ * previously-staged mutation; otherwise the tool runs (and may stage a review).
+ */
+export async function executeLocalCopilotServerTool(params: {
+  toolName: string
+  payload?: unknown
+  context?: LocalCopilotToolExecutionContext
+  accepting?: boolean
+  reviewToken?: string
+}): Promise<LocalCopilotToolResult> {
+  const { toolName, payload, context } = params
+  const { userId } = context ?? {}
+
+  if (!userId) {
+    return { success: false, errorMessage: 'Authenticated user is required' }
+  }
+
+  const { isToolId } = await import('@/lib/copilot/registry')
+  if (!isToolId(toolName)) {
+    return { success: false, errorMessage: `Unknown server tool: ${toolName}` }
+  }
+  const toolId = toolName as never
+
+  const { routeExecution } = await import('@/lib/copilot/tools/server/router')
+  const {
+    acceptServerManagedToolReview,
+    stageServerManagedToolReview,
+  } = await import('@/lib/copilot/tools/server/review-acceptance')
+
+  const executionContext = {
+    userId,
+    accessLevel: (context?.accessLevel ?? 'limited') as 'limited' | 'full',
+    ...(context?.contextEntityKind ? { contextEntityKind: context.contextEntityKind as never } : {}),
+    ...(context?.contextEntityId ? { contextEntityId: context.contextEntityId } : {}),
+    ...(context?.workspaceId ? { workspaceId: context.workspaceId } : {}),
+    signal: context?.signal,
+  }
+
+  try {
+    let result: unknown
+    if (params.accepting && params.reviewToken) {
+      result = await acceptServerManagedToolReview(toolId, params.reviewToken, executionContext)
+    } else {
+      const executed = await routeExecution(toolName, payload, executionContext)
+      result = await stageServerManagedToolReview(toolId, payload, executed, executionContext)
+    }
+
+    const maybeReview = result as
+      | { requiresReview?: boolean; reviewToken?: string; reviewBaseStateHash?: unknown }
+      | null
+    if (maybeReview && maybeReview.requiresReview === true && maybeReview.reviewToken) {
+      const { requiresReview: _r, reviewToken, reviewBaseStateHash: _h, ...rest } =
+        maybeReview as Record<string, unknown> & {
+          requiresReview?: boolean
+          reviewToken?: string
+          reviewBaseStateHash?: unknown
+        }
+      return {
+        success: true,
+        result: rest,
+        review: { reviewToken, preview: rest },
+      }
+    }
+
+    return { success: true, result }
+  } catch (error) {
+    const errorDetails = getCopilotServerToolErrorDetails(error)
+    const errorStatus = getCopilotServerToolErrorStatus(error)
+    const errorMessage = error instanceof Error ? error.message : 'Tool execution failed'
+    logger.warn('Local copilot server tool failed', {
+      toolName,
+      status: errorStatus,
+      errorMessage,
+      hasDetails: !!errorDetails,
+    })
+    return { success: false, errorMessage, errorStatus, errorDetails }
+  }
+}

--- a/apps/tradinggoose/lib/copilot/local-runtime/types.ts
+++ b/apps/tradinggoose/lib/copilot/local-runtime/types.ts
@@ -1,0 +1,43 @@
+import type { LocalWorkingMessage } from '@/lib/copilot/local-runtime/working-messages'
+
+export interface LocalSseEventSink {
+  send(event: Record<string, unknown>): void
+  close(): void
+  error(err: unknown): void
+}
+
+export interface LocalRuntimeContext {
+  userId: string
+  accessLevel: 'limited' | 'full'
+  contextEntityKind?: string
+  contextEntityId?: string
+  workspaceId?: string
+  signal?: AbortSignal
+}
+
+export interface LocalAgentTurnParams {
+  model: string
+  /** Review-session id; also the key for the persisted working history. */
+  conversationId: string
+  /** User-facing message for this turn. */
+  userMessage: string
+  /** Context blocks already processed by processContextsServer. */
+  contexts: Array<{ type: string; tag?: string; content: string }>
+  fileContents?: Array<{ filename?: string; mediaType?: string; content?: string }>
+  /** Working history loaded by the caller (null on a first turn). */
+  priorWorkingMessages?: LocalWorkingMessage[] | null
+  ctx: LocalRuntimeContext
+  sink: LocalSseEventSink
+  requestId: string
+  /**
+   * When resuming after a client-executed tool, the result to feed back to the
+   * model so the loop can continue.
+   */
+  continuation?: {
+    toolCallId: string
+    toolName: string
+    status: number
+    message?: unknown
+    data?: unknown
+  }
+}

--- a/apps/tradinggoose/lib/copilot/local-runtime/working-messages.ts
+++ b/apps/tradinggoose/lib/copilot/local-runtime/working-messages.ts
@@ -1,0 +1,127 @@
+/**
+ * Working-message helpers for the local Copilot runtime.
+ *
+ * The managed Copilot service keeps the model conversation server-side. The
+ * local runtime has no such service, so the OpenAI-style working history is
+ * persisted by us (see `persistence.ts`) and rebuilt for every turn and tool
+ * continuation.
+ */
+
+export interface LocalWorkingMessage {
+  role: string
+  content?: string | null
+  tool_calls?: Array<{
+    id: string
+    type: 'function'
+    function: { name: string; arguments: string }
+  }>
+  tool_call_id?: string
+  name?: string
+}
+
+export interface LocalContinuationInput {
+  toolCallId: string
+  toolName: string
+  status: number
+  message?: unknown
+  data?: unknown
+}
+
+export interface LocalWorkingState {
+  /** Working messages in truncation order (system message excluded then re-added). */
+  messages: LocalWorkingMessage[]
+  /** System prompt that produced this history. */
+  systemPrompt: string
+  /** Model context window in tokens, used for trimming. */
+  contextWindow: number
+}
+
+export const DEFAULT_LOCAL_CONTEXT_WINDOW = 32_768
+/** Rough characters-per-token ratio used to estimate prompt size. */
+const CHARS_PER_TOKEN = 4
+
+function isToolMessage(message: LocalWorkingMessage): boolean {
+  return typeof message.tool_call_id === 'string' && message.tool_call_id.length > 0
+}
+
+/**
+ * Builds the working message list for a turn.
+ *
+ * The system prompt is not stored in the list — it is prepended at request time
+ * by `trimLocalWorkingMessages` — so prompt changes take effect immediately.
+ */
+export function buildLocalWorkingMessages(params: {
+  systemPrompt: string
+  priorWorkingMessages: LocalWorkingMessage[]
+  userContent: string
+  continuation?: LocalContinuationInput
+  defaultContextWindow?: number
+  contextWindow?: number
+}): LocalWorkingMessage[] {
+  const messages = [...(params.priorWorkingMessages ?? [])]
+
+  if (params.continuation) {
+    const { toolCallId, toolName, status, message, data } = params.continuation
+    messages.push({
+      role: 'tool',
+      tool_call_id: toolCallId,
+      name: toolName,
+      content: truncate(
+        JSON.stringify({
+          ok: status >= 200 && status < 300,
+          status,
+          ...(message !== undefined ? { message } : {}),
+          ...(data !== undefined ? { data } : {}),
+        }),
+        200_000
+      ),
+    })
+    return trimLocalWorkingMessages(messages, {
+      systemPrompt: params.systemPrompt,
+      contextWindow: params.contextWindow ?? params.defaultContextWindow,
+    })
+  }
+
+  messages.push({ role: 'user', content: params.userContent })
+  return trimLocalWorkingMessages(messages, {
+    systemPrompt: params.systemPrompt,
+    contextWindow: params.contextWindow ?? params.defaultContextWindow,
+  })
+}
+
+/**
+ * Drops the oldest whole tool exchanges until the estimated prompt fits the
+ * model context window, then prepends the system prompt.
+ */
+export function trimLocalWorkingMessages(
+  messages: LocalWorkingMessage[],
+  options: { systemPrompt: string; contextWindow?: number }
+): LocalWorkingMessage[] {
+  const contextWindow = options.contextWindow ?? DEFAULT_LOCAL_CONTEXT_WINDOW
+  const systemMessage: LocalWorkingMessage = { role: 'system', content: options.systemPrompt }
+
+  // Reserve room for the response, tools schema and context blocks.
+  const budgetTokens = Math.max(2_048, Math.floor(contextWindow * 0.5))
+  const budgetChars = budgetTokens * CHARS_PER_TOKEN
+
+  const estimate = (list: LocalWorkingMessage[]) =>
+    list.reduce((total, message) => total + JSON.stringify(message).length, 0)
+
+  let trimmed = messages
+  let index = 0
+  while (estimate(trimmed) > budgetChars && index < trimmed.length - 2) {
+    // Never split an assistant tool_calls message from its tool results: drop
+    // forward until the next user/assistant message so the pairing survives.
+    let end = index + 1
+    while (end < trimmed.length && isToolMessage(trimmed[end])) end++
+    trimmed = [...trimmed.slice(0, index), ...trimmed.slice(end)]
+    // Keep the loop bounded if nothing was removable.
+    if (isToolMessage(trimmed[index])) index++
+  }
+
+  return [systemMessage, ...trimmed]
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}\n…[truncated]` : value
+}

--- a/apps/tradinggoose/lib/copilot/runtime-models.ts
+++ b/apps/tradinggoose/lib/copilot/runtime-models.ts
@@ -1,3 +1,10 @@
+import {
+  isCopilotLocalRuntimeModel,
+  LOCAL_COPILOT_MODEL_PREFIX,
+} from '@/lib/copilot/local-runtime/runtime-models'
+
+export { isCopilotLocalRuntimeModel, LOCAL_COPILOT_MODEL_PREFIX }
+
 export const COPILOT_RUNTIME_MODELS = [
   'deepseek/deepseek-v4-pro',
   'openai/gpt-5.6-terra',
@@ -7,6 +14,25 @@ export const COPILOT_RUNTIME_MODELS = [
   'x-ai/grok-4.6',
 ] as const
 
-export type CopilotRuntimeModel = (typeof COPILOT_RUNTIME_MODELS)[number]
+export type HostedCopilotRuntimeModel = (typeof COPILOT_RUNTIME_MODELS)[number]
 
-export const DEFAULT_COPILOT_RUNTIME_MODEL: CopilotRuntimeModel = 'anthropic/claude-fable-5'
+/**
+ * Hosted models plus any self-hosted `vllm/` model. Local ids are validated by
+ * prefix rather than enum membership, so a newly deployed vLLM model works
+ * without an app rebuild. The `& {}` keeps autocomplete for hosted ids.
+ */
+export type CopilotRuntimeModel = HostedCopilotRuntimeModel | (string & {})
+
+export const HOSTED_COPILOT_RUNTIME_MODEL_SET: ReadonlySet<string> = new Set(
+  COPILOT_RUNTIME_MODELS
+)
+
+export const DEFAULT_COPILOT_RUNTIME_MODEL: CopilotRuntimeModel =
+  'anthropic/claude-fable-5'
+
+export function isValidCopilotRuntimeModel(model: unknown): model is string {
+  return (
+    typeof model === 'string' &&
+    (HOSTED_COPILOT_RUNTIME_MODEL_SET.has(model) || isCopilotLocalRuntimeModel(model))
+  )
+}

--- a/apps/tradinggoose/lib/env.ts
+++ b/apps/tradinggoose/lib/env.ts
@@ -50,7 +50,10 @@ const getKubernetesRealtimeUrl = () => {
 }
 
 const getInternalRealtimeUrl = () =>
-  getKubernetesRealtimeUrl() || getEnv('NEXT_PUBLIC_SOCKET_URL')?.trim() || 'http://localhost:3002'
+  getEnv('INTERNAL_REALTIME_URL')?.trim() ||
+  getKubernetesRealtimeUrl() ||
+  getEnv('NEXT_PUBLIC_SOCKET_URL')?.trim() ||
+  'http://localhost:3002'
 
 // Wrap createEnv in a function so non-Next.js consumers (e.g. React Email preview)
 // get a safe fallback instead of a top-level crash.
@@ -145,6 +148,7 @@ function safeCreateEnv() {
     KB_CONFIG_DELAY_BETWEEN_DOCUMENTS: z.number().optional().default(50),      // Delay between documents in ms
 
     // Real-time Communication
+    INTERNAL_REALTIME_URL: z.string().url().optional(),           // Internal realtime URL for container-to-container comms
     SOCKET_PORT: z.number().optional(),                  // Port for the realtime socket server process
     PORT: z.number().optional(),                  // Main application port
     ALLOWED_ORIGINS: z.string().optional(),                  // CORS allowed origins

--- a/apps/tradinggoose/lib/env.ts
+++ b/apps/tradinggoose/lib/env.ts
@@ -50,7 +50,10 @@ const getKubernetesRealtimeUrl = () => {
 }
 
 const getInternalRealtimeUrl = () =>
-  getKubernetesRealtimeUrl() || getEnv('NEXT_PUBLIC_SOCKET_URL')?.trim() || 'http://localhost:3002'
+  getEnv('INTERNAL_REALTIME_URL')?.trim() ||
+  getKubernetesRealtimeUrl() ||
+  getEnv('NEXT_PUBLIC_SOCKET_URL')?.trim() ||
+  'http://localhost:3002'
 
 // Wrap createEnv in a function so non-Next.js consumers (e.g. React Email preview)
 // get a safe fallback instead of a top-level crash.
@@ -98,6 +101,13 @@ function safeCreateEnv() {
     TRIGGER_SECRET_KEY: z.string().min(1).optional(),           // Trigger.dev secret key for background jobs
     CRON_SECRET: z.string().optional(),                  // Secret for authenticating cron job requests
 
+    // Kronos forecasting service
+    KRONOS_ENABLED: z.boolean().optional().default(false),           // Enable the Kronos forecast block
+    KRONOS_INTERNAL_URL: z.string().url().optional(),                 // Internal Kronos service URL
+    KRONOS_INTERNAL_TOKEN: z.string().min(32).optional(),             // Bearer token for the Kronos service
+    KRONOS_TIMEOUT_MS: z.number().int().positive().optional(),       // Timeout for Kronos requests in ms
+    KRONOS_MAX_HORIZON: z.number().int().positive().optional(),      // Max forecast horizon in bars
+
     // Cloud Storage - AWS S3
     STORAGE_PROVIDER: z.enum(['local', 's3', 'azure', 'vercel']).optional(),                  // Explicit storage provider override
     AWS_REGION: z.string().optional(),                  // AWS region for S3 buckets
@@ -138,6 +148,7 @@ function safeCreateEnv() {
     KB_CONFIG_DELAY_BETWEEN_DOCUMENTS: z.number().optional().default(50),      // Delay between documents in ms
 
     // Real-time Communication
+    INTERNAL_REALTIME_URL: z.string().url().optional(),           // Internal realtime URL for container-to-container comms
     SOCKET_PORT: z.number().optional(),                  // Port for the realtime socket server process
     PORT: z.number().optional(),                  // Main application port
     ALLOWED_ORIGINS: z.string().optional(),                  // CORS allowed origins

--- a/apps/tradinggoose/lib/env.ts
+++ b/apps/tradinggoose/lib/env.ts
@@ -98,6 +98,13 @@ function safeCreateEnv() {
     TRIGGER_SECRET_KEY: z.string().min(1).optional(),           // Trigger.dev secret key for background jobs
     CRON_SECRET: z.string().optional(),                  // Secret for authenticating cron job requests
 
+    // Kronos forecasting service
+    KRONOS_ENABLED: z.boolean().optional().default(false),           // Enable the Kronos forecast block
+    KRONOS_INTERNAL_URL: z.string().url().optional(),                 // Internal Kronos service URL
+    KRONOS_INTERNAL_TOKEN: z.string().min(32).optional(),             // Bearer token for the Kronos service
+    KRONOS_TIMEOUT_MS: z.number().int().positive().optional(),       // Timeout for Kronos requests in ms
+    KRONOS_MAX_HORIZON: z.number().int().positive().optional(),      // Max forecast horizon in bars
+
     // Cloud Storage - AWS S3
     STORAGE_PROVIDER: z.enum(['local', 's3', 'azure', 'vercel']).optional(),                  // Explicit storage provider override
     AWS_REGION: z.string().optional(),                  // AWS region for S3 buckets

--- a/apps/tradinggoose/lib/kronos/__tests__/client.test.ts
+++ b/apps/tradinggoose/lib/kronos/__tests__/client.test.ts
@@ -1,0 +1,176 @@
+import { KronosErrorCode, KronosError, ForecastRequestSchema } from '@/lib/kronos/types'
+import { getMaxHorizon, isKronosEnabled, callKronosForecast } from '@/lib/kronos/client'
+
+describe('kronos types', () => {
+  test('ForecastRequestSchema accepts a valid request', () => {
+    const result = ForecastRequestSchema.safeParse({
+      requestId: 'request-1',
+      listing: { listingId: 'AAPL', listingType: 'stock' },
+      interval: '5m',
+      timezone: 'America/New_York',
+      normalizationMode: 'raw',
+      history: Array.from({ length: 32 }, (_, i) => ({
+        timestamp: `2026-01-02T14:${30 + i}:00+00:00`,
+        open: 100 + i,
+        high: 102 + i,
+        low: 99 + i,
+        close: 101 + i,
+        volume: 1000 + i,
+      })),
+      futureTimestamps: ['2026-01-02T15:05:00+00:00'],
+      parameters: { temperature: 1.0, topP: 0.9, sampleCount: 1 },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('ForecastRequestSchema rejects too few history bars', () => {
+    const result = ForecastRequestSchema.safeParse({
+      requestId: 'request-1',
+      listing: { listingId: 'AAPL', listingType: 'stock' },
+      interval: '5m',
+      timezone: 'America/New_York',
+      history: [
+        {
+          timestamp: '2026-01-02T14:30:00+00:00',
+          open: 100,
+          high: 102,
+          low: 99,
+          close: 101,
+        },
+      ],
+      futureTimestamps: ['2026-01-02T14:35:00+00:00'],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  test('ForecastRequestSchema rejects invalid timezone', () => {
+    const result = ForecastRequestSchema.safeParse({
+      requestId: 'request-1',
+      listing: { listingId: 'AAPL', listingType: 'stock' },
+      interval: '5m',
+      timezone: 'Invalid/Timezone',
+      history: Array.from({ length: 32 }, (_, i) => ({
+        timestamp: `2026-01-02T14:${30 + i}:00+00:00`,
+        open: 100 + i,
+        high: 102 + i,
+        low: 99 + i,
+        close: 101 + i,
+      })),
+      futureTimestamps: ['2026-01-02T15:05:00+00:00'],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  test('ForecastRequestSchema rejects duplicate timestamps', () => {
+    const result = ForecastRequestSchema.safeParse({
+      requestId: 'request-1',
+      listing: { listingId: 'AAPL', listingType: 'stock' },
+      interval: '5m',
+      timezone: 'America/New_York',
+      history: Array.from({ length: 32 }, () => ({
+        timestamp: '2026-01-02T14:30:00+00:00',
+        open: 100,
+        high: 102,
+        low: 99,
+        close: 101,
+      })),
+      futureTimestamps: ['2026-01-02T14:35:00+00:00'],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  test('ForecastRequestSchema rejects future timestamps before last bar', () => {
+    const result = ForecastRequestSchema.safeParse({
+      requestId: 'request-1',
+      listing: { listingId: 'AAPL', listingType: 'stock' },
+      interval: '5m',
+      timezone: 'America/New_York',
+      history: Array.from({ length: 32 }, (_, i) => ({
+        timestamp: `2026-01-02T14:${30 + i}:00+00:00`,
+        open: 100 + i,
+        high: 102 + i,
+        low: 99 + i,
+        close: 101 + i,
+      })),
+      futureTimestamps: ['2026-01-02T14:30:00+00:00'],
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('kronos client utilities', () => {
+  beforeEach(() => {
+    delete process.env.KRONOS_ENABLED
+    delete process.env.KRONOS_INTERNAL_URL
+    delete process.env.KRONOS_INTERNAL_TOKEN
+    delete process.env.KRONOS_MAX_HORIZON
+  })
+
+  test('isKronosEnabled returns false when env vars are missing', () => {
+    expect(isKronosEnabled()).toBe(false)
+  })
+
+  test('isKronosEnabled returns true when all env vars are set', () => {
+    process.env.KRONOS_ENABLED = 'true'
+    process.env.KRONOS_INTERNAL_URL = 'http://kronos:8000'
+    process.env.KRONOS_INTERNAL_TOKEN = 'this-is-a-test-token-thats-long-enough-32'
+    expect(isKronosEnabled()).toBe(true)
+  })
+
+  test('getMaxHorizon returns default when not configured', () => {
+    expect(getMaxHorizon()).toBe(32)
+  })
+
+  test('getMaxHorizon returns configured value', () => {
+    process.env.KRONOS_MAX_HORIZON = '16'
+    expect(getMaxHorizon()).toBe(16)
+  })
+
+  test('callKronosForecast throws DISABLED when not enabled', async () => {
+    await expect(
+      callKronosForecast({
+        requestId: 'request-1',
+        listing: { listingId: 'AAPL', listingType: 'stock' },
+        interval: '5m',
+        timezone: 'America/New_York',
+        history: Array.from({ length: 32 }, (_, i) => ({
+          timestamp: `2026-01-02T14:${30 + i}:00+00:00`,
+          open: 100 + i,
+          high: 102 + i,
+          low: 99 + i,
+          close: 101 + i,
+        })),
+        futureTimestamps: ['2026-01-02T15:05:00+00:00'],
+      })
+    ).rejects.toMatchObject({ code: KronosErrorCode.DISABLED })
+  })
+
+  test('callKronosForecast throws HORIZON_EXCEEDED when horizon is too large', async () => {
+    process.env.KRONOS_ENABLED = 'true'
+    process.env.KRONOS_INTERNAL_URL = 'http://kronos:8000'
+    process.env.KRONOS_INTERNAL_TOKEN = 'this-is-a-test-token-thats-long-enough-32'
+    process.env.KRONOS_MAX_HORIZON = '12'
+
+    await expect(
+      callKronosForecast({
+        requestId: 'request-1',
+        listing: { listingId: 'AAPL', listingType: 'stock' },
+        interval: '5m',
+        timezone: 'America/New_York',
+        history: Array.from({ length: 32 }, (_, i) => ({
+          timestamp: `2026-01-02T14:${30 + i}:00+00:00`,
+          open: 100 + i,
+          high: 102 + i,
+          low: 99 + i,
+          close: 101 + i,
+        })),
+        futureTimestamps: Array.from(
+          { length: 13 },
+          (_, i) => `2026-01-02T${15 + Math.floor((i + 32) / 60)}:${((32 + i) % 60)
+            .toString()
+            .padStart(2, '0')}:00+00:00`
+        ),
+      })
+    ).rejects.toMatchObject({ code: KronosErrorCode.HORIZON_EXCEEDED })
+  })
+})

--- a/apps/tradinggoose/lib/kronos/__tests__/paper-risk.test.ts
+++ b/apps/tradinggoose/lib/kronos/__tests__/paper-risk.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from 'vitest'
+import { PaperRiskManager, deriveForecastSignalInput } from '../paper-risk'
+
+describe('PaperRiskManager', () => {
+  const risk = new PaperRiskManager({
+    maxQuantityPerSymbol: 100,
+    maxGrossExposure: 300,
+    maxNetExposure: 150,
+    maxOrdersPerHour: 6,
+    cooldownMs: 5 * 60_000,
+    dailyLossLimitFraction: 0.02,
+    startingCapital: 100_000,
+  })
+
+  it('approves a valid order within limits', () => {
+    const result = risk.check({
+      action: 'buy',
+      quantity: 10,
+      symbol: 'AAPL',
+      currentPositions: new Map([['MSFT', 50]]),
+      orderHistory: [],
+      lastSignalAt: null,
+      dailyPnL: 0,
+    })
+    expect(result.approved).toBe(true)
+    expect(result.reason).toBe('Risk checks passed')
+  })
+
+  it('rejects when daily loss limit reached', () => {
+    const result = risk.check({
+      action: 'buy',
+      quantity: 10,
+      symbol: 'AAPL',
+      currentPositions: new Map(),
+      orderHistory: [],
+      lastSignalAt: null,
+      dailyPnL: -3000,
+    })
+    expect(result.approved).toBe(false)
+    expect(result.reason).toContain('loss limit')
+  })
+
+  it('rejects during cooldown', () => {
+    const result = risk.check({
+      action: 'buy',
+      quantity: 10,
+      symbol: 'AAPL',
+      currentPositions: new Map(),
+      orderHistory: [],
+      lastSignalAt: Date.now() - 30_000, // 30 seconds ago
+      dailyPnL: 0,
+    })
+    expect(result.approved).toBe(false)
+    expect(result.reason).toContain('Cooldown')
+  })
+
+  it('rejects when orders per hour limit reached', () => {
+    const now = Date.now()
+    const orderHistory = Array.from({ length: 6 }, (_, i) => ({
+      timestamp: now - i * 5 * 60_000,
+      side: 'buy' as const,
+      quantity: 10,
+    }))
+    const result = risk.check({
+      action: 'buy',
+      quantity: 10,
+      symbol: 'AAPL',
+      currentPositions: new Map(),
+      orderHistory,
+      lastSignalAt: null,
+      dailyPnL: 0,
+    })
+    expect(result.approved).toBe(false)
+    expect(result.reason).toContain('hour limit')
+  })
+
+  it('rejects when per-symbol limit cannot be satisfied even with adjustment', () => {
+    const result = risk.check({
+      action: 'buy',
+      quantity: 20,
+      symbol: 'AAPL',
+      currentPositions: new Map([['AAPL', 100]]),
+      orderHistory: [],
+      lastSignalAt: null,
+      dailyPnL: 0,
+    })
+    expect(result.approved).toBe(false)
+    expect(result.reason).toContain('Per-symbol limit')
+  })
+
+  it('adjusts quantity to stay within per-symbol limit', () => {
+    const result = risk.check({
+      action: 'buy',
+      quantity: 10,
+      symbol: 'AAPL',
+      currentPositions: new Map([['AAPL', 95]]),
+      orderHistory: [],
+      lastSignalAt: null,
+      dailyPnL: 0,
+    })
+    expect(result.approved).toBe(true)
+    expect(result.adjustedQuantity).toBe(5)
+  })
+
+  it('rejects when gross exposure exceeded', () => {
+    const result = risk.check({
+      action: 'buy',
+      quantity: 100,
+      symbol: 'AAPL',
+      currentPositions: new Map([['MSFT', 150], ['GOOGL', 150]]),
+      orderHistory: [],
+      lastSignalAt: null,
+      dailyPnL: 0,
+    })
+    expect(result.approved).toBe(false)
+    expect(result.reason).toContain('Gross exposure')
+  })
+
+  it('rejects when net exposure exceeded', () => {
+    const result = risk.check({
+      action: 'buy',
+      quantity: 100,
+      symbol: 'AAPL',
+      currentPositions: new Map([['MSFT', 100]]),
+      orderHistory: [],
+      lastSignalAt: null,
+      dailyPnL: 0,
+    })
+    expect(result.approved).toBe(false)
+    expect(result.reason).toContain('Net exposure')
+  })
+
+  it('approves selling to reduce position', () => {
+    const result = risk.check({
+      action: 'sell',
+      quantity: 50,
+      symbol: 'AAPL',
+      currentPositions: new Map([['AAPL', 100], ['MSFT', 50]]),
+      orderHistory: [],
+      lastSignalAt: null,
+      dailyPnL: 0,
+    })
+    expect(result.approved).toBe(true)
+  })
+
+  it('approves when under both gross and net exposure limits', () => {
+    const result = risk.check({
+      action: 'buy',
+      quantity: 50,
+      symbol: 'AAPL',
+      currentPositions: new Map([['MSFT', 50], ['GOOGL', 50]]),
+      orderHistory: [],
+      lastSignalAt: null,
+      dailyPnL: 0,
+    })
+    expect(result.approved).toBe(true)
+  })
+})
+
+describe('deriveForecastSignalInput', () => {
+  it('calculates terminal return correctly', () => {
+    const result = deriveForecastSignalInput({
+      lastClose: 100,
+      predictedClose: 102,
+      predictedPath: [{ high: 103, low: 99 }],
+      realizedVolatilityAnnualized: 0.3,
+      currentPositionSide: 'flat',
+      currentPositionQuantity: 0,
+    })
+    expect(result.forecastTerminalReturn).toBeCloseTo(0.02, 5)
+  })
+
+  it('calculates predicted path drawdown', () => {
+    const result = deriveForecastSignalInput({
+      lastClose: 100,
+      predictedClose: 102,
+      predictedPath: [{ high: 103, low: 95 }],
+      realizedVolatilityAnnualized: 0.3,
+      currentPositionSide: 'flat',
+      currentPositionQuantity: 0,
+    })
+    expect(result.predictedPathDrawdown).toBeCloseTo(0.05, 5)
+  })
+
+  it('handles zero lastClose gracefully', () => {
+    const result = deriveForecastSignalInput({
+      lastClose: 0,
+      predictedClose: 0,
+      predictedPath: [{ high: 0, low: 0 }],
+      realizedVolatilityAnnualized: 0,
+      currentPositionSide: 'flat',
+      currentPositionQuantity: 0,
+    })
+    expect(result.forecastTerminalReturn).toBe(0)
+    expect(result.predictedPathDrawdown).toBe(0)
+  })
+
+  it('preserves position information', () => {
+    const result = deriveForecastSignalInput({
+      lastClose: 100,
+      predictedClose: 101,
+      predictedPath: [{ high: 102, low: 99 }],
+      realizedVolatilityAnnualized: 0.4,
+      currentPositionSide: 'long',
+      currentPositionQuantity: 10,
+    })
+    expect(result.currentPositionSide).toBe('long')
+    expect(result.currentPositionQuantity).toBe(10)
+    expect(result.realizedVolatilityAnnualized).toBe(0.4)
+  })
+
+  it('handles negative terminal return', () => {
+    const result = deriveForecastSignalInput({
+      lastClose: 100,
+      predictedClose: 98,
+      predictedPath: [{ high: 101, low: 97 }],
+      realizedVolatilityAnnualized: 0.3,
+      currentPositionSide: 'flat',
+      currentPositionQuantity: 0,
+    })
+    expect(result.forecastTerminalReturn).toBeCloseTo(-0.02, 5)
+  })
+
+  it('calculates maximum drawdown across multiple bars', () => {
+    const result = deriveForecastSignalInput({
+      lastClose: 100,
+      predictedClose: 105,
+      predictedPath: [
+        { high: 106, low: 99 },
+        { high: 107, low: 94 },
+        { high: 108, low: 101 },
+      ],
+      realizedVolatilityAnnualized: 0.3,
+      currentPositionSide: 'flat',
+      currentPositionQuantity: 0,
+    })
+    expect(result.predictedPathDrawdown).toBeCloseTo(0.06, 5)
+  })
+})

--- a/apps/tradinggoose/lib/kronos/__tests__/signal-policy.test.ts
+++ b/apps/tradinggoose/lib/kronos/__tests__/signal-policy.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import { KronosSignalPolicy } from '../signal-policy'
+
+describe('KronosSignalPolicy', () => {
+  const policy = new KronosSignalPolicy({
+    minTerminalReturn: 0.005,
+    maxPredictedDrawdown: 0.02,
+    maxRealizedVolatility: 0.6,
+    allowFlip: true,
+  })
+
+  it('returns buy when forecast is positive and above threshold', () => {
+    const result = policy.evaluate({
+      forecastTerminalReturn: 0.01,
+      predictedPathDrawdown: 0.005,
+      realizedVolatilityAnnualized: 0.3,
+      currentPositionSide: 'flat',
+      currentPositionQuantity: 0,
+    })
+    expect(result.action).toBe('buy')
+  })
+
+  it('returns sell when forecast is negative and above threshold', () => {
+    const result = policy.evaluate({
+      forecastTerminalReturn: -0.01,
+      predictedPathDrawdown: 0.005,
+      realizedVolatilityAnnualized: 0.3,
+      currentPositionSide: 'flat',
+      currentPositionQuantity: 0,
+    })
+    expect(result.action).toBe('sell')
+  })
+
+  it('returns no_trade when terminal return is below threshold', () => {
+    const result = policy.evaluate({
+      forecastTerminalReturn: 0.001,
+      predictedPathDrawdown: 0.001,
+      realizedVolatilityAnnualized: 0.3,
+      currentPositionSide: 'flat',
+      currentPositionQuantity: 0,
+    })
+    expect(result.action).toBe('no_trade')
+    expect(result.reason).toContain('below threshold')
+  })
+
+  it('returns no_trade when predicted drawdown exceeds limit', () => {
+    const result = policy.evaluate({
+      forecastTerminalReturn: 0.01,
+      predictedPathDrawdown: 0.05,
+      realizedVolatilityAnnualized: 0.3,
+      currentPositionSide: 'flat',
+      currentPositionQuantity: 0,
+    })
+    expect(result.action).toBe('no_trade')
+    expect(result.reason).toContain('drawdown')
+  })
+
+  it('returns no_trade when realized volatility exceeds limit', () => {
+    const result = policy.evaluate({
+      forecastTerminalReturn: 0.01,
+      predictedPathDrawdown: 0.005,
+      realizedVolatilityAnnualized: 0.8,
+      currentPositionSide: 'flat',
+      currentPositionQuantity: 0,
+    })
+    expect(result.action).toBe('no_trade')
+    expect(result.reason).toContain('volatility')
+  })
+
+  it('returns no_trade when already holding the same side', () => {
+    const result = policy.evaluate({
+      forecastTerminalReturn: 0.01,
+      predictedPathDrawdown: 0.005,
+      realizedVolatilityAnnualized: 0.3,
+      currentPositionSide: 'long',
+      currentPositionQuantity: 10,
+    })
+    expect(result.action).toBe('no_trade')
+    expect(result.reason).toContain('Already')
+  })
+
+  it('returns sell when flipping from long to short and allowFlip is true', () => {
+    const result = policy.evaluate({
+      forecastTerminalReturn: -0.01,
+      predictedPathDrawdown: 0.005,
+      realizedVolatilityAnnualized: 0.3,
+      currentPositionSide: 'long',
+      currentPositionQuantity: 10,
+    })
+    expect(result.action).toBe('sell')
+  })
+
+  it('returns no_trade when flipping is disallowed', () => {
+    const noFlipPolicy = new KronosSignalPolicy({
+      minTerminalReturn: 0.005,
+      maxPredictedDrawdown: 0.02,
+      maxRealizedVolatility: 0.6,
+      allowFlip: false,
+    })
+    const result = noFlipPolicy.evaluate({
+      forecastTerminalReturn: -0.01,
+      predictedPathDrawdown: 0.005,
+      realizedVolatilityAnnualized: 0.3,
+      currentPositionSide: 'long',
+      currentPositionQuantity: 10,
+    })
+    expect(result.action).toBe('no_trade')
+    expect(result.reason).toContain('Flip')
+  })
+
+  it('returns no_trade when forecast is exactly zero', () => {
+    const result = policy.evaluate({
+      forecastTerminalReturn: 0,
+      predictedPathDrawdown: 0.001,
+      realizedVolatilityAnnualized: 0.3,
+      currentPositionSide: 'flat',
+      currentPositionQuantity: 0,
+    })
+    expect(result.action).toBe('no_trade')
+  })
+
+  it('includes metadata in the result', () => {
+    const result = policy.evaluate({
+      forecastTerminalReturn: 0.01,
+      predictedPathDrawdown: 0.005,
+      realizedVolatilityAnnualized: 0.3,
+      currentPositionSide: 'flat',
+      currentPositionQuantity: 0,
+    })
+    expect(result.metadata.terminalReturn).toBe(0.01)
+    expect(result.metadata.predictedDrawdown).toBe(0.005)
+    expect(result.metadata.realizedVolatility).toBe(0.3)
+    expect(result.expiresAt).toBeDefined()
+  })
+})

--- a/apps/tradinggoose/lib/kronos/client.ts
+++ b/apps/tradinggoose/lib/kronos/client.ts
@@ -1,0 +1,146 @@
+import { createLogger } from '@/lib/logs/console/logger'
+import {
+  ForecastRequest,
+  ForecastResponse,
+  ForecastResponseSchema,
+  KronosError,
+  KronosErrorCode,
+} from './types'
+
+const logger = createLogger('KronosClient')
+
+const DEFAULT_TIMEOUT_MS = 30_000
+const DEFAULT_MAX_HORIZON = 32
+
+export interface KronosCallOptions {
+  signal?: AbortSignal
+}
+
+function readEnv(variable: string): string | undefined {
+  return process.env[variable]?.trim() || undefined
+}
+
+function getBoolean(variable: string): boolean {
+  const value = readEnv(variable)
+  return value?.toLowerCase() === 'true' || value === '1'
+}
+
+function getNumber(variable: string): number | undefined {
+  const value = readEnv(variable)
+  if (value === undefined) return undefined
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+export async function callKronosForecast(
+  request: ForecastRequest,
+  options: KronosCallOptions = {}
+): Promise<ForecastResponse> {
+  const enabled = getBoolean('KRONOS_ENABLED')
+  const url = readEnv('KRONOS_INTERNAL_URL')
+  const token = readEnv('KRONOS_INTERNAL_TOKEN')
+  const timeoutMs = getNumber('KRONOS_TIMEOUT_MS') ?? DEFAULT_TIMEOUT_MS
+  const maxHorizon = getNumber('KRONOS_MAX_HORIZON') ?? DEFAULT_MAX_HORIZON
+
+  if (!enabled) {
+    throw new KronosError(KronosErrorCode.DISABLED, 'Kronos forecasting is not enabled')
+  }
+  if (!url) {
+    throw new KronosError(
+      KronosErrorCode.UNAVAILABLE,
+      'Kronos service URL is not configured'
+    )
+  }
+  if (!token) {
+    throw new KronosError(
+      KronosErrorCode.UNAVAILABLE,
+      'Kronos service token is not configured'
+    )
+  }
+  if (request.futureTimestamps.length > maxHorizon) {
+    throw new KronosError(
+      KronosErrorCode.HORIZON_EXCEEDED,
+      `Forecast horizon ${request.futureTimestamps.length} exceeds the configured maximum of ${maxHorizon}`
+    )
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+
+  try {
+    const response = await fetch(`${url}/v1/forecast`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(request),
+      signal: options.signal
+        ? AbortSignal.any([controller.signal, options.signal])
+        : controller.signal,
+    })
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '')
+      if (response.status === 503) {
+        throw new KronosError(
+          KronosErrorCode.UNAVAILABLE,
+          'Kronos service is not ready'
+        )
+      }
+      if (response.status === 429) {
+        throw new KronosError(
+          KronosErrorCode.UNAVAILABLE,
+          'Kronos service is overloaded'
+        )
+      }
+      throw new KronosError(
+        KronosErrorCode.INVALID_RESPONSE,
+        `Kronos request failed with status ${response.status}: ${detail.slice(0, 200)}`
+      )
+    }
+
+    const raw = await response.json()
+    const parsed = ForecastResponseSchema.safeParse(raw)
+    if (!parsed.success) {
+      logger.error('Kronos response failed validation', {
+        requestId: request.requestId,
+        issues: parsed.error.issues,
+      })
+      throw new KronosError(
+        KronosErrorCode.INVALID_RESPONSE,
+        'Kronos returned an invalid forecast response'
+      )
+    }
+    return parsed.data
+  } catch (error) {
+    if (error instanceof KronosError) {
+      throw error
+    }
+    if (error instanceof Error) {
+      if (error.name === 'AbortError') {
+        throw new KronosError(
+          KronosErrorCode.TIMEOUT,
+          'Kronos request timed out'
+        )
+      }
+      throw new KronosError(
+        KronosErrorCode.UNAVAILABLE,
+        `Kronos request failed: ${error.message}`
+      )
+    }
+    throw new KronosError(KronosErrorCode.UNAVAILABLE, 'Kronos request failed')
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+export function isKronosEnabled(): boolean {
+  return getBoolean('KRONOS_ENABLED')
+    && Boolean(readEnv('KRONOS_INTERNAL_URL'))
+    && Boolean(readEnv('KRONOS_INTERNAL_TOKEN'))
+}
+
+export function getMaxHorizon(): number {
+  return getNumber('KRONOS_MAX_HORIZON') ?? DEFAULT_MAX_HORIZON
+}

--- a/apps/tradinggoose/lib/kronos/index.ts
+++ b/apps/tradinggoose/lib/kronos/index.ts
@@ -26,4 +26,5 @@ export async function callKronosForecast(
 }
 
 export { logForecastRequest, logForecastRealization, logForecastError }
+export { isKronosEnabled } from './client'
 export * from './types'

--- a/apps/tradinggoose/lib/kronos/index.ts
+++ b/apps/tradinggoose/lib/kronos/index.ts
@@ -1,0 +1,29 @@
+import { ForecastRequest, ForecastResponse } from './types'
+import { logForecastRequest, logForecastRealization, logForecastError } from './ledger'
+
+export interface KronosCallContext {
+  workflowId?: string
+  executionId?: string
+  blockId?: string
+  workspaceId?: string
+  userId?: string
+}
+
+export async function callKronosForecast(
+  request: ForecastRequest,
+  context: KronosCallContext = {},
+  options: { signal?: AbortSignal } = {}
+): Promise<ForecastResponse> {
+  const { callKronosForecast: rawCall } = await import('./client')
+  try {
+    const response = await rawCall(request, options)
+    logForecastRequest(request, response, context)
+    return response
+  } catch (error) {
+    logForecastError(request.requestId, error, context)
+    throw error
+  }
+}
+
+export { logForecastRequest, logForecastRealization, logForecastError }
+export * from './types'

--- a/apps/tradinggoose/lib/kronos/ledger.ts
+++ b/apps/tradinggoose/lib/kronos/ledger.ts
@@ -1,0 +1,171 @@
+import { createLogger } from '@/lib/logs/console/logger'
+import { ForecastRequest, ForecastResponse } from '@/lib/kronos/types'
+
+const logger = createLogger('KronosLedger')
+
+export interface ForecastLedgerEntry {
+  requestId: string
+  workflowId?: string
+  executionId?: string
+  blockId?: string
+  workspaceId?: string
+  userId?: string
+  listingId: string
+  listingType: string
+  interval: string
+  timezone: string
+  normalizationMode: string
+  barCount: number
+  horizonBars: number
+  lastCompletedBarTimestamp?: string
+  modelName: string
+  modelRevision: string
+  tokenizerRevision: string
+  sourceRevision: string
+  device: string
+  parameters: {
+    temperature: number
+    topP: number
+    sampleCount: number
+  }
+  diagnostics: {
+    volumeImputed: boolean
+    amountImputed: boolean
+    candleReconciliationCount: number
+    warnings: string[]
+  }
+  timingMs: {
+    queue: number
+    inference: number
+    total: number
+  }
+  inputDataFreshnessMs?: number
+  createdAt: string
+}
+
+export interface ForecastRealizationEntry {
+  requestId: string
+  listingId: string
+  interval: string
+  timezone: string
+  realizedAt: string
+  horizonBars: number
+  realizedPrices?: Array<{
+    timestamp: string
+    open: number
+    high: number
+    low: number
+    close: number
+  }>
+}
+
+function sanitizeForLog(value: unknown): unknown {
+  if (value === null || value === undefined) return value
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed.length > 200) return `${trimmed.slice(0, 200)}...`
+    return trimmed
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') return value
+  if (Array.isArray(value)) return value.slice(0, 50).map(sanitizeForLog)
+  if (typeof value === 'object') {
+    const result: Record<string, unknown> = {}
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      if (key.toLowerCase().includes('token') || key.toLowerCase().includes('secret')) {
+        result[key] = '[REDACTED]'
+      } else {
+        result[key] = sanitizeForLog(val)
+      }
+    }
+    return result
+  }
+  return String(value)
+}
+
+export function logForecastRequest(
+  request: ForecastRequest,
+  response: ForecastResponse,
+  context: {
+    workflowId?: string
+    executionId?: string
+    blockId?: string
+    workspaceId?: string
+    userId?: string
+    createdAt?: string
+  }
+): ForecastLedgerEntry {
+  const entry: ForecastLedgerEntry = {
+    requestId: request.requestId,
+    workflowId: context.workflowId,
+    executionId: context.executionId,
+    blockId: context.blockId,
+    workspaceId: context.workspaceId,
+    userId: context.userId,
+    listingId: request.listing.listingId,
+    listingType: request.listing.listingType,
+    interval: request.interval,
+    timezone: request.timezone,
+    normalizationMode: request.normalizationMode,
+    barCount: request.history.length,
+    horizonBars: request.futureTimestamps.length,
+    lastCompletedBarTimestamp: request.history.at(-1)?.timestamp,
+    modelName: response.model.name,
+    modelRevision: response.model.modelRevision,
+    tokenizerRevision: response.model.tokenizerRevision,
+    sourceRevision: response.model.sourceRevision,
+    device: response.model.device,
+    parameters: {
+      temperature: request.parameters.temperature,
+      topP: request.parameters.topP,
+      sampleCount: request.parameters.sampleCount,
+    },
+    diagnostics: {
+      volumeImputed: response.diagnostics.volumeImputed,
+      amountImputed: response.diagnostics.amountImputed,
+      candleReconciliationCount: response.diagnostics.candleReconciliationCount,
+      warnings: response.diagnostics.warnings,
+    },
+    timingMs: {
+      queue: Math.round(response.timingMs.queue),
+      inference: Math.round(response.timingMs.inference),
+      total: Math.round(response.timingMs.total),
+    },
+    createdAt: context.createdAt ?? new Date().toISOString(),
+  }
+
+  logger.info('Kronos forecast generated', sanitizeForLog(entry))
+
+  return entry
+}
+
+export function logForecastRealization(
+  entry: ForecastRealizationEntry
+): void {
+  logger.info('Kronos forecast realization recorded', sanitizeForLog(entry))
+}
+
+export function logForecastError(
+  requestId: string,
+  error: unknown,
+  context: {
+    workflowId?: string
+    executionId?: string
+    blockId?: string
+    workspaceId?: string
+    userId?: string
+    listingId?: string
+  }
+): void {
+  const message = error instanceof Error ? error.message : String(error)
+  const code =
+    error instanceof Error && 'code' in error
+      ? (error as { code: string }).code
+      : 'UNKNOWN'
+
+  logger.error('Kronos forecast failed', sanitizeToLog({
+    requestId,
+    errorCode: code,
+    errorMessage: message,
+    ...context,
+  }))
+}

--- a/apps/tradinggoose/lib/kronos/paper-risk.ts
+++ b/apps/tradinggoose/lib/kronos/paper-risk.ts
@@ -1,0 +1,194 @@
+import { KronosSignalPolicy, type SignalPolicyConfig, type SignalPolicyInput } from './signal-policy'
+
+export interface PaperRiskConfig {
+  /** Maximum number of units to hold per symbol. */
+  maxQuantityPerSymbol: number
+  /** Maximum gross exposure (sum of abs(quantity) across symbols). */
+  maxGrossExposure: number
+  /** Maximum net exposure (sum of signed quantities). */
+  maxNetExposure: number
+  /** Maximum number of orders per hour. */
+  maxOrdersPerHour: number
+  /** Cooldown in ms after an order or rejected signal. */
+  cooldownMs: number
+  /** Daily loss limit as a fraction of starting capital. */
+  dailyLossLimitFraction: number
+  /** Starting capital for the paper account. */
+  startingCapital: number
+}
+
+export const DEFAULT_PAPER_RISK_CONFIG: PaperRiskConfig = {
+  maxQuantityPerSymbol: 100,
+  maxGrossExposure: 300,
+  maxNetExposure: 150,
+  maxOrdersPerHour: 6,
+  cooldownMs: 5 * 60_000,
+  dailyLossLimitFraction: 0.02,
+  startingCapital: 100_000,
+}
+
+export interface RiskCheckInput {
+  action: 'buy' | 'sell'
+  quantity: number
+  symbol: string
+  currentPositions: Map<string, number>
+  orderHistory: Array<{ timestamp: number; side: 'buy' | 'sell'; quantity: number }>
+  lastSignalAt: number | null
+  dailyPnL: number
+}
+
+export interface RiskCheckResult {
+  approved: boolean
+  reason: string
+  adjustedQuantity?: number
+}
+
+export class PaperRiskManager {
+  private config: PaperRiskConfig
+
+  constructor(config: Partial<PaperRiskConfig> = {}) {
+    this.config = { ...DEFAULT_PAPER_RISK_CONFIG, ...config }
+  }
+
+  check(input: RiskCheckInput): RiskCheckResult {
+    const {
+      action,
+      quantity,
+      symbol,
+      currentPositions,
+      orderHistory,
+      lastSignalAt,
+      dailyPnL,
+    } = input
+
+    const {
+      maxQuantityPerSymbol,
+      maxGrossExposure,
+      maxNetExposure,
+      maxOrdersPerHour,
+      cooldownMs,
+      dailyLossLimitFraction,
+      startingCapital,
+    } = this.config
+
+    // Daily loss limit
+    if (dailyPnL < -startingCapital * dailyLossLimitFraction) {
+      return {
+        approved: false,
+        reason: `Daily loss limit reached: ${dailyPnL.toFixed(2)} < ${(
+          -startingCapital * dailyLossLimitFraction
+        ).toFixed(2)}`,
+      }
+    }
+
+    // Cooldown
+    if (lastSignalAt !== null && Date.now() - lastSignalAt < cooldownMs) {
+      return {
+        approved: false,
+        reason: `Cooldown active: ${Math.ceil(
+          (cooldownMs - (Date.now() - lastSignalAt)) / 1000
+        )}s remaining`,
+      }
+    }
+
+    // Orders per hour
+    const oneHourAgo = Date.now() - 3_600_000
+    const recentOrders = orderHistory.filter((o) => o.timestamp > oneHourAgo).length
+    if (recentOrders >= maxOrdersPerHour) {
+      return {
+        approved: false,
+        reason: `Orders per hour limit reached: ${recentOrders} >= ${maxOrdersPerHour}`,
+      }
+    }
+
+    // Calculate new position for the symbol
+    const currentSymbolQty = currentPositions.get(symbol) ?? 0
+    const delta = action === 'buy' ? quantity : -quantity
+    const newSymbolQty = currentSymbolQty + delta
+
+    // Per-symbol quantity check
+    if (Math.abs(newSymbolQty) > maxQuantityPerSymbol) {
+      const room = maxQuantityPerSymbol - Math.abs(currentSymbolQty)
+      if (room <= 0) {
+        return {
+          approved: false,
+          reason: `Per-symbol limit reached: ${symbol} at ${currentSymbolQty}`,
+        }
+      }
+      if (Math.abs(delta) > room) {
+        return {
+          approved: true,
+          reason: `Quantity adjusted to ${room} due to per-symbol limit`,
+          adjustedQuantity: room,
+        }
+      }
+    }
+
+    // Build the new positions map
+    const newPositions = new Map(currentPositions)
+    newPositions.set(symbol, newSymbolQty)
+
+    // Gross exposure check
+    let grossExposure = 0
+    for (const qty of newPositions.values()) {
+      grossExposure += Math.abs(qty)
+    }
+    if (grossExposure > maxGrossExposure) {
+      return {
+        approved: false,
+        reason: `Gross exposure limit reached: ${grossExposure} > ${maxGrossExposure}`,
+      }
+    }
+
+    // Net exposure check
+    let netExposure = 0
+    for (const qty of newPositions.values()) {
+      netExposure += qty
+    }
+    if (Math.abs(netExposure) > maxNetExposure) {
+      return {
+        approved: false,
+        reason: `Net exposure limit reached: ${netExposure} > ${maxNetExposure}`,
+      }
+    }
+
+    return { approved: true, reason: 'Risk checks passed' }
+  }
+}
+
+export function deriveForecastSignalInput(args: {
+  lastClose: number
+  predictedClose: number
+  predictedPath: Array<{ high: number; low: number }>
+  realizedVolatilityAnnualized: number
+  currentPositionSide: 'long' | 'short' | 'flat'
+  currentPositionQuantity: number
+}): SignalPolicyInput {
+  const {
+    lastClose,
+    predictedClose,
+    predictedPath,
+    realizedVolatilityAnnualized,
+    currentPositionSide,
+    currentPositionQuantity,
+  } = args
+  const terminalReturn = lastClose > 0 ? (predictedClose - lastClose) / lastClose : 0
+
+  let maxDrawdown = 0
+  for (const bar of predictedPath) {
+    if (lastClose > 0) {
+      const drawdown = (lastClose - bar.low) / lastClose
+      if (drawdown > maxDrawdown) maxDrawdown = drawdown
+    }
+  }
+
+  return {
+    forecastTerminalReturn: terminalReturn,
+    predictedPathDrawdown: maxDrawdown,
+    realizedVolatilityAnnualized,
+    currentPositionSide,
+    currentPositionQuantity,
+  }
+}
+
+export type { SignalPolicyConfig, SignalPolicyInput }

--- a/apps/tradinggoose/lib/kronos/signal-policy.ts
+++ b/apps/tradinggoose/lib/kronos/signal-policy.ts
@@ -1,0 +1,147 @@
+export type SignalAction = 'buy' | 'sell' | 'no_trade'
+
+export interface SignalPolicyConfig {
+  /** Minimum forecast terminal return (fraction, e.g. 0.005 = 0.5%) to trigger a trade. */
+  minTerminalReturn: number
+  /** Maximum predicted path drawdown (fraction) beyond which we stand aside. */
+  maxPredictedDrawdown: number
+  /** Realized annualized volatility above which we stand aside. */
+  maxRealizedVolatility: number
+  /** When true, reduce position when already holding the same side. */
+  allowFlip: boolean
+}
+
+export interface SignalPolicyInput {
+  forecastTerminalReturn: number
+  predictedPathDrawdown: number
+  realizedVolatilityAnnualized: number
+  currentPositionSide: 'long' | 'short' | 'flat'
+  currentPositionQuantity: number
+}
+
+export interface SignalPolicyResult {
+  action: SignalAction
+  reason: string
+  expiresAt: string
+  metadata: {
+    terminalReturn: number
+    predictedDrawdown: number
+    realizedVolatility: number
+    score: number
+  }
+}
+
+export const DEFAULT_SIGNAL_POLICY_CONFIG: SignalPolicyConfig = {
+  minTerminalReturn: 0.005,
+  maxPredictedDrawdown: 0.02,
+  maxRealizedVolatility: 0.6,
+  allowFlip: true,
+}
+
+export class KronosSignalPolicy {
+  private config: SignalPolicyConfig
+
+  constructor(config: Partial<SignalPolicyConfig> = {}) {
+    this.config = { ...DEFAULT_SIGNAL_POLICY_CONFIG, ...config }
+  }
+
+  evaluate(input: SignalPolicyInput): SignalPolicyResult {
+    const {
+      forecastTerminalReturn,
+      predictedPathDrawdown,
+      realizedVolatilityAnnualized,
+      currentPositionSide,
+      currentPositionQuantity,
+    } = input
+
+    const { minTerminalReturn, maxPredictedDrawdown, maxRealizedVolatility, allowFlip } =
+      this.config
+
+    const absReturn = Math.abs(forecastTerminalReturn)
+    const direction: SignalAction =
+      forecastTerminalReturn > 0 ? 'buy' : forecastTerminalReturn < 0 ? 'sell' : 'no_trade'
+
+    let score = absReturn
+    const reasons: string[] = []
+
+    // Volatility gate
+    if (realizedVolatilityAnnualized > maxRealizedVolatility) {
+      return this.noTrade(
+        input,
+        score,
+        `Realized volatility ${realizedVolatilityAnnualized.toFixed(3)} exceeds limit ${maxRealizedVolatility}`
+      )
+    }
+
+    // Predicted drawdown gate
+    if (predictedPathDrawdown > maxPredictedDrawdown) {
+      return this.noTrade(
+        input,
+        score,
+        `Predicted drawdown ${predictedPathDrawdown.toFixed(4)} exceeds limit ${maxPredictedDrawdown}`
+      )
+    }
+
+    // Minimum return threshold
+    if (absReturn < minTerminalReturn) {
+      return this.noTrade(
+        input,
+        score,
+        `Forecast terminal return ${absReturn.toFixed(4)} below threshold ${minTerminalReturn}`
+      )
+    }
+
+    // Already holding the same side
+    if (
+      currentPositionSide !== 'flat' &&
+      ((direction === 'buy' && currentPositionSide === 'long') ||
+        (direction === 'sell' && currentPositionSide === 'short'))
+    ) {
+      return this.noTrade(input, score, `Already ${currentPositionSide} ${direction === 'buy' ? 'long' : 'short'}`)
+    }
+
+    // Flip check
+    if (
+      !allowFlip &&
+      currentPositionSide !== 'flat' &&
+      ((direction === 'buy' && currentPositionSide === 'short') ||
+        (direction === 'sell' && currentPositionSide === 'long'))
+    ) {
+      return this.noTrade(input, score, `Flip from ${currentPositionSide} to ${direction} not allowed`)
+    }
+
+    reasons.push(`terminal_return=${absReturn.toFixed(4)}`)
+    reasons.push(`predicted_drawdown=${predictedPathDrawdown.toFixed(4)}`)
+    reasons.push(`realized_vol=${realizedVolatilityAnnualized.toFixed(3)}`)
+
+    return {
+      action: direction,
+      reason: reasons.join(' '),
+      expiresAt: new Date(Date.now() + 5 * 60_000).toISOString(),
+      metadata: {
+        terminalReturn: forecastTerminalReturn,
+        predictedDrawdown: predictedPathDrawdown,
+        realizedVolatility: realizedVolatilityAnnualized,
+        score,
+      },
+    }
+  }
+
+  private noTrade(
+    input: SignalPolicyInput,
+    score: number,
+    reason: string
+  ): SignalPolicyResult {
+    return {
+      action: 'no_trade',
+      reason,
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      metadata: {
+        terminalReturn: input.forecastTerminalReturn,
+        predictedDrawdown: input.predictedPathDrawdown,
+        realizedVolatility: input.realizedVolatilityAnnualized,
+        score,
+      },
+    }
+  }
+}

--- a/apps/tradinggoose/lib/kronos/types.ts
+++ b/apps/tradinggoose/lib/kronos/types.ts
@@ -1,0 +1,157 @@
+import { z } from 'zod'
+
+export const LISTING_IDENTITY_VALUE_TYPE = 'json' as const
+
+export const KronosStatus = {
+  DISABLED: 'disabled',
+  ENABLED: 'enabled',
+} as const
+
+export type KronosStatus = (typeof KronosStatus)[keyof typeof KronosStatus]
+
+const marketBarSchema = z.object({
+  timestamp: z.string(),
+  open: z.number().positive().finite(),
+  high: z.number().positive().finite(),
+  low: z.number().positive().finite(),
+  close: z.number().positive().finite(),
+  volume: z.number().min(0).finite().nullable().optional(),
+  amount: z.number().min(0).finite().nullable().optional(),
+})
+
+const isValidTimezone = (value: string): boolean => {
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: value })
+    return true
+  } catch {
+    return false
+  }
+}
+
+export const ForecastRequestSchema = z
+  .object({
+    requestId: z.string().min(1).max(255),
+    listing: z.object({
+      listingId: z.string().min(1).max(255),
+      listingType: z.string().min(1).max(64),
+    }),
+    interval: z.string().min(1).max(16),
+    timezone: z.string().min(1).max(64).refine(isValidTimezone, {
+      message: 'timezone must be a valid IANA timezone',
+    }),
+    normalizationMode: z.string().min(1).max(32).default('raw'),
+    history: z.array(marketBarSchema).min(32).max(512),
+    futureTimestamps: z.array(z.string()).min(1).max(32),
+    parameters: z
+      .object({
+        temperature: z.number().positive().max(5).default(1.0),
+        topP: z.number().positive().max(1).default(0.9),
+        sampleCount: z.number().int().positive().max(1).default(1),
+      })
+      .default({ temperature: 1.0, topP: 0.9, sampleCount: 1 }),
+  })
+  .refine(
+    (data) => {
+      const timestamps = data.history.map((bar) => bar.timestamp)
+      const unique = new Set(timestamps)
+      return unique.size === timestamps.length
+    },
+    { message: 'historical timestamps must be unique' }
+  )
+  .refine(
+    (data) => {
+      const timestamps = data.history.map((bar) => bar.timestamp)
+      for (let i = 1; i < timestamps.length; i++) {
+        if (timestamps[i] <= timestamps[i - 1]) return false
+      }
+      return true
+    },
+    { message: 'historical timestamps must be strictly increasing' }
+  )
+  .refine(
+    (data) => {
+      const lastBar = data.history[data.history.length - 1].timestamp
+      return data.futureTimestamps.every((timestamp) => timestamp > lastBar)
+    },
+    { message: 'future timestamps must be after the final historical timestamp' }
+  )
+
+export type ForecastRequest = z.infer<typeof ForecastRequestSchema>
+
+export const ForecastPointSchema = z.object({
+  timestamp: z.string(),
+  open: z.number(),
+  high: z.number(),
+  low: z.number(),
+  close: z.number(),
+  volume: z.number(),
+  amount: z.number(),
+})
+
+export const ForecastResponseSchema = z.object({
+  requestId: z.string(),
+  forecast: z.array(ForecastPointSchema),
+  model: z.object({
+    name: z.string(),
+    sourceRevision: z.string(),
+    modelRevision: z.string(),
+    tokenizerRevision: z.string(),
+    device: z.string(),
+    maxContext: z.number().int(),
+  }),
+  input: z.object({
+    listing: z.object({
+      listingId: z.string(),
+      listingType: z.string(),
+    }),
+    interval: z.string(),
+    timezone: z.string(),
+    normalizationMode: z.string(),
+    barCount: z.number().int(),
+    lastCompletedBarTimestamp: z.string(),
+  }),
+  parameters: z.object({
+    temperature: z.number(),
+    topP: z.number(),
+    sampleCount: z.number().int(),
+  }),
+  diagnostics: z.object({
+    volumeImputed: z.boolean(),
+    amountImputed: z.boolean(),
+    candleReconciliationCount: z.number().int(),
+    warnings: z.array(z.string()),
+  }),
+  timingMs: z.object({
+    queue: z.number(),
+    inference: z.number(),
+    total: z.number(),
+  }),
+})
+
+export type ForecastResponse = z.infer<typeof ForecastResponseSchema>
+
+export const KronosErrorCode = {
+  DISABLED: 'KRONOS_DISABLED',
+  UNAVAILABLE: 'KRONOS_UNAVAILABLE',
+  TIMEOUT: 'KRONOS_TIMEOUT',
+  INVALID_RESPONSE: 'KRONOS_INVALID_RESPONSE',
+  LISTING_REQUIRED: 'KRONOS_LISTING_REQUIRED',
+  MARKET_DATA_REQUIRED: 'KRONOS_MARKET_DATA_REQUIRED',
+  INTERVAL_REQUIRED: 'KRONOS_INTERVAL_REQUIRED',
+  TOO_FEW_BARS: 'KRONOS_TOO_FEW_BARS',
+  TOO_MANY_BARS: 'KRONOS_TOO_MANY_BARS',
+  HORIZON_EXCEEDED: 'KRONOS_HORIZON_EXCEEDED',
+  MARKET_DATA_STALE: 'KRONOS_MARKET_DATA_STALE',
+} as const
+
+export type KronosErrorCode = (typeof KronosErrorCode)[keyof typeof KronosErrorCode]
+
+export class KronosError extends Error {
+  constructor(
+    public readonly code: KronosErrorCode,
+    message: string
+  ) {
+    super(message)
+    this.name = 'KronosError'
+  }
+}

--- a/apps/tradinggoose/lib/market/market-provider-settings.ts
+++ b/apps/tradinggoose/lib/market/market-provider-settings.ts
@@ -32,15 +32,17 @@ export const resolveMarketProviderSettingsDefinitions = (
 
 export const sanitizeMarketProviderAuth = (
   auth: unknown
-): { apiKey?: string; apiSecret?: string } | undefined => {
+): { apiKey?: string; apiSecret?: string; accessToken?: string } | undefined => {
   if (!isRecord(auth)) return undefined
 
-  const nextAuth: { apiKey?: string; apiSecret?: string } = {}
+  const nextAuth: { apiKey?: string; apiSecret?: string; accessToken?: string } = {}
   const apiKey = readCredentialString(auth.apiKey)
   const apiSecret = readCredentialString(auth.apiSecret)
+  const accessToken = readCredentialString(auth.accessToken)
 
   if (apiKey) nextAuth.apiKey = apiKey
   if (apiSecret) nextAuth.apiSecret = apiSecret
+  if (accessToken) nextAuth.accessToken = accessToken
 
   return Object.keys(nextAuth).length > 0 ? nextAuth : undefined
 }

--- a/apps/tradinggoose/lib/market/quote-snapshots.ts
+++ b/apps/tradinggoose/lib/market/quote-snapshots.ts
@@ -29,7 +29,7 @@ const buildDailyRequest = async ({
 }: {
   provider: string
   listing: ListingIdentity
-  auth?: { apiKey?: string; apiSecret?: string }
+  auth?: { apiKey?: string; apiSecret?: string; accessToken?: string }
   providerParams?: Record<string, unknown>
 }) => {
   const response = await executeProviderRequest(provider, {
@@ -55,7 +55,7 @@ const buildRegularLastRequest = async ({
 }: {
   provider: string
   listing: ListingIdentity
-  auth?: { apiKey?: string; apiSecret?: string }
+  auth?: { apiKey?: string; apiSecret?: string; accessToken?: string }
   providerParams?: Record<string, unknown>
 }) => {
   try {
@@ -86,7 +86,7 @@ export const buildMarketQuoteSnapshot = async ({
 }: {
   provider: string
   listing: ListingIdentity
-  auth?: { apiKey?: string; apiSecret?: string }
+  auth?: { apiKey?: string; apiSecret?: string; accessToken?: string }
   providerParams?: Record<string, unknown>
 }): Promise<MarketQuoteSnapshot> => {
   try {

--- a/apps/tradinggoose/lib/oauth/oauth.server.ts
+++ b/apps/tradinggoose/lib/oauth/oauth.server.ts
@@ -123,6 +123,11 @@ function getProviderAuthTemplate(
         tokenEndpoint: 'https://api.tradier.com/v1/oauth/refreshtoken',
         useBasicAuth: true,
       }
+    case 'ibkr':
+      return {
+        tokenEndpoint: 'https://api.ibkr.com/v1/api/oauth2/token',
+        useBasicAuth: true,
+      }
     case 'wealthbox':
       return {
         tokenEndpoint: 'https://app.crmworkspace.com/oauth/token',

--- a/apps/tradinggoose/lib/oauth/oauth.ts
+++ b/apps/tradinggoose/lib/oauth/oauth.ts
@@ -50,6 +50,7 @@ export type OAuthProvider =
   | 'wealthbox'
   | 'webflow'
   | 'tradier'
+  | 'ibkr'
   | string
 
 export type OAuthService =
@@ -83,6 +84,8 @@ export type OAuthService =
   | 'onedrive'
   | 'webflow'
   | 'tradier-live'
+  | 'ibkr-live'
+  | 'ibkr-paper'
   | string
 
 export interface OAuthCredentialFieldConfig {
@@ -118,6 +121,7 @@ const DEFAULT_OAUTH_CREDENTIAL_FIELDS: OAuthCredentialFieldConfig[] = [
 
 const ALPACA_OAUTH_SCOPES = ['trading', 'data']
 const TRADIER_OAUTH_SCOPES = ['read', 'write', 'trade']
+const IBKR_OAUTH_SCOPES = ['read', 'trade']
 
 export interface OAuthProviderConfig {
   id: OAuthProvider
@@ -608,6 +612,31 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
       },
     },
     defaultService: 'wealthbox',
+  },
+  ibkr: {
+    id: 'ibkr',
+    name: 'IBKR',
+    icon: (props) => DollarIcon(props),
+    services: {
+      'ibkr-live': {
+        id: 'ibkr-live',
+        name: 'IBKR Live',
+        description: 'Trade and manage an Interactive Brokers live account.',
+        providerId: 'ibkr-live',
+        icon: (props) => DollarIcon(props),
+        baseProviderIcon: (props) => DollarIcon(props),
+        scopes: IBKR_OAUTH_SCOPES,
+      },
+      'ibkr-paper': {
+        id: 'ibkr-paper',
+        name: 'IBKR Paper',
+        description: 'Trade and manage an Interactive Brokers paper account.',
+        providerId: 'ibkr-paper',
+        icon: (props) => DollarIcon(props),
+        baseProviderIcon: (props) => DollarIcon(props),
+        scopes: IBKR_OAUTH_SCOPES,
+      },
+    },
   },
   tradier: {
     id: 'tradier',

--- a/apps/tradinggoose/lib/security/csp.ts
+++ b/apps/tradinggoose/lib/security/csp.ts
@@ -112,7 +112,7 @@ export const buildTimeCSPDirectives: CSPDirectives = {
 
   'media-src': ["'self'", 'blob:'],
 
-  'font-src': ["'self'", 'https://fonts.gstatic.com'],
+  'font-src': ["'self'", 'data:', 'https://fonts.gstatic.com'],
 
   'connect-src': [
     "'self'",
@@ -202,7 +202,7 @@ export async function generateRuntimeCSP(): Promise<string> {
       ...(getEnv('NODE_ENV') === 'development' ? getOriginFromUrl('http://localhost:3001') : []),
     ],
     'media-src': ["'self'", 'blob:'],
-    'font-src': ["'self'", 'https://fonts.gstatic.com'],
+    'font-src': ["'self'", 'data:', 'https://fonts.gstatic.com'],
     'connect-src': [
       "'self'",
       ...getOriginFromUrl(getEnv('NEXT_PUBLIC_APP_URL')),

--- a/apps/tradinggoose/lib/system-services/catalog.ts
+++ b/apps/tradinggoose/lib/system-services/catalog.ts
@@ -290,13 +290,13 @@ export const SYSTEM_SERVICE_DEFINITIONS: SystemServiceDefinition[] = [
   },
   {
     id: 'vllm',
-    displayName: 'vLLM',
-    description: 'Base URL and optional bearer token for the OpenAI-compatible vLLM service.',
+    displayName: 'Self-hosted / custom OpenAI-compatible endpoint',
+    description: 'Point the app at any OpenAI-compatible host: vLLM, llama.cpp, LM Studio, or a local gateway. Models are discovered from /v1/models and offered in the Copilot model picker as vllm/<model>.',
     credentialFields: [
       {
         key: 'apiKey',
         label: 'API Key',
-        description: 'Optional bearer token for the vLLM endpoint.',
+        description: 'Optional bearer token for the endpoint, if it requires one.',
         required: false,
       },
     ],
@@ -304,7 +304,7 @@ export const SYSTEM_SERVICE_DEFINITIONS: SystemServiceDefinition[] = [
       {
         key: 'baseUrl',
         label: 'Base URL',
-        description: 'Base URL for the OpenAI-compatible vLLM host.',
+        description: 'Base URL of the OpenAI-compatible host, e.g. http://host:8080. Do not include a trailing /v1; the app appends it.',
         type: 'url',
         required: false,
       },

--- a/apps/tradinggoose/providers/market/errors.test.ts
+++ b/apps/tradinggoose/providers/market/errors.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @vitest-environment node
+ */
+
+import { describe, expect, it } from 'vitest'
+import { MarketProviderError, normalizeMarketProviderError } from '@/providers/market/errors'
+
+const brokerError = (status: number) =>
+  Object.assign(new Error(`Broker request failed with status ${status}`), {
+    name: 'TradingBrokerRequestError',
+    status,
+    providerId: 'ibkr',
+    url: 'http://host.containers.internal:5002/v1/api/iserver/accounts',
+    payload: { error: `broker rejected the request with ${status}` },
+  })
+
+describe('normalizeMarketProviderError', () => {
+  it('preserves the broker status, url and payload', () => {
+    const normalized = normalizeMarketProviderError(brokerError(400), 'ibkr')
+
+    expect(normalized).toBeInstanceOf(MarketProviderError)
+    expect(normalized.code).toBe('PROVIDER ERROR')
+    expect(normalized.status).toBe(400)
+    expect(normalized.provider).toBe('ibkr')
+    expect(normalized.details).toMatchObject({
+      brokerStatus: 400,
+      url: 'http://host.containers.internal:5002/v1/api/iserver/accounts',
+      payload: { error: 'broker rejected the request with 400' },
+    })
+  })
+
+  it('turns an unauthenticated IBKR gateway into an instruction', () => {
+    const normalized = normalizeMarketProviderError(brokerError(401), 'ibkr')
+
+    expect(normalized.status).toBe(401)
+    expect(normalized.message).toContain('Broker request failed with status 401')
+    expect(normalized.message).toContain('log in at the gateway URL')
+  })
+
+  it('does not attach the session hint to a non-auth failure', () => {
+    const normalized = normalizeMarketProviderError(brokerError(400), 'ibkr')
+
+    expect(normalized.message).not.toContain('log in at the gateway URL')
+  })
+
+  it('uses a credential hint for a non-IBKR provider', () => {
+    const error = Object.assign(new Error('Broker request failed with status 401'), {
+      status: 401,
+      providerId: 'alpaca',
+      url: 'https://api.alpaca.markets/v2/account',
+    })
+
+    const normalized = normalizeMarketProviderError(error, 'alpaca')
+
+    expect(normalized.message).toContain('rejected the credentials or session')
+    expect(normalized.message).not.toContain('Client Portal Gateway')
+  })
+
+  it('still maps a plain error without a status', () => {
+    const normalized = normalizeMarketProviderError(new Error('boom'), 'ibkr')
+
+    expect(normalized.status).toBeUndefined()
+    expect(normalized.message).toBe('boom')
+  })
+
+  it('does not treat an object without a providerId as a broker error', () => {
+    const normalized = normalizeMarketProviderError({ status: 401, message: 'x' }, 'ibkr')
+
+    expect(normalized.status).toBeUndefined()
+    expect(normalized.message).toBe('Market provider error')
+  })
+})

--- a/apps/tradinggoose/providers/market/errors.ts
+++ b/apps/tradinggoose/providers/market/errors.ts
@@ -37,6 +37,45 @@ export const isMarketProviderError = (error: unknown): error is MarketProviderEr
     'message' in error &&
     (error as { code?: unknown }).code !== undefined)
 
+/**
+ * Shape of `TradingBrokerRequestError`, which the shared request helper throws
+ * with the broker's HTTP status, URL and response payload attached.
+ *
+ * Detected structurally rather than by import: the market layer must not depend
+ * on the trading layer, which is the cycle this provider already had to unwind.
+ */
+interface BrokerRequestErrorLike {
+  message?: unknown
+  status?: unknown
+  providerId?: unknown
+  url?: unknown
+  payload?: unknown
+}
+
+const asBrokerRequestError = (error: unknown): BrokerRequestErrorLike | null => {
+  if (typeof error !== 'object' || error === null) return null
+  const candidate = error as BrokerRequestErrorLike
+  if (typeof candidate.status !== 'number') return null
+  if (typeof candidate.providerId !== 'string') return null
+  return candidate
+}
+
+/**
+ * A rejected credential or session needs an instruction, not a status code: the
+ * IBKR Client Portal Gateway has no way to re-authenticate itself, so the only
+ * remedy is a browser login at the gateway URL.
+ */
+const brokerFailureHint = (provider: string | undefined, status: number): string | undefined => {
+  if (status !== 401 && status !== 403) return undefined
+  if (provider === 'ibkr') {
+    return (
+      'The IBKR Client Portal Gateway session is not authenticated - log in at the ' +
+      'gateway URL (default https://localhost:5001) and retry'
+    )
+  }
+  return 'The broker rejected the credentials or session for this connection'
+}
+
 export const normalizeMarketProviderError = (
   error: unknown,
   provider?: string
@@ -49,6 +88,32 @@ export const normalizeMarketProviderError = (
       provider: typed.provider ?? provider,
       status: typed.status,
       details: typed.details,
+    })
+  }
+
+  const brokerError = asBrokerRequestError(error)
+  if (brokerError) {
+    const status = brokerError.status as number
+    const providerId =
+      typeof brokerError.providerId === 'string' ? brokerError.providerId : provider
+    const baseMessage =
+      (typeof brokerError.message === 'string' && brokerError.message.trim()) ||
+      `Broker request failed with status ${status}`
+    const hint = brokerFailureHint(providerId ?? provider, status)
+
+    // Carry the broker's own status, URL and body through to the caller: the
+    // generic message alone is what made a session lapse look like a provider
+    // bug for an entire debugging session.
+    return new MarketProviderError({
+      code: 'PROVIDER ERROR',
+      message: hint ? `${baseMessage}. ${hint}` : baseMessage,
+      provider: providerId ?? provider,
+      status,
+      details: {
+        brokerStatus: status,
+        url: typeof brokerError.url === 'string' ? brokerError.url : undefined,
+        payload: brokerError.payload,
+      },
     })
   }
 

--- a/apps/tradinggoose/providers/market/ibkr/config.ts
+++ b/apps/tradinggoose/providers/market/ibkr/config.ts
@@ -90,7 +90,8 @@ export const ibkrMarketProviderConfig: MarketProviderConfig = {
     live: {
       channels: ['quote-snapshots'],
       supportsInterval: false,
-      pollingIntervalMs: 5_000,
+      // IBKR enforces hard pacing limits; 5s per widget invites a block.
+      pollingIntervalMs: 15_000,
     },
   },
   rulePrecedence: {

--- a/apps/tradinggoose/providers/market/ibkr/config.ts
+++ b/apps/tradinggoose/providers/market/ibkr/config.ts
@@ -1,5 +1,4 @@
-import { ibkrTradingSymbolRules } from '@/providers/trading/ibkr/rules'
-import type { MarketProviderConfig } from '@/providers/market/providers'
+import type { MarketProviderConfig, MarketSymbolRule } from '@/providers/market/providers'
 import type { AssetClass } from '@/providers/market/types'
 
 const availableAssetClasses: AssetClass[] = [
@@ -26,6 +25,38 @@ const exchangeCodesList: MarketProviderConfig['exchangeCodes'] = []
 
 const exchangeCodeToMarketMap: MarketProviderConfig['exchangeCodeToMarket'] = {}
 const marketToExchangeCodeMap: MarketProviderConfig['marketToExchangeCode'] = {}
+
+const ibkrMarketSymbolRules: MarketSymbolRule[] = [
+  {
+    currency: 'USD',
+    template: '{base}',
+    active: true,
+  },
+  {
+    currency: 'EUR',
+    template: '{base}',
+    active: true,
+  },
+  {
+    currency: 'GBP',
+    template: '{base}',
+    active: true,
+  },
+  {
+    currency: 'JPY',
+    template: '{base}',
+    active: true,
+  },
+  {
+    assetClass: 'currency',
+    template: '{base}{quote}',
+    active: true,
+  },
+  {
+    template: '{base}',
+    active: true,
+  },
+]
 
 export const ibkrMarketProviderConfig: MarketProviderConfig = {
   id: 'ibkr',
@@ -75,5 +106,5 @@ export const ibkrMarketProviderConfig: MarketProviderConfig = {
   exchangeCodeToMarket: exchangeCodeToMarketMap,
   marketToExchangeCode: marketToExchangeCodeMap,
   exchangeCodes: exchangeCodesList,
-  rules: ibkrTradingSymbolRules,
+  rules: ibkrMarketSymbolRules,
 }

--- a/apps/tradinggoose/providers/market/ibkr/config.ts
+++ b/apps/tradinggoose/providers/market/ibkr/config.ts
@@ -1,0 +1,79 @@
+import { ibkrTradingSymbolRules } from '@/providers/trading/ibkr/rules'
+import type { MarketProviderConfig } from '@/providers/market/providers'
+import type { AssetClass } from '@/providers/market/types'
+
+const availableAssetClasses: AssetClass[] = [
+  'stock',
+  'etf',
+  'future',
+  'currency',
+  'indice',
+  'mutualfund',
+]
+
+const availability: MarketProviderConfig['availability'] = {
+  assetClass: availableAssetClasses,
+  availableListingQuote: [],
+  availableCurrencyBase: [],
+  availableCurrencyQuote: [],
+  availableCryptoBase: [],
+  availableCryptoQuote: [],
+  series: true,
+  live: true,
+}
+
+const exchangeCodesList: MarketProviderConfig['exchangeCodes'] = []
+
+const exchangeCodeToMarketMap: MarketProviderConfig['exchangeCodeToMarket'] = {}
+const marketToExchangeCodeMap: MarketProviderConfig['marketToExchangeCode'] = {}
+
+export const ibkrMarketProviderConfig: MarketProviderConfig = {
+  id: 'ibkr',
+  name: 'IBKR',
+  utcOffset: 0,
+  availability,
+  params: {
+    shared: [],
+    series: [],
+  },
+  api_endpoints: {
+    default: '/iserver/marketdata',
+  },
+  capabilities: {
+    series: {
+      supportsInterval: true,
+      intervals: ['1m', '5m', '15m', '30m', '1h', '1d', '1w', '1mo'],
+      windowModes: ['range', 'bars', 'absolute'],
+      normalizationModes: ['raw'],
+      marketSessions: ['regular'],
+      retention: {
+        byInterval: {
+          '1m': { maxRangeDays: 30 },
+          '5m': { maxRangeDays: 30 },
+          '15m': { maxRangeDays: 30 },
+          '30m': { maxRangeDays: 30 },
+          '1h': { maxRangeDays: 30 },
+        },
+      },
+    },
+    live: {
+      channels: ['quote-snapshots'],
+      supportsInterval: false,
+      pollingIntervalMs: 5_000,
+    },
+  },
+  rulePrecedence: {
+    default: ['market', 'currency', 'assetClass', 'country', 'city', 'listing'],
+    stock: ['market', 'currency', 'country', 'city', 'listing'],
+    etf: ['market', 'currency', 'country', 'city', 'listing'],
+    indice: ['market', 'currency', 'country', 'city', 'listing'],
+    mutualfund: ['market', 'currency', 'country', 'city', 'listing'],
+    future: ['market', 'currency', 'country', 'city', 'listing'],
+    crypto: ['currency', 'market', 'country', 'city', 'listing'],
+    currency: ['currency', 'market', 'country', 'city', 'listing'],
+  },
+  exchangeCodeToMarket: exchangeCodeToMarketMap,
+  marketToExchangeCode: marketToExchangeCodeMap,
+  exchangeCodes: exchangeCodesList,
+  rules: ibkrTradingSymbolRules,
+}

--- a/apps/tradinggoose/providers/market/ibkr/index.ts
+++ b/apps/tradinggoose/providers/market/ibkr/index.ts
@@ -1,0 +1,22 @@
+import { ibkrMarketProviderConfig } from '@/providers/market/ibkr/config'
+import { fetchIbkrLiveSnapshot } from '@/providers/market/ibkr/live'
+import { fetchIbkrSeries } from '@/providers/market/ibkr/series'
+import type { MarketProvider } from '@/providers/market/providers'
+import type {
+  MarketLiveRequest,
+  MarketLiveSnapshot,
+  MarketSeries,
+  MarketSeriesRequest,
+} from '@/providers/market/types'
+
+export const ibkrMarketProvider: MarketProvider = {
+  id: 'ibkr',
+  name: 'IBKR',
+  config: ibkrMarketProviderConfig,
+  fetchMarketSeries: async (request: MarketSeriesRequest): Promise<MarketSeries> => {
+    return fetchIbkrSeries(request)
+  },
+  fetchMarketLive: async (request: MarketLiveRequest): Promise<MarketLiveSnapshot> => {
+    return fetchIbkrLiveSnapshot(request)
+  },
+}

--- a/apps/tradinggoose/providers/market/ibkr/live.ts
+++ b/apps/tradinggoose/providers/market/ibkr/live.ts
@@ -1,0 +1,48 @@
+import { createLogger } from '@/lib/logs/console/logger'
+import { ibkrMarketProviderConfig } from '@/providers/market/ibkr/config'
+import type {
+  MarketLiveRequest,
+  MarketLiveSnapshot,
+  MarketSeriesRequest,
+} from '@/providers/market/types'
+import { resolveListingContext, resolveProviderSymbol } from '@/providers/market/utils'
+import { fetchIbkrSeries } from '@/providers/market/ibkr/series'
+
+const logger = createLogger('MarketProvider:IBKR:Live')
+
+export async function fetchIbkrLiveSnapshot(
+  request: MarketLiveRequest
+): Promise<MarketLiveSnapshot> {
+  const seriesRequest: MarketSeriesRequest = {
+    kind: 'series',
+    listing: request.listing,
+    interval: request.interval,
+    start: Date.now() - 24 * 60 * 60 * 1000,
+    end: Date.now(),
+    auth: request.auth,
+    providerParams: request.providerParams,
+  }
+
+  logger.info('Fetching IBKR live snapshot', {
+    listing: request.listing,
+    interval: seriesRequest.interval,
+  })
+
+  const series = await fetchIbkrSeries(seriesRequest)
+  const bar = series.bars[series.bars.length - 1]
+
+  if (!bar) {
+    throw new Error('No live bar data returned')
+  }
+
+  return {
+    listing: series.listing,
+    listingBase: series.listingBase,
+    listingQuote: series.listingQuote,
+    marketCode: series.marketCode,
+    interval: seriesRequest.interval,
+    timezone: series.timezone,
+    stream: request.stream,
+    bar,
+  }
+}

--- a/apps/tradinggoose/providers/market/ibkr/live.ts
+++ b/apps/tradinggoose/providers/market/ibkr/live.ts
@@ -1,47 +1,102 @@
 import { createLogger } from '@/lib/logs/console/logger'
 import { ibkrMarketProviderConfig } from '@/providers/market/ibkr/config'
-import type {
-  MarketLiveRequest,
-  MarketLiveSnapshot,
-  MarketSeriesRequest,
-} from '@/providers/market/types'
+import type { MarketBar, MarketLiveRequest, MarketLiveSnapshot } from '@/providers/market/types'
 import { resolveListingContext, resolveProviderSymbol } from '@/providers/market/utils'
-import { fetchIbkrSeries } from '@/providers/market/ibkr/series'
+import { buildIbkrAuthHeaders } from '@/providers/trading/ibkr/auth'
+import { buildIbkrApiUrl } from '@/providers/trading/ibkr/client'
+import { ensureIbkrSession } from '@/providers/trading/ibkr/session'
+import { resolveIbkrConidFromApi } from '@/providers/trading/ibkr/symbols'
+import { fetchBrokerJson } from '@/providers/trading/portfolio-utils'
 
 const logger = createLogger('MarketProvider:IBKR:Live')
+
+/**
+ * Snapshot field ids. IBKR returns these as string-keyed numbers.
+ *   31 last, 70 high, 71 low, 84 bid, 86 ask, 87 volume
+ */
+const FIELDS = ['31', '70', '71', '84', '86', '87']
+
+interface IbkrSnapshotRow {
+  conid?: number
+  _updated?: number
+  '31'?: string | number
+  '70'?: string | number
+  '71'?: string | number
+  '84'?: string | number
+  '86'?: string | number
+  '87'?: string | number
+}
+
+const toNumber = (value?: string | number): number | undefined => {
+  if (value === undefined || value === null) return undefined
+  // IBKR prefixes some values with markers such as 'C' (close) or 'H' (halted).
+  const cleaned = typeof value === 'string' ? value.replace(/[^0-9.\-]/g, '') : value
+  const parsed = typeof cleaned === 'number' ? cleaned : Number.parseFloat(cleaned)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
 
 export async function fetchIbkrLiveSnapshot(
   request: MarketLiveRequest
 ): Promise<MarketLiveSnapshot> {
-  const seriesRequest: MarketSeriesRequest = {
-    kind: 'series',
-    listing: request.listing,
-    interval: request.interval,
-    start: Date.now() - 24 * 60 * 60 * 1000,
-    end: Date.now(),
-    auth: request.auth,
-    providerParams: request.providerParams,
-  }
+  const context = await resolveListingContext(request.listing)
+  const symbol = resolveProviderSymbol(ibkrMarketProviderConfig, context)
+  const accessToken = request.auth?.accessToken
 
-  logger.info('Fetching IBKR live snapshot', {
-    listing: request.listing,
-    interval: seriesRequest.interval,
+  await ensureIbkrSession({ accessToken })
+
+  const { conid } = await resolveIbkrConidFromApi({
+    symbol,
+    assetClass: context.assetClass,
+    accessToken,
   })
 
-  const series = await fetchIbkrSeries(seriesRequest)
-  const bar = series.bars[series.bars.length - 1]
+  const url = `${buildIbkrApiUrl('/iserver/marketdata/snapshot')}?${new URLSearchParams({
+    conids: String(conid),
+    fields: FIELDS.join(','),
+  }).toString()}`
 
-  if (!bar) {
-    throw new Error('No live bar data returned')
+  const headers = buildIbkrAuthHeaders({ accessToken })
+
+  // IBKR primes the subscription on first call and frequently returns a row
+  // without price fields; the immediate follow-up carries the data. One retry
+  // is enough and avoids reporting a spurious "no data" to the widget.
+  let rows = await fetchBrokerJson<IbkrSnapshotRow[]>({
+    providerId: 'ibkr',
+    url,
+    init: { method: 'GET', headers },
+  })
+  if (!rows?.[0] || toNumber(rows[0]['31']) === undefined) {
+    rows = await fetchBrokerJson<IbkrSnapshotRow[]>({
+      providerId: 'ibkr',
+      url,
+      init: { method: 'GET', headers },
+    })
   }
 
+  const row = rows?.[0]
+  const last = toNumber(row?.['31'])
+  if (!row || last === undefined) {
+    throw new Error(`IBKR returned no live quote for ${symbol} (conid ${conid})`)
+  }
+
+  const bar: MarketBar = {
+    timeStamp: new Date(row._updated ?? Date.now()).toISOString(),
+    open: undefined,
+    high: toNumber(row['70']),
+    low: toNumber(row['71']),
+    close: last,
+    volume: toNumber(row['87']),
+  }
+
+  logger.info('IBKR live snapshot', { symbol, conid, last })
+
   return {
-    listing: series.listing,
-    listingBase: series.listingBase,
-    listingQuote: series.listingQuote,
-    marketCode: series.marketCode,
-    interval: seriesRequest.interval,
-    timezone: series.timezone,
+    listing: context.listing,
+    listingBase: context.base,
+    listingQuote: context.quote,
+    marketCode: context.marketCode,
+    interval: request.interval,
+    timezone: context.timeZoneName,
     stream: request.stream,
     bar,
   }

--- a/apps/tradinggoose/providers/market/ibkr/series.ts
+++ b/apps/tradinggoose/providers/market/ibkr/series.ts
@@ -1,62 +1,85 @@
 import { createLogger } from '@/lib/logs/console/logger'
 import { ibkrMarketProviderConfig } from '@/providers/market/ibkr/config'
-import type {
-  MarketBar,
-  MarketSeries,
-  MarketSeriesRequest,
-} from '@/providers/market/types'
+import type { MarketBar, MarketSeries, MarketSeriesRequest } from '@/providers/market/types'
 import { resolveListingContext, resolveProviderSymbol } from '@/providers/market/utils'
 import { buildIbkrAuthHeaders } from '@/providers/trading/ibkr/auth'
 import { buildIbkrApiUrl } from '@/providers/trading/ibkr/client'
+import { ensureIbkrSession } from '@/providers/trading/ibkr/session'
+import { resolveIbkrConidFromApi } from '@/providers/trading/ibkr/symbols'
 import { fetchBrokerJson } from '@/providers/trading/portfolio-utils'
 
 const logger = createLogger('MarketProvider:IBKR')
 
-const IBKR_RESOLUTION_MAP: Partial<Record<string, string>> = {
+/**
+ * IBKR bar sizes, not generic resolution strings. Valid values are
+ * 1min..30min, 1h..8h, 1d, 1w, 1m -- note `1m` means one MONTH here, while one
+ * minute is `1min`.
+ */
+const IBKR_BAR_MAP: Record<string, string> = {
   '1m': '1min',
   '5m': '5min',
   '15m': '15min',
   '30m': '30min',
-  '1h': '1hour',
-  '1d': '1day',
-  '1w': '1week',
-  '1mo': '1month',
+  '1h': '1h',
+  '1d': '1d',
+  '1w': '1w',
+  '1mo': '1m',
 }
 
-function resolveResolution(interval?: string): string {
-  if (!interval) return '1day'
-  return IBKR_RESOLUTION_MAP[interval] || '1day'
+/** Largest lookback IBKR will serve for a given bar size, in days. */
+const MAX_PERIOD_DAYS: Record<string, number> = {
+  '1min': 1,
+  '5min': 7,
+  '15min': 14,
+  '30min': 30,
+  '1h': 30,
+  '1d': 365,
+  '1w': 365 * 5,
+  '1m': 365 * 20,
 }
 
-function toUnixSeconds(value?: string | number): number | undefined {
+const resolveBar = (interval?: string): string => (interval && IBKR_BAR_MAP[interval]) || '1d'
+
+const toMillis = (value?: string | number): number | undefined => {
   if (value === undefined || value === null) return undefined
   if (typeof value === 'number' && Number.isFinite(value)) {
-    return value > 1e12 ? Math.floor(value / 1000) : Math.floor(value)
+    return value > 1e12 ? value : value * 1000
   }
-  if (typeof value === 'string') {
-    const parsed = Date.parse(value)
-    if (Number.isFinite(parsed)) {
-      return Math.floor(parsed / 1000)
-    }
-  }
-  return undefined
+  const parsed = Date.parse(String(value))
+  return Number.isFinite(parsed) ? parsed : undefined
 }
 
-function toIsoString(value?: string | number): string | undefined {
-  if (value === undefined || value === null) return undefined
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    const date = new Date(value > 1e12 ? value : value * 1000)
-    return Number.isNaN(date.getTime()) ? undefined : date.toISOString()
-  }
-  if (typeof value === 'string') {
-    const date = new Date(value)
-    return Number.isNaN(date.getTime()) ? undefined : date.toISOString()
-  }
-  return undefined
+const toIsoString = (millis?: number): string | undefined => {
+  if (millis === undefined) return undefined
+  const date = new Date(millis)
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString()
+}
+
+/**
+ * IBKR takes a duration string, not a from/to window. We convert the requested
+ * range into the smallest period that covers it, clamped to what the chosen bar
+ * size actually supports so the request is not rejected outright.
+ */
+const buildPeriod = (startMs: number, endMs: number, bar: string): string => {
+  const days = Math.max(1, Math.ceil((endMs - startMs) / 86_400_000))
+  const capped = Math.min(days, MAX_PERIOD_DAYS[bar] ?? 365)
+  if (capped <= 30) return `${capped}d`
+  if (capped <= 365) return `${Math.ceil(capped / 30)}m`
+  return `${Math.ceil(capped / 365)}y`
+}
+
+/** IBKR wants startTime as YYYYMMDD-HH:mm:ss, in UTC. */
+const toIbkrStartTime = (millis: number): string => {
+  const d = new Date(millis)
+  const p = (n: number, w = 2) => String(n).padStart(w, '0')
+  return (
+    `${d.getUTCFullYear()}${p(d.getUTCMonth() + 1)}${p(d.getUTCDate())}` +
+    `-${p(d.getUTCHours())}:${p(d.getUTCMinutes())}:${p(d.getUTCSeconds())}`
+  )
 }
 
 interface IbkrHistoryBar {
-  t?: number | string
+  t?: number
   o?: number
   h?: number
   l?: number
@@ -64,63 +87,96 @@ interface IbkrHistoryBar {
   v?: number
 }
 
+/** The endpoint returns an envelope; bars live under `data`. */
+interface IbkrHistoryResponse {
+  data?: IbkrHistoryBar[]
+  priceFactor?: number
+  barLength?: number
+  symbol?: string
+  text?: string
+  error?: string
+}
+
 export async function fetchIbkrSeries(request: MarketSeriesRequest): Promise<MarketSeries> {
   const context = await resolveListingContext(request.listing)
   const symbol = resolveProviderSymbol(ibkrMarketProviderConfig, context)
-  const resolution = resolveResolution(request.interval)
-  const to = toUnixSeconds(request.end) || Math.floor(Date.now() / 1000)
-  const from = toUnixSeconds(request.start) || to - 30 * 24 * 60 * 60
+  const bar = resolveBar(request.interval)
+
+  const endMs = toMillis(request.end) ?? Date.now()
+  const startMs = toMillis(request.start) ?? endMs - 30 * 86_400_000
+  const period = buildPeriod(startMs, endMs, bar)
 
   const accessToken = request.auth?.accessToken
-  if (!accessToken) {
-    throw new Error('IBKR access token is required for market data')
-  }
+  await ensureIbkrSession({ accessToken })
+
+  // The history endpoint is conid-keyed; a symbol alone resolves to nothing.
+  const { conid } = await resolveIbkrConidFromApi({
+    symbol,
+    assetClass: context.assetClass,
+    accessToken,
+  })
 
   const params = new URLSearchParams({
-    symbol,
-    conid: '0',
-    resolution,
-    from: String(from),
-    to: String(to),
+    conid: String(conid),
+    period,
+    bar,
+    outsideRth: 'false',
   })
+  // Only pin startTime when the caller asked for a window ending in the past;
+  // otherwise let IBKR anchor the period to now.
+  if (endMs < Date.now() - 60_000) {
+    params.set('startTime', toIbkrStartTime(endMs))
+  }
 
   const url = `${buildIbkrApiUrl('/iserver/marketdata/history')}?${params.toString()}`
 
-  logger.info('Fetching IBKR market series', {
-    symbol,
-    resolution,
-    from,
-    to,
-  })
+  logger.info('Fetching IBKR market series', { symbol, conid, bar, period })
 
-  const response = await fetchBrokerJson<IbkrHistoryBar[]>({
+  const response = await fetchBrokerJson<IbkrHistoryResponse>({
     providerId: 'ibkr',
     url,
-    init: {
-      method: 'GET',
-      headers: buildIbkrAuthHeaders({ accessToken }),
-    },
+    init: { method: 'GET', headers: buildIbkrAuthHeaders({ accessToken }) },
   })
 
-  const bars: MarketBar[] = (response || [])
-    .filter((bar): bar is IbkrHistoryBar => typeof bar === 'object')
-    .map((bar) => ({
-      timeStamp: toIsoString(bar.t) || new Date().toISOString(),
-      open: bar.o,
-      high: bar.h,
-      low: bar.l,
-      close: bar.c ?? 0,
-      volume: bar.v,
+  if (response?.error) {
+    throw new Error(`IBKR market data error for ${symbol}: ${response.error}`)
+  }
+
+  // IBKR scales prices for some contracts; dividing is required for
+  // correctness and its absence is silent rather than an error.
+  const priceFactor =
+    typeof response?.priceFactor === 'number' && response.priceFactor > 0
+      ? response.priceFactor
+      : 1
+  const scale = (value?: number): number | undefined =>
+    typeof value === 'number' && Number.isFinite(value) ? value / priceFactor : undefined
+
+  const bars: MarketBar[] = (response?.data ?? [])
+    .filter((entry): entry is IbkrHistoryBar => Boolean(entry) && typeof entry === 'object')
+    // Drop bars with no usable close rather than defaulting them to 0, which
+    // would silently poison every downstream indicator.
+    .filter((entry) => typeof entry.c === 'number' && Number.isFinite(entry.c))
+    .map((entry) => ({
+      timeStamp: toIsoString(toMillis(entry.t)) ?? new Date().toISOString(),
+      open: scale(entry.o),
+      high: scale(entry.h),
+      low: scale(entry.l),
+      close: scale(entry.c) as number,
+      volume: typeof entry.v === 'number' ? entry.v : undefined,
     }))
-    .filter((bar) => bar.close !== undefined)
+    .sort((a, b) => Date.parse(a.timeStamp) - Date.parse(b.timeStamp))
+
+  if (bars.length === 0) {
+    logger.warn('IBKR returned no bars', { symbol, conid, bar, period, text: response?.text })
+  }
 
   return {
     listing: context.listing,
     listingBase: context.base,
     listingQuote: context.quote,
     marketCode: context.marketCode,
-    start: toIsoString(from * 1000),
-    end: toIsoString(to * 1000),
+    start: toIsoString(startMs),
+    end: toIsoString(endMs),
     timezone: context.timeZoneName,
     normalizationMode: 'raw',
     bars,

--- a/apps/tradinggoose/providers/market/ibkr/series.ts
+++ b/apps/tradinggoose/providers/market/ibkr/series.ts
@@ -1,0 +1,128 @@
+import { createLogger } from '@/lib/logs/console/logger'
+import { ibkrMarketProviderConfig } from '@/providers/market/ibkr/config'
+import type {
+  MarketBar,
+  MarketSeries,
+  MarketSeriesRequest,
+} from '@/providers/market/types'
+import { resolveListingContext, resolveProviderSymbol } from '@/providers/market/utils'
+import { buildIbkrAuthHeaders } from '@/providers/trading/ibkr/auth'
+import { buildIbkrApiUrl } from '@/providers/trading/ibkr/client'
+import { fetchBrokerJson } from '@/providers/trading/portfolio-utils'
+
+const logger = createLogger('MarketProvider:IBKR')
+
+const IBKR_RESOLUTION_MAP: Partial<Record<string, string>> = {
+  '1m': '1min',
+  '5m': '5min',
+  '15m': '15min',
+  '30m': '30min',
+  '1h': '1hour',
+  '1d': '1day',
+  '1w': '1week',
+  '1mo': '1month',
+}
+
+function resolveResolution(interval?: string): string {
+  if (!interval) return '1day'
+  return IBKR_RESOLUTION_MAP[interval] || '1day'
+}
+
+function toUnixSeconds(value?: string | number): number | undefined {
+  if (value === undefined || value === null) return undefined
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value > 1e12 ? Math.floor(value / 1000) : Math.floor(value)
+  }
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value)
+    if (Number.isFinite(parsed)) {
+      return Math.floor(parsed / 1000)
+    }
+  }
+  return undefined
+}
+
+function toIsoString(value?: string | number): string | undefined {
+  if (value === undefined || value === null) return undefined
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const date = new Date(value > 1e12 ? value : value * 1000)
+    return Number.isNaN(date.getTime()) ? undefined : date.toISOString()
+  }
+  if (typeof value === 'string') {
+    const date = new Date(value)
+    return Number.isNaN(date.getTime()) ? undefined : date.toISOString()
+  }
+  return undefined
+}
+
+interface IbkrHistoryBar {
+  t?: number | string
+  o?: number
+  h?: number
+  l?: number
+  c?: number
+  v?: number
+}
+
+export async function fetchIbkrSeries(request: MarketSeriesRequest): Promise<MarketSeries> {
+  const context = await resolveListingContext(request.listing)
+  const symbol = resolveProviderSymbol(ibkrMarketProviderConfig, context)
+  const resolution = resolveResolution(request.interval)
+  const to = toUnixSeconds(request.end) || Math.floor(Date.now() / 1000)
+  const from = toUnixSeconds(request.start) || to - 30 * 24 * 60 * 60
+
+  const accessToken = request.auth?.accessToken
+  if (!accessToken) {
+    throw new Error('IBKR access token is required for market data')
+  }
+
+  const params = new URLSearchParams({
+    symbol,
+    conid: '0',
+    resolution,
+    from: String(from),
+    to: String(to),
+  })
+
+  const url = `${buildIbkrApiUrl('/iserver/marketdata/history')}?${params.toString()}`
+
+  logger.info('Fetching IBKR market series', {
+    symbol,
+    resolution,
+    from,
+    to,
+  })
+
+  const response = await fetchBrokerJson<IbkrHistoryBar[]>({
+    providerId: 'ibkr',
+    url,
+    init: {
+      method: 'GET',
+      headers: buildIbkrAuthHeaders({ accessToken }),
+    },
+  })
+
+  const bars: MarketBar[] = (response || [])
+    .filter((bar): bar is IbkrHistoryBar => typeof bar === 'object')
+    .map((bar) => ({
+      timeStamp: toIsoString(bar.t) || new Date().toISOString(),
+      open: bar.o,
+      high: bar.h,
+      low: bar.l,
+      close: bar.c ?? 0,
+      volume: bar.v,
+    }))
+    .filter((bar) => bar.close !== undefined)
+
+  return {
+    listing: context.listing,
+    listingBase: context.base,
+    listingQuote: context.quote,
+    marketCode: context.marketCode,
+    start: toIsoString(from * 1000),
+    end: toIsoString(to * 1000),
+    timezone: context.timeZoneName,
+    normalizationMode: 'raw',
+    bars,
+  }
+}

--- a/apps/tradinggoose/providers/market/index.ts
+++ b/apps/tradinggoose/providers/market/index.ts
@@ -3,6 +3,7 @@ import { alpacaProvider } from '@/providers/market/alpaca'
 import { alphaVantageProvider } from '@/providers/market/alpha-vantage'
 import { MarketProviderError } from '@/providers/market/errors'
 import { finnhubProvider } from '@/providers/market/finnhub'
+import { ibkrMarketProvider } from '@/providers/market/ibkr'
 import {
   clampToMarketSession,
   filterSeriesBySessions,
@@ -27,6 +28,7 @@ const providers = {
   'alpha-vantage': alphaVantageProvider,
   alpaca: alpacaProvider,
   finnhub: finnhubProvider,
+  ibkr: ibkrMarketProvider,
   'yahoo-finance': YahooFinanceProvider,
 }
 

--- a/apps/tradinggoose/providers/market/providers.ts
+++ b/apps/tradinggoose/providers/market/providers.ts
@@ -214,6 +214,12 @@ export const MARKET_PROVIDER_DEFINITIONS: Record<string, MarketProviderDefinitio
     config: finnhubProviderConfig,
     icon: FinnhubIcon,
   },
+  ibkr: {
+    id: 'ibkr',
+    name: 'IBKR',
+    description: 'IBKR market data (live quotes & historical bars).',
+    config: ibkrMarketProviderConfig,
+  },
 }
 
 export function getMarketProviderDefinition(providerId: string): MarketProviderDefinition | null {

--- a/apps/tradinggoose/providers/market/providers.ts
+++ b/apps/tradinggoose/providers/market/providers.ts
@@ -18,6 +18,7 @@ import type { WorkflowProviderParamType } from '@/lib/workflows/value-types'
 import { alpacaProviderConfig } from '@/providers/market/alpaca/config'
 import { alphaVantageProviderConfig } from '@/providers/market/alpha-vantage/config'
 import { finnhubProviderConfig } from '@/providers/market/finnhub/config'
+import { ibkrMarketProviderConfig } from '@/providers/market/ibkr/config'
 import type {
   AssetClass,
   MarketDataAvailability,

--- a/apps/tradinggoose/providers/market/types/base.ts
+++ b/apps/tradinggoose/providers/market/types/base.ts
@@ -56,6 +56,7 @@ export interface MarketProviderParams {
 export type MarketProviderAuth = {
   apiKey?: string
   apiSecret?: string
+  accessToken?: string
 }
 
 export interface MarketRequestBase {

--- a/apps/tradinggoose/providers/trading/ibkr/accounts.test.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/accounts.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeIbkrTradingAccount } from '@/providers/trading/ibkr/accounts'
+
+const context = {
+  providerId: 'ibkr' as const,
+  credentialId: 'cred-1',
+  serviceId: 'ibkr-paper',
+}
+
+describe('normalizeIbkrTradingAccount', () => {
+  it('normalizes a margin account', () => {
+    const identity = normalizeIbkrTradingAccount(
+      {
+        id: 'DU123456',
+        accountId: 'DU123456',
+        accountTitle: 'Paper Trading Account',
+        accountType: 'Margin',
+        currency: 'USD',
+        status: 'Active',
+      },
+      context
+    )
+
+    expect(identity).toMatchObject({
+      providerId: 'ibkr',
+      credentialId: 'cred-1',
+      serviceId: 'ibkr-paper',
+      accountId: 'DU123456',
+      providerName: 'IBKR',
+      accountName: 'Paper Trading Account',
+      accountType: 'margin',
+      baseCurrency: 'USD',
+      accountStatus: 'active',
+    })
+  })
+
+  it('normalizes a cash account', () => {
+    const identity = normalizeIbkrTradingAccount(
+      {
+        id: 'U1234567',
+        accountType: 'Cash',
+        currency: 'eur',
+      },
+      context
+    )
+
+    expect(identity.accountType).toBe('cash')
+    expect(identity.baseCurrency).toBe('EUR')
+  })
+
+  it('uses accountId when id is missing', () => {
+    const identity = normalizeIbkrTradingAccount(
+      {
+        accountId: 'DU999',
+        accountType: 'Individual',
+      },
+      context
+    )
+
+    expect(identity.accountId).toBe('DU999')
+    expect(identity.accountType).toBe('margin')
+  })
+
+  it('maps unknown account types and statuses', () => {
+    const identity = normalizeIbkrTradingAccount(
+      {
+        id: 'X1',
+        accountType: 'SomethingElse',
+        status: 'WeirdState',
+      },
+      context
+    )
+
+    expect(identity.accountType).toBe('unknown')
+    expect(identity.accountStatus).toBe('unknown')
+  })
+
+  it('throws when no id is present', () => {
+    expect(() => normalizeIbkrTradingAccount({ accountTitle: 'No Id' }, context)).toThrow(
+      'missing account id'
+    )
+  })
+})

--- a/apps/tradinggoose/providers/trading/ibkr/accounts.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/accounts.ts
@@ -1,0 +1,118 @@
+import { buildIbkrAuthHeaders } from '@/providers/trading/ibkr/auth'
+import { buildIbkrApiUrl } from '@/providers/trading/ibkr/client'
+import type { PortfolioIdentity } from '@/providers/trading/portfolio-identity'
+import { fetchBrokerJson, toFiniteNumber } from '@/providers/trading/portfolio-utils'
+import type {
+  TradingPortfolioBaseContext,
+  UnifiedTradingAccountStatus,
+  UnifiedTradingAccountType,
+} from '@/providers/trading/types'
+
+interface IbkrAccountsResponse {
+  accounts?: Array<{
+    id?: string
+    accountId?: string
+    accountTitle?: string
+    accountType?: string
+    currency?: string
+    status?: string
+  }>
+}
+
+export const mapIbkrAccountStatus = (value: unknown): UnifiedTradingAccountStatus => {
+  if (typeof value !== 'string') return 'unknown'
+
+  switch (value.trim().toUpperCase()) {
+    case 'ACTIVE':
+    case 'PASSED':
+      return 'active'
+    case 'CLOSED':
+    case 'PENDING_CLOSE':
+      return 'closed'
+    case 'NEW':
+    case 'PENDING':
+    case 'VERIFICATION_REQUIRED':
+    case 'DISABLED':
+    case 'INACTIVE':
+    case 'RESTRICTED':
+      return 'restricted'
+    default:
+      return 'unknown'
+  }
+}
+
+export const mapIbkrAccountType = (value: unknown): UnifiedTradingAccountType => {
+  if (typeof value !== 'string') return 'unknown'
+
+  switch (value.trim().toLowerCase()) {
+    case 'cash':
+      return 'cash'
+    case 'margin':
+      return 'margin'
+    case 'portfolio':
+      return 'portfolio'
+    case 'individual':
+    case 'joint':
+    case 'ira':
+    case 'trust':
+    case 'llc':
+      return 'margin'
+    case 'advisor':
+      return 'portfolio'
+    default:
+      return 'unknown'
+  }
+}
+
+const readText = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed || undefined
+}
+
+export const normalizeIbkrTradingAccount = (
+  account: any,
+  context: Pick<TradingPortfolioBaseContext, 'credentialId' | 'serviceId' | 'providerId'>
+): PortfolioIdentity => {
+  const id = readText(account?.id) || readText(account?.accountId)
+  if (!id) {
+    throw new Error('IBKR accounts response missing account id')
+  }
+
+  const rawType = readText(account?.accountType)
+  const accountType = mapIbkrAccountType(rawType)
+  const leverage = toFiniteNumber(account?.leverage)
+  const type = typeof leverage === 'number' && leverage > 1 ? 'margin' : accountType
+
+  return {
+    providerId: context.providerId,
+    credentialId: context.credentialId,
+    serviceId: context.serviceId,
+    accountId: id,
+    providerName: 'IBKR',
+    accountName: readText(account?.accountTitle) || `IBKR (${id})`,
+    accountType: type,
+    baseCurrency: readText(account?.currency)?.toUpperCase() ?? 'USD',
+    accountStatus: mapIbkrAccountStatus(readText(account?.status)),
+  }
+}
+
+export async function getIbkrTradingAccounts(
+  context: TradingPortfolioBaseContext
+): Promise<PortfolioIdentity[]> {
+  const response = await fetchBrokerJson<IbkrAccountsResponse>({
+    providerId: context.providerId,
+    url: buildIbkrApiUrl('/iserver/accounts'),
+    init: {
+      method: 'GET',
+      headers: buildIbkrAuthHeaders({ accessToken: context.accessToken }),
+    },
+  })
+
+  const accounts = Array.isArray(response?.accounts) ? response.accounts : []
+  const identities = accounts.map((account) => normalizeIbkrTradingAccount(account, context))
+  if (identities.length === 0) {
+    throw new Error('No IBKR accounts returned for the connected session')
+  }
+  return identities
+}

--- a/apps/tradinggoose/providers/trading/ibkr/auth.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/auth.ts
@@ -1,0 +1,12 @@
+import { resolveIbkrApiIp } from '@/providers/trading/ibkr/config'
+
+export const buildIbkrAuthHeaders = (params: { accessToken?: string }): Record<string, string> => {
+  if (!params.accessToken) {
+    throw new Error('IBKR access token is required')
+  }
+
+  return {
+    Authorization: `Bearer ${params.accessToken}`,
+    ip: resolveIbkrApiIp(),
+  }
+}

--- a/apps/tradinggoose/providers/trading/ibkr/auth.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/auth.ts
@@ -1,11 +1,49 @@
-import { resolveIbkrApiIp } from '@/providers/trading/ibkr/config'
+import { resolveIbkrApiBaseUrl, resolveIbkrApiIp } from '@/providers/trading/ibkr/config'
 
-export const buildIbkrAuthHeaders = (params: { accessToken?: string }): Record<string, string> => {
+/**
+ * IBKR exposes two different surfaces with incompatible auth:
+ *
+ *  - Client Portal Gateway (local, the default here): the session is
+ *    established by logging in through the browser at the gateway's own URL.
+ *    Requests carry that session implicitly; there is NO bearer token, and
+ *    sending an Authorization header is simply ignored. Requiring a token here
+ *    is what made every market-data call fail before a request was even sent.
+ *  - Hosted OAuth API (api.ibkr.com): bearer token, plus the originating `ip`.
+ *
+ * We pick by base URL rather than by a flag so the two can never disagree.
+ */
+const IBKR_HOSTED_HOST = /(^|\.)api\.ibkr\.com$/i
+
+/**
+ * The canonical hosted URL is `https://api.ibkr.com/v1/api`, whose host is
+ * preceded by `//`. A `(^|\.)` anchored pattern never matches that form, which
+ * silently disabled the hosted branch below and stripped the bearer token from
+ * every hosted request. Match the parsed hostname instead, and keep a substring
+ * fallback for values that are not absolute URLs.
+ */
+export const isIbkrHostedApi = (): boolean => {
+  const base = resolveIbkrApiBaseUrl()
+  try {
+    return IBKR_HOSTED_HOST.test(new URL(base).hostname)
+  } catch {
+    return /api\.ibkr\.com/i.test(base)
+  }
+}
+
+export const buildIbkrAuthHeaders = (
+  params: { accessToken?: string } = {}
+): Record<string, string> => {
+  if (!isIbkrHostedApi()) {
+    // Gateway mode: the session cookie does the work. Nothing to add.
+    return { Accept: 'application/json' }
+  }
+
   if (!params.accessToken) {
-    throw new Error('IBKR access token is required')
+    throw new Error('IBKR hosted API requires an access token')
   }
 
   return {
+    Accept: 'application/json',
     Authorization: `Bearer ${params.accessToken}`,
     ip: resolveIbkrApiIp(),
   }

--- a/apps/tradinggoose/providers/trading/ibkr/client.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/client.ts
@@ -1,0 +1,26 @@
+import { resolveIbkrApiBaseUrl } from '@/providers/trading/ibkr/config'
+
+export const buildIbkrApiUrl = (path: string): string => {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${resolveIbkrApiBaseUrl()}${normalizedPath}`
+}
+
+export const buildIbkrAccountUrl = (accountId: string, path: string): string =>
+  buildIbkrApiUrl(`/portfolio/${encodeURIComponent(accountId)}${path}`)
+
+/**
+ * In-memory cache for IBKR security definition lookups (symbol -> conid).
+ * The Client Portal Web API is conid-centric; caching avoids repeated
+ * /iserver/secdef/search calls and reduces exposure to IBKR pacing limits.
+ */
+const conidCache = new Map<string, number>()
+
+export const cacheIbkrConid = (key: string, conid: number): void => {
+  conidCache.set(key, conid)
+}
+
+export const getCachedIbkrConid = (key: string): number | undefined => conidCache.get(key)
+
+export const clearIbkrConidCache = (): void => {
+  conidCache.clear()
+}

--- a/apps/tradinggoose/providers/trading/ibkr/config.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/config.ts
@@ -1,0 +1,96 @@
+import type { AssetClass } from '@/providers/market/types'
+import { ibkrTradingSymbolRules } from '@/providers/trading/ibkr/rules'
+import type { TradingProviderConfig } from '@/providers/trading/providers'
+
+export const IBKR_DEFAULT_API_BASE_URL = 'http://127.0.0.1:5000/v1/api'
+export const IBKR_HOSTED_API_BASE_URL = 'https://api.ibkr.com/v1/api'
+export const IBKR_DEFAULT_TOKEN_ENDPOINT = 'https://api.ibkr.com/v1/api/oauth2/token'
+export const IBKR_DEFAULT_API_IP = '127.0.0.1'
+
+export const resolveIbkrApiBaseUrl = (): string =>
+  process.env.IBKR_API_BASE_URL?.trim() || IBKR_DEFAULT_API_BASE_URL
+
+export const resolveIbkrTokenEndpoint = (): string =>
+  process.env.IBKR_TOKEN_ENDPOINT?.trim() || IBKR_DEFAULT_TOKEN_ENDPOINT
+
+export const resolveIbkrApiIp = (): string => process.env.IBKR_API_IP?.trim() || IBKR_DEFAULT_API_IP
+
+const availableAssetClasses: AssetClass[] = [
+  'stock',
+  'etf',
+  'future',
+  'currency',
+  'indice',
+  'mutualfund',
+]
+
+const availability: TradingProviderConfig['availability'] = {
+  assetClass: availableAssetClasses,
+  order: true,
+  portfolioDetail: true,
+  availableCurrencyBase: [],
+  availableCurrencyQuote: [],
+  availableCryptoBase: [],
+  availableCryptoQuote: [],
+}
+
+export const ibkrTradingProviderConfig: TradingProviderConfig = {
+  id: 'ibkr',
+  name: 'IBKR',
+  availability,
+  capabilities: {
+    order: {
+      sizingModes: [{ id: 'quantity', label: 'Quantity (Shares / Contracts)' }],
+      orderTypes: [
+        {
+          id: 'market',
+          label: 'Market',
+          assetClasses: ['stock', 'etf', 'future', 'currency', 'indice', 'mutualfund'],
+        },
+        {
+          id: 'limit',
+          label: 'Limit',
+          assetClasses: ['stock', 'etf', 'future', 'currency', 'indice', 'mutualfund'],
+          requires: ['limitPrice'],
+        },
+        {
+          id: 'stop',
+          label: 'Stop',
+          assetClasses: ['stock', 'etf', 'future', 'currency', 'indice', 'mutualfund'],
+          requires: ['stopPrice'],
+        },
+        {
+          id: 'stop_limit',
+          label: 'Stop Limit',
+          assetClasses: ['stock', 'etf', 'future', 'currency', 'indice', 'mutualfund'],
+          requires: ['limitPrice', 'stopPrice'],
+        },
+        {
+          id: 'trailing_stop',
+          label: 'Trailing Stop',
+          assetClasses: ['stock', 'etf', 'future', 'currency', 'indice', 'mutualfund'],
+          requiresOneOf: ['trailPrice', 'trailPercent'],
+          excludes: ['limitPrice', 'stopPrice'],
+        },
+      ],
+      timeInForce: ['day', 'gtc', 'ioc', 'fok', 'gtd'],
+    },
+    portfolioDetail: {
+      performanceWindows: ['1W', '1M', '3M', 'YTD', '1Y', 'MAX'],
+    },
+  },
+  rulePrecedence: {
+    default: ['market', 'currency', 'assetClass', 'country', 'city', 'listing'],
+    stock: ['market', 'currency', 'country', 'city', 'listing'],
+    etf: ['market', 'currency', 'country', 'city', 'listing'],
+    indice: ['market', 'currency', 'country', 'city', 'listing'],
+    mutualfund: ['market', 'currency', 'country', 'city', 'listing'],
+    future: ['market', 'currency', 'country', 'city', 'listing'],
+    crypto: ['currency', 'market', 'country', 'city', 'listing'],
+    currency: ['currency', 'market', 'country', 'city', 'listing'],
+  },
+  exchangeCodeToMarket: {},
+  marketToExchangeCode: {},
+  exchangeCodes: [],
+  rules: ibkrTradingSymbolRules,
+}

--- a/apps/tradinggoose/providers/trading/ibkr/index.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/index.ts
@@ -1,0 +1,9 @@
+import { ibkrOrderDetailRequest } from '@/providers/trading/ibkr/orderDetail'
+import { buildIbkrOrderRequest, normalizeIbkrOrder } from '@/providers/trading/ibkr/orders'
+import type { TradingProviderAdapter } from '@/providers/trading/providers'
+
+export const ibkrProvider: TradingProviderAdapter = {
+  buildOrderRequest: buildIbkrOrderRequest,
+  orderDetailRequest: ibkrOrderDetailRequest,
+  normalizeOrder: normalizeIbkrOrder,
+}

--- a/apps/tradinggoose/providers/trading/ibkr/orderDetail.test.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/orderDetail.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import {
+  findIbkrOrderById,
+  normalizeIbkrOrderDetail,
+  resolveIbkrOrderDetailProviderOrderId,
+} from '@/providers/trading/ibkr/orderDetail'
+
+const historyRecord: any = {
+  id: 'app-order-1',
+  workspaceId: 'ws-1',
+  provider: 'ibkr',
+  environment: 'paper',
+  submissionSource: 'manual',
+  request: { accountId: 'DU123456' },
+  response: {
+    orderId: '12345',
+    clientOrderId: 'tg-client-1',
+  },
+  normalizedOrder: {
+    id: '12345',
+  },
+}
+
+describe('resolveIbkrOrderDetailProviderOrderId', () => {
+  it('resolves from response orderId', () => {
+    expect(resolveIbkrOrderDetailProviderOrderId(historyRecord)).toBe('12345')
+  })
+})
+
+describe('findIbkrOrderById', () => {
+  it('finds an order by provider order id', () => {
+    const orders = {
+      orders: [
+        { order_id: 999, order_ref: 'other' },
+        { order_id: 12345, order_ref: 'tg-client-1' },
+      ],
+    }
+
+    const found = findIbkrOrderById(orders, '12345')
+    expect(found?.order_id).toBe(12345)
+  })
+
+  it('finds an order by client order ref when ids do not match', () => {
+    const orders = {
+      orders: [{ order_id: 88888, order_ref: 'tg-client-1' }],
+    }
+
+    const found = findIbkrOrderById(orders, '12345', 'tg-client-1')
+    expect(found?.order_id).toBe(88888)
+  })
+
+  it('returns null when no order matches', () => {
+    const orders = { orders: [{ order_id: 1, order_ref: 'x' }] }
+    expect(findIbkrOrderById(orders, '99999')).toBeNull()
+  })
+
+  it('handles nested order arrays', () => {
+    const orders = [{ orders: [{ order_id: 12345 }] }]
+    expect(findIbkrOrderById(orders, '12345')?.order_id).toBe(12345)
+  })
+})
+
+describe('normalizeIbkrOrderDetail', () => {
+  it('normalizes a filled order', () => {
+    const detail = normalizeIbkrOrderDetail('app-order-1', '12345', historyRecord, {
+      order_id: 12345,
+      order_ref: 'tg-client-1',
+      ticker: 'AAPL',
+      side: 'BUY',
+      status: 'FILLED',
+      order_type: 'LMT',
+      tif: 'DAY',
+      quantity: 10,
+      filled: 10,
+      lmt_price: 250,
+      avg_price: 249.5,
+      submit_time: 1785600000,
+      last_update_time: 1785603600,
+    })
+
+    expect(detail).toMatchObject({
+      appOrderId: 'app-order-1',
+      provider: 'ibkr',
+      providerOrderId: '12345',
+      environment: 'paper',
+      clientOrderId: 'tg-client-1',
+      symbol: 'AAPL',
+      side: 'BUY',
+      status: 'FILLED',
+      orderType: 'LMT',
+      quantity: 10,
+      filledQuantity: 10,
+      remainingQuantity: 0,
+      limitPrice: 250,
+      averageFillPrice: 249.5,
+    })
+    expect(detail.createdAt).toBeTruthy()
+    expect(detail.updatedAt).toBeTruthy()
+  })
+
+  it('computes remaining quantity for partial fills', () => {
+    const detail = normalizeIbkrOrderDetail('app-order-1', '12345', historyRecord, {
+      order_id: 12345,
+      quantity: 10,
+      filled: 4,
+      status: 'PARTIALLY_FILLED',
+    })
+
+    expect(detail.remainingQuantity).toBe(6)
+  })
+})

--- a/apps/tradinggoose/providers/trading/ibkr/orderDetail.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/orderDetail.ts
@@ -1,0 +1,177 @@
+import { buildIbkrAuthHeaders } from '@/providers/trading/ibkr/auth'
+import { buildIbkrAccountUrl } from '@/providers/trading/ibkr/client'
+import { fetchBrokerJson } from '@/providers/trading/portfolio-utils'
+import type {
+  TradingOrderDetailInput,
+  TradingOrderDetailOutput,
+  TradingOrderDetailResult,
+  TradingOrderHistoryRecord,
+} from '@/providers/trading/types'
+
+const firstDefinedString = (...values: unknown[]): string | null => {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim()
+    }
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return String(value)
+    }
+  }
+  return null
+}
+
+export const resolveIbkrOrderDetailProviderOrderId = (
+  historyRecord: TradingOrderHistoryRecord
+): string | null =>
+  firstDefinedString(
+    historyRecord?.response?.orderId,
+    historyRecord?.normalizedOrder?.id,
+    historyRecord?.normalizedOrder?.raw?.order?.order_id,
+    historyRecord?.response?.raw?.order?.order_id,
+    historyRecord?.response?.raw?.order_id
+  )
+
+const normalizeIbkrOrderTimestamp = (value: unknown): string | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return new Date(value * 1000).toISOString()
+  }
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  const numeric = Number(trimmed)
+  if (Number.isFinite(numeric)) {
+    return new Date(numeric * 1000).toISOString()
+  }
+  const parsed = Date.parse(trimmed)
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null
+}
+
+export const normalizeIbkrOrderDetail = (
+  appOrderId: string,
+  providerOrderId: string,
+  historyRecord: TradingOrderHistoryRecord,
+  rawOrder: Record<string, any>
+): TradingOrderDetailOutput => ({
+  appOrderId,
+  provider: 'ibkr',
+  providerOrderId,
+  environment: historyRecord.environment ?? null,
+  clientOrderId: firstDefinedString(rawOrder.order_ref, rawOrder.orderRef),
+  createdAt: normalizeIbkrOrderTimestamp(rawOrder.submit_time) ?? undefined,
+  updatedAt: normalizeIbkrOrderTimestamp(rawOrder.last_update_time) ?? undefined,
+  submittedAt: normalizeIbkrOrderTimestamp(rawOrder.submit_time) ?? undefined,
+  filledAt: undefined,
+  canceledAt: undefined,
+  expiredAt: undefined,
+  symbol: firstDefinedString(rawOrder.ticker, rawOrder.symbol),
+  side: firstDefinedString(rawOrder.side),
+  status: firstDefinedString(rawOrder.status),
+  orderType: firstDefinedString(rawOrder.order_type, rawOrder.orderType),
+  timeInForce: firstDefinedString(rawOrder.tif, rawOrder.timeInForce),
+  quantity: rawOrder.quantity ?? rawOrder.totalQuantity ?? null,
+  filledQuantity: rawOrder.filled ?? rawOrder.filledQuantity ?? null,
+  remainingQuantity:
+    rawOrder.remainingQuantity ??
+    (typeof rawOrder.quantity === 'number' && typeof rawOrder.filled === 'number'
+      ? rawOrder.quantity - rawOrder.filled
+      : null),
+  notional: null,
+  limitPrice: rawOrder.lmt_price ?? rawOrder.limitPrice ?? null,
+  stopPrice: rawOrder.aux_price ?? rawOrder.auxPrice ?? rawOrder.stopPrice ?? null,
+  averageFillPrice: rawOrder.avg_price ?? rawOrder.averageFillPrice ?? null,
+  raw: rawOrder,
+})
+
+const toRecord = (value: unknown): Record<string, any> => {
+  if (value && typeof value === 'object') {
+    return value as Record<string, any>
+  }
+  return { value }
+}
+
+const flattenOrders = (value: unknown): any[] => {
+  if (Array.isArray(value)) {
+    return value.flatMap(flattenOrders)
+  }
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, any>
+    const orders = record.orders
+    if (Array.isArray(orders)) {
+      return orders.flatMap(flattenOrders)
+    }
+    const recordOrders = record.order
+    if (Array.isArray(recordOrders)) {
+      return recordOrders.flatMap(flattenOrders)
+    }
+  }
+  return value && typeof value === 'object' && 'order_id' in (value as object) ? [value] : []
+}
+
+export const findIbkrOrderById = (
+  rawOrders: unknown,
+  providerOrderId: string,
+  clientOrderId?: string | null
+): Record<string, any> | null => {
+  const normalizedProviderOrderId = providerOrderId.trim()
+  const normalizedClientOrderId = clientOrderId?.trim()
+
+  const candidates = flattenOrders(rawOrders)
+  for (const candidate of candidates) {
+    const record = toRecord(candidate)
+    const candidateOrderId = firstDefinedString(record.order_id, record.orderId, record.ibkrOrderId)
+    const candidateOrderRef = firstDefinedString(record.order_ref, record.orderRef)
+
+    if (candidateOrderId === normalizedProviderOrderId) {
+      return record
+    }
+    if (normalizedClientOrderId && candidateOrderRef === normalizedClientOrderId) {
+      return record
+    }
+  }
+
+  return null
+}
+
+export const ibkrOrderDetailRequest = async (
+  historyRecord: TradingOrderHistoryRecord,
+  params: TradingOrderDetailInput
+): Promise<TradingOrderDetailResult> => {
+  const providerOrderId = resolveIbkrOrderDetailProviderOrderId(historyRecord)
+  if (!providerOrderId) {
+    throw new Error('Unable to resolve IBKR provider order ID from order history record.')
+  }
+
+  const accountId = params.accountId ?? historyRecord?.response?.accountId
+  if (!accountId) {
+    throw new Error('IBKR order detail requires accountId.')
+  }
+
+  const headers = buildIbkrAuthHeaders({ accessToken: params.accessToken })
+  const rawOrders = await fetchBrokerJson<unknown>({
+    providerId: 'ibkr',
+    url: buildIbkrAccountUrl(String(accountId), '/orders'),
+    init: {
+      method: 'GET',
+      headers,
+    },
+  })
+
+  const rawOrder = findIbkrOrderById(
+    rawOrders,
+    providerOrderId,
+    historyRecord?.response?.clientOrderId
+  )
+  if (!rawOrder) {
+    throw new Error('IBKR order not found in account orders.')
+  }
+
+  return {
+    providerOrderId,
+    orderDetail: normalizeIbkrOrderDetail(
+      historyRecord.id,
+      providerOrderId,
+      historyRecord,
+      rawOrder
+    ),
+  }
+}

--- a/apps/tradinggoose/providers/trading/ibkr/orders.test.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/orders.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cacheIbkrConid, clearIbkrConidCache } from '@/providers/trading/ibkr/client'
 import { buildIbkrOrderRequest } from '@/providers/trading/ibkr/orders'
 
@@ -24,15 +24,21 @@ describe('buildIbkrOrderRequest', () => {
     cacheIbkrConid('STK:AAPL', 265598)
   })
 
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   it('builds a market order request', () => {
     const request = buildIbkrOrderRequest(baseParams)
 
     expect(request.url).toBe('http://127.0.0.1:5000/v1/api/portfolio/DU123456/orders')
     expect(request.method).toBe('POST')
     expect(request.headers).toMatchObject({
-      Authorization: 'Bearer test-token',
+      Accept: 'application/json',
       'Content-Type': 'application/json',
     })
+    // Gateway mode authenticates with the browser session, so no bearer token.
+    expect(request.headers).not.toHaveProperty('Authorization')
     expect(request.body).toMatchObject({
       conid: 265598,
       conidSpec: 'STK',
@@ -171,6 +177,19 @@ describe('buildIbkrOrderRequest', () => {
     expect(request.body).toMatchObject({
       side: 'SELL',
       quantity: '5',
+    })
+  })
+
+  it('sends a bearer token and the originating ip against the hosted API', () => {
+    vi.stubEnv('IBKR_API_BASE_URL', 'https://api.ibkr.com/v1/api')
+
+    const request = buildIbkrOrderRequest(baseParams)
+
+    expect(request.headers).toMatchObject({
+      Accept: 'application/json',
+      Authorization: 'Bearer test-token',
+      ip: '127.0.0.1',
+      'Content-Type': 'application/json',
     })
   })
 })

--- a/apps/tradinggoose/providers/trading/ibkr/orders.test.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/orders.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+import { cacheIbkrConid, clearIbkrConidCache } from '@/providers/trading/ibkr/client'
+import { buildIbkrOrderRequest } from '@/providers/trading/ibkr/orders'
+
+const baseParams = {
+  listing: {
+    listing_id: 'AAPL',
+    base_id: '',
+    quote_id: '',
+    listing_type: 'default' as const,
+  },
+  side: 'buy' as const,
+  orderType: 'market' as const,
+  timeInForce: 'day' as const,
+  accessToken: 'test-token',
+  accountId: 'DU123456',
+  quantity: 10,
+  orderSizingMode: 'quantity' as const,
+}
+
+describe('buildIbkrOrderRequest', () => {
+  beforeEach(() => {
+    clearIbkrConidCache()
+    cacheIbkrConid('STK:AAPL', 265598)
+  })
+
+  it('builds a market order request', () => {
+    const request = buildIbkrOrderRequest(baseParams)
+
+    expect(request.url).toBe('http://127.0.0.1:5000/v1/api/portfolio/DU123456/orders')
+    expect(request.method).toBe('POST')
+    expect(request.headers).toMatchObject({
+      Authorization: 'Bearer test-token',
+      'Content-Type': 'application/json',
+    })
+    expect(request.body).toMatchObject({
+      conid: 265598,
+      conidSpec: 'STK',
+      side: 'BUY',
+      quantity: '10',
+      orderType: 'MKT',
+      tif: 'DAY',
+    })
+  })
+
+  it('maps clientOrderId to orderRef', () => {
+    const request = buildIbkrOrderRequest({
+      ...baseParams,
+      clientOrderId: 'tg-abc123',
+    })
+
+    expect(request.body).toMatchObject({ orderRef: 'tg-abc123' })
+  })
+
+  it('builds a limit order with price', () => {
+    const request = buildIbkrOrderRequest({
+      ...baseParams,
+      orderType: 'limit',
+      limitPrice: 250.5,
+    })
+
+    expect(request.body).toMatchObject({
+      orderType: 'LMT',
+      price: 250.5,
+    })
+  })
+
+  it('builds a stop order with auxPrice', () => {
+    const request = buildIbkrOrderRequest({
+      ...baseParams,
+      orderType: 'stop',
+      stopPrice: 240,
+    })
+
+    expect(request.body).toMatchObject({
+      orderType: 'STP',
+      auxPrice: 240,
+    })
+  })
+
+  it('builds a stop limit order', () => {
+    const request = buildIbkrOrderRequest({
+      ...baseParams,
+      orderType: 'stop_limit',
+      stopPrice: 240,
+      limitPrice: 238,
+    })
+
+    expect(request.body).toMatchObject({
+      orderType: 'STP LMT',
+      auxPrice: 240,
+      price: 238,
+    })
+  })
+
+  it('builds a trailing stop with trailPrice', () => {
+    const request = buildIbkrOrderRequest({
+      ...baseParams,
+      orderType: 'trailing_stop',
+      trailPrice: 1.5,
+    })
+
+    expect(request.body).toMatchObject({
+      orderType: 'TRAIL',
+      auxPrice: 1.5,
+    })
+  })
+
+  it('builds a trailing stop with trailPercent', () => {
+    const request = buildIbkrOrderRequest({
+      ...baseParams,
+      orderType: 'trailing_stop',
+      trailPercent: 2,
+    })
+
+    expect(request.body).toMatchObject({
+      orderType: 'TRAIL',
+      trailingPercent: 2,
+    })
+  })
+
+  it('rejects trailing stop without trail fields', () => {
+    expect(() =>
+      buildIbkrOrderRequest({
+        ...baseParams,
+        orderType: 'trailing_stop',
+      })
+    ).toThrow('either trailPrice or trailPercent')
+  })
+
+  it('rejects notional sizing', () => {
+    expect(() =>
+      buildIbkrOrderRequest({
+        ...baseParams,
+        orderSizingMode: 'notional',
+        notional: 1000,
+      })
+    ).toThrow('notional')
+  })
+
+  it('rejects missing quantity', () => {
+    expect(() =>
+      buildIbkrOrderRequest({
+        ...baseParams,
+        quantity: undefined as unknown as number,
+      })
+    ).toThrow('quantity')
+  })
+
+  it('rejects unsupported order type', () => {
+    expect(() =>
+      buildIbkrOrderRequest({
+        ...baseParams,
+        orderType: 'pegged' as never,
+      })
+    ).toThrow('Unsupported order type')
+  })
+
+  it('throws when conid is not cached', () => {
+    clearIbkrConidCache()
+    expect(() => buildIbkrOrderRequest(baseParams)).toThrow('contract identifier not resolved')
+  })
+
+  it('sells short as negative quantity', () => {
+    const request = buildIbkrOrderRequest({
+      ...baseParams,
+      side: 'sell',
+      quantity: 5,
+    })
+
+    expect(request.body).toMatchObject({
+      side: 'SELL',
+      quantity: '5',
+    })
+  })
+})

--- a/apps/tradinggoose/providers/trading/ibkr/orders.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/orders.ts
@@ -1,0 +1,140 @@
+import { buildIbkrAuthHeaders } from '@/providers/trading/ibkr/auth'
+import { buildIbkrAccountUrl } from '@/providers/trading/ibkr/client'
+import { ibkrTradingProviderConfig } from '@/providers/trading/ibkr/config'
+import { resolveIbkrConid, resolveIbkrConidSpec } from '@/providers/trading/ibkr/symbols'
+import type {
+  TradingOrder,
+  TradingOrderInput,
+  TradingRequestConfig,
+} from '@/providers/trading/types'
+import { listingIdentityToTradingSymbol } from '@/providers/trading/utils'
+
+const IBKR_ORDER_TYPE: Record<string, string> = {
+  market: 'MKT',
+  limit: 'LMT',
+  stop: 'STP',
+  stop_limit: 'STP LMT',
+  trailing_stop: 'TRAIL',
+}
+
+const IBKR_TIF: Record<string, string> = {
+  day: 'DAY',
+  gtc: 'GTC',
+  ioc: 'IOC',
+  fok: 'FOK',
+  gtd: 'GTD',
+}
+
+const IBKR_SIDE: Record<string, string> = {
+  buy: 'BUY',
+  sell: 'SELL',
+}
+
+export const buildIbkrOrderRequest = (params: TradingOrderInput): TradingRequestConfig => {
+  const authHeaders = buildIbkrAuthHeaders({ accessToken: params.accessToken })
+
+  const symbol = listingIdentityToTradingSymbol(ibkrTradingProviderConfig, {
+    listing: params.listing,
+    base: params.base,
+    quote: params.quote,
+    assetClass: params.assetClass,
+    marketCode: params.marketCode,
+    countryCode: params.countryCode,
+    cityName: params.cityName,
+  })
+
+  const orderSizingMode = params.orderSizingMode ?? 'quantity'
+  if (orderSizingMode === 'notional') {
+    throw new Error('IBKR orders do not support notional sizing.')
+  }
+  if (typeof params.quantity !== 'number' || !Number.isFinite(params.quantity)) {
+    throw new Error('IBKR orders require quantity.')
+  }
+
+  const orderType = IBKR_ORDER_TYPE[params.orderType ?? 'market']
+  if (!orderType) {
+    throw new Error(`Unsupported order type: ${params.orderType}`)
+  }
+  const tif = IBKR_TIF[params.timeInForce ?? 'day']
+  if (!tif) {
+    throw new Error(`Unsupported time in force: ${params.timeInForce}`)
+  }
+  const side = IBKR_SIDE[params.side]
+  if (!side) {
+    throw new Error(`Unsupported side: ${params.side}`)
+  }
+
+  const { conid, conidSpec } = resolveIbkrConid({
+    symbol,
+    assetClass: params.assetClass,
+  })
+
+  const body: Record<string, any> = {
+    conid,
+    conidSpec: params.assetClass ? resolveIbkrConidSpec(params.assetClass) : conidSpec,
+    side,
+    quantity: String(Math.abs(params.quantity)),
+    orderType,
+    tif,
+    outsideRth: false,
+    ...(params.clientOrderId ? { orderRef: params.clientOrderId } : {}),
+  }
+
+  if (orderType === 'LMT' || orderType === 'STP LMT') {
+    if (typeof params.limitPrice !== 'number' || !Number.isFinite(params.limitPrice)) {
+      throw new Error('IBKR limit orders require limitPrice.')
+    }
+    body.price = params.limitPrice
+  }
+  if (orderType === 'STP' || orderType === 'STP LMT') {
+    if (typeof params.stopPrice !== 'number' || !Number.isFinite(params.stopPrice)) {
+      throw new Error('IBKR stop orders require stopPrice.')
+    }
+    body.auxPrice = params.stopPrice
+  }
+  if (orderType === 'TRAIL') {
+    const hasTrailPrice =
+      typeof params.trailPrice === 'number' && Number.isFinite(params.trailPrice)
+    const hasTrailPercent =
+      typeof params.trailPercent === 'number' && Number.isFinite(params.trailPercent)
+    if (hasTrailPrice === hasTrailPercent) {
+      throw new Error('IBKR trailing stop orders require either trailPrice or trailPercent.')
+    }
+    if (hasTrailPrice) {
+      body.auxPrice = params.trailPrice
+    } else {
+      body.trailingPercent = params.trailPercent
+    }
+  }
+
+  const accountId = params.accountId
+  if (!accountId) {
+    throw new Error('IBKR orders require accountId.')
+  }
+
+  return {
+    url: buildIbkrAccountUrl(accountId, '/orders'),
+    method: 'POST',
+    headers: {
+      ...authHeaders,
+      'Content-Type': 'application/json',
+    },
+    body,
+  }
+}
+
+export const normalizeIbkrOrder = (data: any): TradingOrder => {
+  const rawOrder = data?.order ?? data
+  return {
+    id: typeof rawOrder?.order_id === 'number' ? String(rawOrder.order_id) : rawOrder?.order_id,
+    clientOrderId: rawOrder?.order_ref ?? rawOrder?.orderRef,
+    status: rawOrder?.status,
+    submittedAt: rawOrder?.last_update_time
+      ? new Date(rawOrder.last_update_time * 1000).toISOString()
+      : undefined,
+    filledQty: typeof rawOrder?.filled === 'number' ? rawOrder.filled : undefined,
+    symbol: rawOrder?.ticker,
+    side: rawOrder?.side,
+    raw: data,
+  }
+}

--- a/apps/tradinggoose/providers/trading/ibkr/performance.test.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/performance.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeIbkrPerformanceResponse } from '@/providers/trading/ibkr/performance'
+
+describe('normalizeIbkrPerformanceResponse', () => {
+  const baseResponse = (nav: unknown) => ({ nav })
+
+  it('normalizes daily performance data', () => {
+    const response = baseResponse({
+      base: {
+        freq: 'D',
+        data: [
+          { $: 1000, t: '2026-08-01T00:00:00Z' },
+          { $: 1010, t: '2026-08-02T00:00:00Z' },
+          { $: 1020, t: '2026-08-03T00:00:00Z' },
+        ],
+      },
+    })
+
+    const result = normalizeIbkrPerformanceResponse({
+      response,
+      currency: 'USD',
+      window: '1W',
+    })
+
+    expect(result.window).toBe('1W')
+    expect(result.series).toHaveLength(3)
+    expect(result.series[0]).toMatchObject({ equity: 1000 })
+    expect(result.series[2]).toMatchObject({ equity: 1020 })
+    expect(result.summary).toMatchObject({
+      currency: 'USD',
+      startEquity: 1000,
+      endEquity: 1020,
+      absoluteReturn: 20,
+    })
+  })
+
+  it('handles empty data as unavailable', () => {
+    const response = baseResponse({
+      base: {
+        freq: 'M',
+        data: [],
+      },
+    })
+
+    const result = normalizeIbkrPerformanceResponse({
+      response,
+      currency: 'USD',
+      window: '1Y',
+    })
+
+    expect(result.summary).toBeNull()
+    expect(result.unavailableReason).toBeTruthy()
+  })
+
+  it('handles missing nav as unavailable', () => {
+    const result = normalizeIbkrPerformanceResponse({
+      response: {},
+      currency: 'USD',
+      window: '1M',
+    })
+
+    expect(result.summary).toBeNull()
+    expect(result.series).toEqual([])
+  })
+
+  it('deduplicates entries by day keeping the latest value', () => {
+    const response = baseResponse({
+      base: {
+        freq: 'D',
+        data: [
+          { $: 100, t: 1785600000 },
+          { $: 110, t: 1785600001 },
+        ],
+      },
+    })
+
+    const result = normalizeIbkrPerformanceResponse({
+      response,
+      currency: 'USD',
+      window: '1M',
+    })
+
+    expect(result.series).toHaveLength(1)
+    expect(result.series[0]?.equity).toBe(110)
+  })
+})

--- a/apps/tradinggoose/providers/trading/ibkr/performance.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/performance.ts
@@ -1,0 +1,145 @@
+import { buildIbkrAuthHeaders } from '@/providers/trading/ibkr/auth'
+import { buildIbkrAccountUrl } from '@/providers/trading/ibkr/client'
+import { ibkrTradingProviderConfig } from '@/providers/trading/ibkr/config'
+import {
+  buildTradingPortfolioPerformance,
+  createUnavailableTradingPortfolioPerformance,
+  fetchBrokerJson,
+  toFiniteNumber,
+} from '@/providers/trading/portfolio-utils'
+import type {
+  TradingPortfolioAccountContext,
+  TradingPortfolioPerformanceWindow,
+  UnifiedTradingPortfolioPerformance,
+  UnifiedTradingPortfolioPerformancePoint,
+} from '@/providers/trading/types'
+
+const IBKR_PERIOD_BY_WINDOW: Partial<
+  Record<TradingPortfolioPerformanceWindow, { period: string; periodType: string }>
+> = {
+  '1W': { period: 'W', periodType: '7D' },
+  '1M': { period: 'M', periodType: '1M' },
+  '3M': { period: 'M', periodType: '3M' },
+  YTD: { period: 'Y', periodType: 'YTD' },
+  '1Y': { period: 'Y', periodType: '1Y' },
+  MAX: { period: 'Y', periodType: '5Y' },
+}
+
+const getIbkrSupportedPerformanceWindows = () =>
+  ibkrTradingProviderConfig.capabilities?.portfolioDetail?.performanceWindows ?? []
+
+const normalizeIbkrTimestamp = (value: unknown): string | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return new Date(value * 1000).toISOString()
+  }
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  const numeric = Number(trimmed)
+  if (Number.isFinite(numeric)) {
+    return new Date(numeric * 1000).toISOString()
+  }
+  const parsed = Date.parse(trimmed)
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null
+}
+
+export const normalizeIbkrPerformanceResponse = ({
+  response,
+  currency,
+  window,
+}: {
+  response: any
+  currency: string
+  window: TradingPortfolioPerformanceWindow
+}): UnifiedTradingPortfolioPerformance => {
+  const nav = response?.nav
+  const base = nav?.base
+  const rawData = Array.isArray(base?.data) ? base.data : []
+  const rawFreq = base?.freq ?? 'M'
+
+  const series: UnifiedTradingPortfolioPerformancePoint[] = []
+  for (const entry of rawData) {
+    if (!entry || typeof entry !== 'object') continue
+    const record = entry as Record<string, unknown>
+    const value = toFiniteNumber(record['$']) ?? toFiniteNumber(record.value)
+    const timestamp = normalizeIbkrTimestamp(record['t']) ?? normalizeIbkrTimestamp(record.t)
+    if (typeof value !== 'number' || !timestamp) continue
+    series.push({ timestamp, equity: value })
+  }
+
+  if (series.length === 0) {
+    return createUnavailableTradingPortfolioPerformance({
+      window,
+      supportedWindows: getIbkrSupportedPerformanceWindows(),
+      unavailableReason: 'No usable performance data returned by broker',
+    })
+  }
+
+  const sorted = series.sort((left, right) => left.timestamp.localeCompare(right.timestamp))
+  const aggregated: UnifiedTradingPortfolioPerformancePoint[] = []
+  const seen = new Map<string, UnifiedTradingPortfolioPerformancePoint>()
+  for (const point of sorted) {
+    const key = point.timestamp.slice(0, 10)
+    const existing = seen.get(key)
+    if (existing) {
+      existing.equity = point.equity
+    } else {
+      seen.set(key, point)
+      aggregated.push(point)
+    }
+  }
+
+  const maxPoints = rawFreq === 'D' ? 2000 : 500
+  const limited = aggregated.slice(-maxPoints)
+
+  return buildTradingPortfolioPerformance({
+    window,
+    supportedWindows: getIbkrSupportedPerformanceWindows(),
+    series: limited,
+    currency,
+    unavailableReason: 'No usable performance data returned by broker',
+  })
+}
+
+export async function getIbkrTradingAccountPerformance(
+  context: TradingPortfolioAccountContext & { window: TradingPortfolioPerformanceWindow }
+): Promise<UnifiedTradingPortfolioPerformance> {
+  const mapping = IBKR_PERIOD_BY_WINDOW[context.window]
+  if (!mapping) {
+    return createUnavailableTradingPortfolioPerformance({
+      window: context.window,
+      supportedWindows: getIbkrSupportedPerformanceWindows(),
+      unavailableReason: `IBKR performance window ${context.window} is not supported`,
+    })
+  }
+
+  const searchParams = new URLSearchParams({
+    period: mapping.period,
+    periodType: mapping.periodType,
+    extended: 'false',
+  })
+
+  const response = await fetchBrokerJson<any>({
+    providerId: context.providerId,
+    url: `${buildIbkrAccountUrl(context.accountId, '/performance')}?${searchParams.toString()}`,
+    init: {
+      method: 'POST',
+      headers: {
+        ...buildIbkrAuthHeaders({ accessToken: context.accessToken }),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    },
+  })
+
+  const currency =
+    typeof response?.currency === 'string' && response.currency.trim()
+      ? response.currency.trim().toUpperCase()
+      : 'USD'
+
+  return normalizeIbkrPerformanceResponse({
+    response,
+    currency,
+    window: context.window,
+  })
+}

--- a/apps/tradinggoose/providers/trading/ibkr/positions.test.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/positions.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeIbkrPositions } from '@/providers/trading/ibkr/positions'
+
+const context = {
+  providerId: 'ibkr' as const,
+  credentialId: 'cred-1',
+  serviceId: 'ibkr-paper',
+}
+
+describe('normalizeIbkrPositions', () => {
+  it('normalizes long stock positions', () => {
+    const positions = normalizeIbkrPositions(
+      [
+        {
+          ticker: 'AAPL',
+          assetClass: 'STK',
+          position: 10,
+          avgCost: 200,
+          mktPrice: 210,
+          mktValue: 2100,
+          unrealizedPnl: 100,
+          unrealizedPnlPercent: 0.05,
+          multiplier: 1,
+        },
+      ],
+      context
+    )
+
+    expect(positions).toHaveLength(1)
+    expect(positions[0]).toMatchObject({
+      quantity: 10,
+      side: 'long',
+      averagePrice: 200,
+      marketPrice: 210,
+      marketValue: 2100,
+      unrealizedPnl: 100,
+      unrealizedPnlPercent: 5,
+      multiplier: 1,
+    })
+  })
+
+  it('normalizes short positions with negative quantity', () => {
+    const positions = normalizeIbkrPositions(
+      [
+        {
+          ticker: 'TSLA',
+          assetClass: 'STK',
+          position: -5,
+          avgCost: 300,
+          mktPrice: 290,
+          mktValue: -1450,
+          unrealizedPnl: 50,
+        },
+      ],
+      context
+    )
+
+    expect(positions[0]?.side).toBe('short')
+    expect(positions[0]?.quantity).toBe(-5)
+  })
+
+  it('skips unknown asset classes', () => {
+    const positions = normalizeIbkrPositions(
+      [
+        {
+          ticker: 'UNKNOWN',
+          assetClass: 'OPTION',
+          position: 1,
+        },
+      ],
+      context
+    )
+
+    expect(positions).toHaveLength(0)
+  })
+
+  it('handles non-array input as empty', () => {
+    expect(normalizeIbkrPositions(null, context)).toEqual([])
+    expect(normalizeIbkrPositions(undefined, context)).toEqual([])
+  })
+
+  it('normalizes future positions with multiplier', () => {
+    const positions = normalizeIbkrPositions(
+      [
+        {
+          ticker: 'ES',
+          assetClass: 'FUT',
+          position: 2,
+          mktValue: 100000,
+          multiplier: 50,
+        },
+      ],
+      context
+    )
+
+    expect(positions[0]?.assetClass ?? positions[0]?.multiplier).toBe(50)
+    expect(positions[0]?.quantity).toBe(2)
+  })
+})

--- a/apps/tradinggoose/providers/trading/ibkr/positions.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/positions.ts
@@ -1,0 +1,146 @@
+import { buildIbkrAuthHeaders } from '@/providers/trading/ibkr/auth'
+import { buildIbkrAccountUrl } from '@/providers/trading/ibkr/client'
+import { ibkrTradingProviderConfig } from '@/providers/trading/ibkr/config'
+import {
+  fetchBrokerJson,
+  sumFiniteNumbers,
+  toFiniteNumber,
+} from '@/providers/trading/portfolio-utils'
+import type {
+  TradingPortfolioBaseContext,
+  UnifiedTradingPosition,
+  UnifiedTradingSymbolAssetClass,
+} from '@/providers/trading/types'
+import { tradingSymbolToListingIdentity } from '@/providers/trading/utils'
+
+export const IBKR_DEFAULT_BASE_CURRENCY = 'USD'
+
+export const mapIbkrPositionSide = (
+  value: unknown,
+  quantity?: unknown
+): UnifiedTradingPosition['side'] => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    if (value > 0) return 'long'
+    if (value < 0) return 'short'
+    return 'flat'
+  }
+  if (typeof value !== 'string') return 'unknown'
+  const normalized = value.toLowerCase()
+  if (normalized === 'long' || normalized === 'l') return 'long'
+  if (normalized === 'short' || normalized === 's') return 'short'
+  if (normalized === 'flat' || normalized === 'f') return 'flat'
+
+  if (typeof quantity === 'number' && Number.isFinite(quantity)) {
+    if (quantity > 0) return 'long'
+    if (quantity < 0) return 'short'
+    return 'flat'
+  }
+  return 'unknown'
+}
+
+export const mapIbkrAssetClass = (value: unknown): UnifiedTradingSymbolAssetClass | null => {
+  if (typeof value !== 'string') return null
+  const normalized = value.trim().toUpperCase()
+  switch (normalized) {
+    case 'STK':
+      return 'stock'
+    case 'ETF':
+      return 'etf'
+    case 'FUT':
+      return 'future'
+    case 'CASH':
+      return 'currency'
+    case 'IND':
+      return 'indice'
+    case 'FUND':
+    case 'MUTUALFUND':
+      return 'mutualfund'
+    case 'OPT':
+      return 'future'
+    default:
+      return null
+  }
+}
+
+const readText = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed || undefined
+}
+
+export const normalizeIbkrPositions = (
+  positions: unknown,
+  context: Pick<TradingPortfolioBaseContext, 'credentialId' | 'serviceId' | 'providerId'>
+): UnifiedTradingPosition[] => {
+  const list = Array.isArray(positions) ? positions : []
+
+  return list.flatMap((position: any) => {
+    const assetClass = mapIbkrAssetClass(position?.assetClass)
+    if (!assetClass) return []
+
+    const symbolValue = readText(position?.ticker) || readText(position?.symbol)
+    if (!symbolValue) return []
+
+    const resolvedSymbol = tradingSymbolToListingIdentity(ibkrTradingProviderConfig, {
+      symbol: symbolValue,
+      assetClass,
+      defaultQuote: IBKR_DEFAULT_BASE_CURRENCY,
+    })
+    const quote = resolvedSymbol?.quote ?? IBKR_DEFAULT_BASE_CURRENCY
+
+    const side = mapIbkrPositionSide(position?.position)
+    const rawQuantity = toFiniteNumber(position?.position) ?? 0
+    const quantity = side === 'short' ? -Math.abs(rawQuantity) : rawQuantity
+    const marketValue = toFiniteNumber(position?.mktValue)
+    const unrealizedPnlPercent = toFiniteNumber(position?.unrealizedPnlPercent)
+    const multiplier = toFiniteNumber(position?.multiplier) ?? 1
+
+    return [
+      {
+        listingIdentity: resolvedSymbol?.listing ?? null,
+        quantity,
+        side,
+        averagePrice: toFiniteNumber(position?.avgCost),
+        marketPrice: toFiniteNumber(position?.mktPrice),
+        marketValue,
+        currencySymbol: quote === IBKR_DEFAULT_BASE_CURRENCY ? '$' : undefined,
+        conversionRate: quote === IBKR_DEFAULT_BASE_CURRENCY ? 1 : undefined,
+        unrealizedPnl: toFiniteNumber(position?.unrealizedPnl),
+        unrealizedPnlPercent:
+          typeof unrealizedPnlPercent === 'number' ? unrealizedPnlPercent * 100 : undefined,
+        costBasis: toFiniteNumber(position?.costBasis),
+        multiplier,
+      },
+    ]
+  })
+}
+
+export const sumIbkrPositionUnrealizedPnl = (positions: UnifiedTradingPosition[]) =>
+  sumFiniteNumbers(positions.map((position) => position.unrealizedPnl))
+
+export async function getIbkrTradingPositions(
+  context: TradingPortfolioBaseContext & { accountId: string }
+): Promise<UnifiedTradingPosition[]> {
+  const headers = buildIbkrAuthHeaders({ accessToken: context.accessToken })
+  const allPositions: any[] = []
+
+  let page = 0
+  for (;;) {
+    const response = await fetchBrokerJson<any[]>({
+      providerId: context.providerId,
+      url: buildIbkrAccountUrl(context.accountId, `/positions/${page}`),
+      init: {
+        method: 'GET',
+        headers,
+      },
+    })
+
+    const batch = Array.isArray(response) ? response : []
+    allPositions.push(...batch)
+
+    if (batch.length < 100 || batch.length === 0) break
+    page += 1
+  }
+
+  return normalizeIbkrPositions(allPositions, context)
+}

--- a/apps/tradinggoose/providers/trading/ibkr/rules.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/rules.ts
@@ -1,0 +1,36 @@
+import { IBKR_DEFAULT_API_IP } from '@/providers/trading/ibkr/config'
+import type { TradingSymbolRule } from '@/providers/trading/providers'
+
+export const ibkrTradingSymbolRules: TradingSymbolRule[] = [
+  {
+    currency: 'USD',
+    template: '{base}',
+    active: true,
+  },
+  {
+    currency: 'EUR',
+    template: '{base}',
+    active: true,
+  },
+  {
+    currency: 'GBP',
+    template: '{base}',
+    active: true,
+  },
+  {
+    currency: 'JPY',
+    template: '{base}',
+    active: true,
+  },
+  {
+    assetClass: 'currency',
+    template: '{base}{quote}',
+    active: true,
+  },
+  {
+    template: '{base}',
+    active: true,
+  },
+]
+
+export const IBKR_API_IP = IBKR_DEFAULT_API_IP

--- a/apps/tradinggoose/providers/trading/ibkr/session.test.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/session.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @vitest-environment node
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  ensureIbkrSession,
+  IBKR_GATEWAY_SESSION_EXPIRED_MESSAGE,
+  resetIbkrSessionState,
+} from '@/providers/trading/ibkr/session'
+
+// `vitest.setup.ts` installs a single global fetch mock for the whole file, so a
+// per-test spy would accumulate its calls. Hoist one mock and clear it instead.
+const { fetchMock } = vi.hoisted(() => ({ fetchMock: vi.fn() }))
+
+const originalBaseUrl = process.env.IBKR_API_BASE_URL
+
+const jsonResponse = (body: unknown, status = 200) =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  }) as unknown as Response
+
+interface Handlers {
+  authStatus?: () => Response
+  tickle?: () => Response
+  accounts?: () => Response
+}
+
+const handlers: Handlers = {}
+
+const callCount = (fragment: string) =>
+  fetchMock.mock.calls.filter(([input]) => String(input).includes(fragment)).length
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  for (const key of Object.keys(handlers) as (keyof Handlers)[]) {
+    delete handlers[key]
+  }
+  fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.includes('/iserver/auth/status')) {
+      return (handlers.authStatus ?? (() => jsonResponse({ authenticated: true })))()
+    }
+    if (url.includes('/tickle')) {
+      return (handlers.tickle ?? (() => jsonResponse({})))()
+    }
+    if (url.includes('/iserver/accounts')) {
+      return (handlers.accounts ?? (() => jsonResponse({ accounts: ['DU123456'] })))()
+    }
+    throw new Error(`unexpected fetch: ${url}`)
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  process.env.IBKR_API_BASE_URL = 'http://host.containers.internal:5002/v1/api'
+  resetIbkrSessionState()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  // `resolveIbkrApiBaseUrl` treats an empty value as unset, so assigning the
+  // original (or an empty string) restores the real environment without the
+  // delete operator, which lint rejects.
+  process.env.IBKR_API_BASE_URL = originalBaseUrl ?? ''
+})
+
+describe('ensureIbkrSession', () => {
+  it('reports an unauthenticated gateway as an instruction, not a bare status', async () => {
+    handlers.accounts = () => jsonResponse({ error: 'not authenticated' }, 401)
+
+    await expect(ensureIbkrSession()).rejects.toThrow(IBKR_GATEWAY_SESSION_EXPIRED_MESSAGE)
+  })
+
+  it('re-primes on the next attempt after the session was rejected', async () => {
+    handlers.accounts = () => jsonResponse({ error: 'not authenticated' }, 401)
+
+    await expect(ensureIbkrSession()).rejects.toThrow(IBKR_GATEWAY_SESSION_EXPIRED_MESSAGE)
+    // A rejected session must not latch the module into a permanently
+    // "primed" state once the operator logs in at the gateway.
+    await expect(ensureIbkrSession()).rejects.toThrow(IBKR_GATEWAY_SESSION_EXPIRED_MESSAGE)
+
+    expect(callCount('/iserver/accounts')).toBe(2)
+  })
+
+  it('does not fail the caller when priming hits a transient non-auth error', async () => {
+    // Observed live: /iserver/accounts answered 400 while the gateway was
+    // mid-login, and the following market-data call succeeded.
+    handlers.accounts = () => jsonResponse({ error: 'bad request' }, 400)
+
+    await expect(ensureIbkrSession()).resolves.toBeUndefined()
+  })
+
+  it('retries priming for as long as it has not succeeded', async () => {
+    handlers.accounts = () => jsonResponse({ error: 'bad request' }, 400)
+
+    await ensureIbkrSession()
+    // The tickle window has not elapsed, so only priming is attempted again.
+    await ensureIbkrSession()
+
+    expect(callCount('/iserver/accounts')).toBe(2)
+    expect(callCount('/iserver/auth/status')).toBe(1)
+  })
+
+  it('primes once and reuses the session afterwards', async () => {
+    await ensureIbkrSession()
+    await ensureIbkrSession()
+
+    expect(callCount('/iserver/accounts')).toBe(1)
+    expect(callCount('/iserver/auth/status')).toBe(1)
+    expect(callCount('/tickle')).toBe(1)
+  })
+
+  it('does nothing for the hosted OAuth API, which is stateless', async () => {
+    process.env.IBKR_API_BASE_URL = 'https://api.ibkr.com/v1/api'
+
+    await expect(ensureIbkrSession()).resolves.toBeUndefined()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/tradinggoose/providers/trading/ibkr/session.test.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/session.test.ts
@@ -26,6 +26,7 @@ interface Handlers {
   authStatus?: () => Response
   tickle?: () => Response
   accounts?: () => Response
+  reauthenticate?: () => Response
 }
 
 const handlers: Handlers = {}
@@ -42,6 +43,13 @@ beforeEach(() => {
     const url = String(input)
     if (url.includes('/iserver/auth/status')) {
       return (handlers.authStatus ?? (() => jsonResponse({ authenticated: true })))()
+    }
+    if (url.includes('/iserver/reauthenticate')) {
+      // Default: the gateway refuses, which is what happens when no browser
+      // login exists to build on.
+      return (
+        handlers.reauthenticate ?? (() => jsonResponse({ error: 'not authenticated' }, 401))
+      )()
     }
     if (url.includes('/tickle')) {
       return (handlers.tickle ?? (() => jsonResponse({})))()
@@ -85,6 +93,67 @@ describe('ensureIbkrSession', () => {
     // behind a portproxy); a hardcoded URL once sent the operator to a port that
     // was not listening.
     expect(IBKR_GATEWAY_SESSION_EXPIRED_MESSAGE).not.toMatch(/localhost|https?:\/\//)
+  })
+
+  it('asks the gateway to rebuild the brokerage session before failing', async () => {
+    // Observed live: a browser login establishes only the SSO half of the
+    // session. The brokerage half completes when the gateway is asked to
+    // reauthenticate, so a 401 here is recoverable without the operator.
+    let primed = false
+    handlers.accounts = () =>
+      primed
+        ? jsonResponse({ accounts: ['DU123456'] })
+        : jsonResponse({ error: 'not authenticated' }, 401)
+    handlers.reauthenticate = () => {
+      primed = true
+      return jsonResponse({ authenticated: true })
+    }
+
+    await expect(ensureIbkrSession()).resolves.toBeUndefined()
+
+    expect(callCount('/iserver/reauthenticate')).toBe(1)
+    // A restored session still needs its priming call, or the data request that
+    // follows would be rejected for the same reason.
+    expect(callCount('/iserver/accounts')).toBe(2)
+  })
+
+  it('restores a session that auth/status reports as unauthenticated', async () => {
+    let authenticated = false
+    handlers.authStatus = () => jsonResponse({ authenticated })
+    handlers.reauthenticate = () => {
+      authenticated = true
+      return jsonResponse({ authenticated: true })
+    }
+
+    await expect(ensureIbkrSession()).resolves.toBeUndefined()
+
+    expect(callCount('/iserver/reauthenticate')).toBe(1)
+    // Recovery must not skip the keepalive and priming that follow it.
+    expect(callCount('/tickle')).toBe(1)
+    expect(callCount('/iserver/accounts')).toBe(1)
+  })
+
+  it('still instructs the operator when the gateway cannot rebuild the session', async () => {
+    handlers.accounts = () => jsonResponse({ error: 'not authenticated' }, 401)
+    handlers.reauthenticate = () => jsonResponse({ error: 'not authenticated' }, 401)
+
+    await expect(ensureIbkrSession()).rejects.toThrow(IBKR_GATEWAY_SESSION_EXPIRED_MESSAGE)
+  })
+
+  it('calls the recovery route the gateway names, as a POST', async () => {
+    // The gateway logs `ssodh failed, retry with /iserver/reauthenticate`; a
+    // divergent path or verb would 404 and look like a dead session.
+    handlers.authStatus = () => jsonResponse({ authenticated: false })
+    handlers.reauthenticate = () => jsonResponse({ authenticated: true })
+
+    await ensureIbkrSession()
+
+    const call = fetchMock.mock.calls.find(([input]) =>
+      String(input).includes('/iserver/reauthenticate')
+    )
+    expect(call).toBeDefined()
+    expect(String(call?.[0])).toMatch(/\/iserver\/reauthenticate$/)
+    expect((call?.[1] as RequestInit | undefined)?.method).toBe('POST')
   })
 
   it('re-primes on the next attempt after the session was rejected', async () => {

--- a/apps/tradinggoose/providers/trading/ibkr/session.test.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/session.test.ts
@@ -71,6 +71,22 @@ describe('ensureIbkrSession', () => {
     await expect(ensureIbkrSession()).rejects.toThrow(IBKR_GATEWAY_SESSION_EXPIRED_MESSAGE)
   })
 
+  it('reports an unauthenticated auth-status check with the same instruction', async () => {
+    // The path an operator actually hits: auth/status answers 200 with
+    // authenticated:false. It shares one message with the 401 path.
+    handlers.authStatus = () =>
+      jsonResponse({ authenticated: false, established: false, connected: false })
+
+    await expect(ensureIbkrSession()).rejects.toThrow(IBKR_GATEWAY_SESSION_EXPIRED_MESSAGE)
+  })
+
+  it('names no deployment-specific URL in the session message', async () => {
+    // The gateway's scheme and port vary by deployment (this one is plain HTTP
+    // behind a portproxy); a hardcoded URL once sent the operator to a port that
+    // was not listening.
+    expect(IBKR_GATEWAY_SESSION_EXPIRED_MESSAGE).not.toMatch(/localhost|https?:\/\//)
+  })
+
   it('re-primes on the next attempt after the session was rejected', async () => {
     handlers.accounts = () => jsonResponse({ error: 'not authenticated' }, 401)
 

--- a/apps/tradinggoose/providers/trading/ibkr/session.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/session.ts
@@ -27,15 +27,25 @@ export const resetIbkrSessionState = (): void => {
 }
 
 /**
- * The gateway reports an unauthenticated or lapsed session as 401 (403 on some
- * builds). The app cannot re-authenticate the gateway by itself - that requires
- * a browser login at the gateway's own URL - so this case must be reported as
- * the actionable instruction it is, not as a bare "Broker request failed with
- * status 401" that reads like a bug in the provider.
+ * An unauthenticated or lapsed gateway session surfaces two ways: as
+ * `authenticated: false` on /iserver/auth/status, and as 401 on the data
+ * endpoints. Both are the same condition for the operator, so both report this
+ * one message.
+ *
+ * The app cannot re-authenticate the gateway by itself - only a browser login at
+ * the gateway's own URL can - so this must read as the instruction it is rather
+ * than a bare "Broker request failed with status 401" that looks like a
+ * provider bug.
+ *
+ * It deliberately names no URL: the gateway's scheme and port are
+ * deployment-specific (this deployment listens on plain HTTP behind a
+ * portproxy), and naming the wrong one sends the operator to a port that is not
+ * listening.
  */
 export const IBKR_GATEWAY_SESSION_EXPIRED_MESSAGE =
   'IBKR Client Portal Gateway session is not authenticated. Log in at the gateway URL ' +
-  '(default https://localhost:5001) and retry; the app cannot re-authenticate the gateway.'
+  'in a browser on the host that runs it, then retry; the app cannot ' +
+  're-authenticate the gateway.'
 
 const readBrokerStatus = (error: unknown): number | undefined => {
   if (typeof error !== 'object' || error === null) return undefined
@@ -61,10 +71,10 @@ export async function ensureIbkrSession(params: { accessToken?: string } = {}): 
     })
 
     if (status && status.authenticated === false) {
-      throw new Error(
-        'IBKR Gateway session is not authenticated. Log in at the gateway URL ' +
-          '(default https://localhost:5000) and retry.'
-      )
+      // The same condition the data endpoints report as 401, so it gets the
+      // same message and the same cache reset as the priming path below.
+      resetIbkrSessionState()
+      throw new Error(IBKR_GATEWAY_SESSION_EXPIRED_MESSAGE)
     }
 
     await fetchBrokerJson<unknown>({

--- a/apps/tradinggoose/providers/trading/ibkr/session.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/session.ts
@@ -21,6 +21,14 @@ interface IbkrAuthStatus {
   competing?: boolean
 }
 
+interface IbkrReauthenticateResult {
+  authenticated?: boolean
+  pass?: boolean
+  passed?: boolean
+}
+
+type IbkrAuthHeaders = ReturnType<typeof buildIbkrAuthHeaders>
+
 export const resetIbkrSessionState = (): void => {
   lastTickleAt = 0
   accountsPrimed = false
@@ -32,10 +40,9 @@ export const resetIbkrSessionState = (): void => {
  * endpoints. Both are the same condition for the operator, so both report this
  * one message.
  *
- * The app cannot re-authenticate the gateway by itself - only a browser login at
- * the gateway's own URL can - so this must read as the instruction it is rather
- * than a bare "Broker request failed with status 401" that looks like a
- * provider bug.
+ * The app asks the gateway to restore the session itself first
+ * (see tryReauthenticate), so reaching this message means even that failed and
+ * there is no browser login to build on.
  *
  * It deliberately names no URL: the gateway's scheme and port are
  * deployment-specific (this deployment listens on plain HTTP behind a
@@ -43,14 +50,67 @@ export const resetIbkrSessionState = (): void => {
  * listening.
  */
 export const IBKR_GATEWAY_SESSION_EXPIRED_MESSAGE =
-  'IBKR Client Portal Gateway session is not authenticated. Log in at the gateway URL ' +
-  'in a browser on the host that runs it, then retry; the app cannot ' +
-  're-authenticate the gateway.'
+  'IBKR Client Portal Gateway session is not authenticated and could not be ' +
+  'restored automatically. Log in at the gateway URL in a browser on the host ' +
+  'that runs it, then retry.'
 
 const readBrokerStatus = (error: unknown): number | undefined => {
   if (typeof error !== 'object' || error === null) return undefined
   const status = (error as { status?: unknown }).status
   return typeof status === 'number' ? status : undefined
+}
+
+/**
+ * A browser login only establishes the SSO half of the session; the brokerage
+ * (iserver) half is established separately, and until something completes it the
+ * gateway keeps reporting `authenticated:false` while its SSO is perfectly
+ * valid. This call is what completes it - observed live, the gateway logging
+ * `iserver init : {"passed":true,"authenticated":true,"connected":true,...}`
+ * immediately after it.
+ *
+ * It also explains the "you have to click Log In twice" symptom: clicking again
+ * can never work, because the gateway answers the second login with
+ * `{"message":"sso dh already set"}` and logs `ssodh failed, retry with
+ * /iserver/reauthenticate`. That logged instruction is what this implements
+ * (IBKR's documented order is reauthenticate first, then validate the SSO).
+ */
+const tryReauthenticate = async (headers: IbkrAuthHeaders): Promise<boolean> => {
+  const result = await fetchBrokerJson<IbkrReauthenticateResult>({
+    providerId: 'ibkr',
+    url: buildIbkrApiUrl('/iserver/reauthenticate'),
+    init: { method: 'POST', headers },
+  }).catch((error) => {
+    logger.warn('IBKR reauthenticate failed', { error })
+    return null
+  })
+
+  if (!result) return false
+
+  // Gateway builds disagree on the body shape, so take an explicit verdict when
+  // one is present and otherwise ask the status endpoint the caller depends on.
+  const verdict = result.authenticated ?? result.passed ?? result.pass
+  if (verdict === true) return true
+  if (verdict === false) return false
+
+  const status = await fetchBrokerJson<IbkrAuthStatus>({
+    providerId: 'ibkr',
+    url: buildIbkrApiUrl('/iserver/auth/status'),
+    init: { method: 'POST', headers },
+  }).catch(() => null)
+
+  return status?.authenticated === true
+}
+
+/**
+ * Priming, not data: the gateway serves 401 on /iserver/* until this has been
+ * called once for the session.
+ */
+const primeIbkrAccounts = async (headers: IbkrAuthHeaders): Promise<void> => {
+  await fetchBrokerJson<unknown>({
+    providerId: 'ibkr',
+    url: buildIbkrApiUrl('/iserver/accounts'),
+    init: { method: 'GET', headers },
+  })
 }
 
 export async function ensureIbkrSession(params: { accessToken?: string } = {}): Promise<void> {
@@ -71,10 +131,15 @@ export async function ensureIbkrSession(params: { accessToken?: string } = {}): 
     })
 
     if (status && status.authenticated === false) {
-      // The same condition the data endpoints report as 401, so it gets the
-      // same message and the same cache reset as the priming path below.
-      resetIbkrSessionState()
-      throw new Error(IBKR_GATEWAY_SESSION_EXPIRED_MESSAGE)
+      // Let the gateway rebuild its brokerage session before telling the
+      // operator to do something they already did.
+      if (await tryReauthenticate(headers)) {
+        logger.info('IBKR gateway session restored via reauthenticate', {})
+        resetIbkrSessionState()
+      } else {
+        resetIbkrSessionState()
+        throw new Error(IBKR_GATEWAY_SESSION_EXPIRED_MESSAGE)
+      }
     }
 
     await fetchBrokerJson<unknown>({
@@ -88,15 +153,24 @@ export async function ensureIbkrSession(params: { accessToken?: string } = {}): 
 
   if (!accountsPrimed) {
     try {
-      await fetchBrokerJson<unknown>({
-        providerId: 'ibkr',
-        url: buildIbkrApiUrl('/iserver/accounts'),
-        init: { method: 'GET', headers },
-      })
+      await primeIbkrAccounts(headers)
       accountsPrimed = true
     } catch (error) {
       const status = readBrokerStatus(error)
       if (status === 401 || status === 403) {
+        // The data endpoints report the same condition as auth/status, so the
+        // gateway gets the same one shot at rebuilding the session here.
+        if (await tryReauthenticate(headers)) {
+          try {
+            await primeIbkrAccounts(headers)
+            accountsPrimed = true
+            return
+          } catch (retryError) {
+            logger.warn('IBKR accounts priming failed after reauthenticate', {
+              error: retryError,
+            })
+          }
+        }
         // Drop the cached state so the next attempt primes from scratch once
         // the operator has logged in at the gateway.
         resetIbkrSessionState()

--- a/apps/tradinggoose/providers/trading/ibkr/session.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/session.ts
@@ -1,0 +1,102 @@
+import { createLogger } from '@/lib/logs/console/logger'
+import { buildIbkrAuthHeaders, isIbkrHostedApi } from '@/providers/trading/ibkr/auth'
+import { buildIbkrApiUrl } from '@/providers/trading/ibkr/client'
+import { fetchBrokerJson } from '@/providers/trading/portfolio-utils'
+
+const logger = createLogger('IBKR:Session')
+
+/**
+ * The Client Portal Gateway drops an idle session after a few minutes, and it
+ * will not serve /iserver/* data until /iserver/accounts has been called once
+ * for the session. Both are cheap, so we do them on a timer rather than
+ * discovering the problem as an opaque 401 halfway through a chart load.
+ */
+const TICKLE_INTERVAL_MS = 60_000
+let lastTickleAt = 0
+let accountsPrimed = false
+
+interface IbkrAuthStatus {
+  authenticated?: boolean
+  connected?: boolean
+  competing?: boolean
+}
+
+export const resetIbkrSessionState = (): void => {
+  lastTickleAt = 0
+  accountsPrimed = false
+}
+
+/**
+ * The gateway reports an unauthenticated or lapsed session as 401 (403 on some
+ * builds). The app cannot re-authenticate the gateway by itself - that requires
+ * a browser login at the gateway's own URL - so this case must be reported as
+ * the actionable instruction it is, not as a bare "Broker request failed with
+ * status 401" that reads like a bug in the provider.
+ */
+export const IBKR_GATEWAY_SESSION_EXPIRED_MESSAGE =
+  'IBKR Client Portal Gateway session is not authenticated. Log in at the gateway URL ' +
+  '(default https://localhost:5001) and retry; the app cannot re-authenticate the gateway.'
+
+const readBrokerStatus = (error: unknown): number | undefined => {
+  if (typeof error !== 'object' || error === null) return undefined
+  const status = (error as { status?: unknown }).status
+  return typeof status === 'number' ? status : undefined
+}
+
+export async function ensureIbkrSession(params: { accessToken?: string } = {}): Promise<void> {
+  // The hosted OAuth API is stateless; none of this applies.
+  if (isIbkrHostedApi()) return
+
+  const headers = buildIbkrAuthHeaders(params)
+  const now = Date.now()
+
+  if (now - lastTickleAt > TICKLE_INTERVAL_MS) {
+    const status = await fetchBrokerJson<IbkrAuthStatus>({
+      providerId: 'ibkr',
+      url: buildIbkrApiUrl('/iserver/auth/status'),
+      init: { method: 'POST', headers },
+    }).catch((error) => {
+      logger.warn('IBKR auth status check failed', { error })
+      return null
+    })
+
+    if (status && status.authenticated === false) {
+      throw new Error(
+        'IBKR Gateway session is not authenticated. Log in at the gateway URL ' +
+          '(default https://localhost:5000) and retry.'
+      )
+    }
+
+    await fetchBrokerJson<unknown>({
+      providerId: 'ibkr',
+      url: buildIbkrApiUrl('/tickle'),
+      init: { method: 'POST', headers },
+    }).catch((error) => logger.warn('IBKR tickle failed', { error }))
+
+    lastTickleAt = now
+  }
+
+  if (!accountsPrimed) {
+    try {
+      await fetchBrokerJson<unknown>({
+        providerId: 'ibkr',
+        url: buildIbkrApiUrl('/iserver/accounts'),
+        init: { method: 'GET', headers },
+      })
+      accountsPrimed = true
+    } catch (error) {
+      const status = readBrokerStatus(error)
+      if (status === 401 || status === 403) {
+        // Drop the cached state so the next attempt primes from scratch once
+        // the operator has logged in at the gateway.
+        resetIbkrSessionState()
+        throw new Error(IBKR_GATEWAY_SESSION_EXPIRED_MESSAGE)
+      }
+      // Priming is a precondition, not the data the caller asked for, so a
+      // transient failure here must not fail the request: observed a 400 while
+      // the gateway was mid-login, where the subsequent call succeeds. Leave
+      // accountsPrimed false so the next request retries.
+      logger.warn('IBKR accounts priming failed; continuing without caching success', { error })
+    }
+  }
+}

--- a/apps/tradinggoose/providers/trading/ibkr/snapshot.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/snapshot.ts
@@ -1,0 +1,99 @@
+import {
+  getIbkrTradingAccounts,
+  normalizeIbkrTradingAccount,
+} from '@/providers/trading/ibkr/accounts'
+import { buildIbkrAuthHeaders } from '@/providers/trading/ibkr/auth'
+import { buildIbkrAccountUrl } from '@/providers/trading/ibkr/client'
+import {
+  getIbkrTradingPositions,
+  IBKR_DEFAULT_BASE_CURRENCY,
+  sumIbkrPositionUnrealizedPnl,
+} from '@/providers/trading/ibkr/positions'
+import { buildPortfolioDetail } from '@/providers/trading/portfolio-detail'
+import type { PortfolioDetail } from '@/providers/trading/portfolio-identity'
+import { fetchBrokerJson, toFiniteNumber } from '@/providers/trading/portfolio-utils'
+import type { TradingPortfolioAccountContext } from '@/providers/trading/types'
+
+interface IbkrSummaryRow {
+  key?: string
+  value?: string | number | null
+}
+
+export const normalizeIbkrSnapshotAccountSummary = (rows: unknown) => {
+  const list = Array.isArray(rows) ? rows : []
+  const values = new Map<string, number | undefined>()
+
+  for (const row of list) {
+    const record = row as IbkrSummaryRow
+    const key = typeof record?.key === 'string' ? record.key : undefined
+    if (!key) continue
+    values.set(key, toFiniteNumber(record?.value))
+  }
+
+  const totalCashValue = values.get('totalcashvalue') ?? 0
+  const equity = values.get('equitywithloan') ?? values.get('netliquidation') ?? 0
+  const totalPortfolioValue = values.get('netliquidation') ?? equity ?? 0
+  const buyingPower = values.get('buyingpower') ?? values.get('cashbalance') ?? 0
+
+  return {
+    totalCashValue,
+    totalPortfolioValue,
+    equity,
+    buyingPower,
+  }
+}
+
+export async function getIbkrTradingAccountSnapshot(
+  context: TradingPortfolioAccountContext
+): Promise<PortfolioDetail> {
+  const headers = buildIbkrAuthHeaders({ accessToken: context.accessToken })
+
+  const [accountIdentity, summaryRows, positions] = await Promise.all([
+    getIbkrTradingAccounts(context).then((identities) => {
+      const match =
+        identities.find((identity) => identity.accountId === context.accountId) ?? identities[0]
+      if (!match) {
+        throw new Error('IBKR account not found for connected session')
+      }
+      return match
+    }),
+    fetchBrokerJson<IbkrSummaryRow[]>({
+      providerId: context.providerId,
+      url: buildIbkrAccountUrl(context.accountId, '/summary'),
+      init: { method: 'GET', headers },
+    }),
+    getIbkrTradingPositions(context),
+  ])
+
+  const account = normalizeIbkrTradingAccount(accountIdentity, context)
+  const summaryTotals = normalizeIbkrSnapshotAccountSummary(summaryRows)
+  const totalUnrealizedPnl = sumIbkrPositionUnrealizedPnl(positions)
+  const totalHoldingsValue = summaryTotals.totalPortfolioValue - summaryTotals.totalCashValue
+
+  return buildPortfolioDetail({
+    identity: {
+      ...account,
+      baseCurrency: account.baseCurrency || IBKR_DEFAULT_BASE_CURRENCY,
+    },
+    environment: context.environment ?? 'live',
+    asOf: new Date().toISOString(),
+    cashBalances: [
+      {
+        currency: account.baseCurrency || IBKR_DEFAULT_BASE_CURRENCY,
+        currencySymbol: account.baseCurrency === IBKR_DEFAULT_BASE_CURRENCY ? '$' : undefined,
+        amount: summaryTotals.totalCashValue,
+        conversionRate: account.baseCurrency === IBKR_DEFAULT_BASE_CURRENCY ? 1 : undefined,
+        amountInAccountCurrency: summaryTotals.totalCashValue,
+      },
+    ],
+    positions,
+    summary: {
+      totalPortfolioValue: summaryTotals.totalPortfolioValue,
+      totalCashValue: summaryTotals.totalCashValue,
+      totalHoldingsValue,
+      totalUnrealizedPnl,
+      buyingPower: summaryTotals.buyingPower,
+      equity: summaryTotals.equity,
+    },
+  })
+}

--- a/apps/tradinggoose/providers/trading/ibkr/symbols.test.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/symbols.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { cacheIbkrConid, clearIbkrConidCache } from '@/providers/trading/ibkr/client'
+import {
+  buildIbkrConidCacheKey,
+  resolveIbkrConid,
+  resolveIbkrConidFromApi,
+  resolveIbkrConidSpec,
+} from '@/providers/trading/ibkr/symbols'
+
+describe('resolveIbkrConidSpec', () => {
+  it('maps asset classes to IBKR security types', () => {
+    expect(resolveIbkrConidSpec('stock')).toBe('STK')
+    expect(resolveIbkrConidSpec('etf')).toBe('STK')
+    expect(resolveIbkrConidSpec('future')).toBe('FUT')
+    expect(resolveIbkrConidSpec('currency')).toBe('CASH')
+    expect(resolveIbkrConidSpec('indice')).toBe('IND')
+    expect(resolveIbkrConidSpec('mutualfund')).toBe('FUND')
+    expect(resolveIbkrConidSpec(undefined)).toBe('STK')
+  })
+})
+
+describe('buildIbkrConidCacheKey', () => {
+  it('builds a normalized cache key', () => {
+    expect(buildIbkrConidCacheKey('aapl', 'stock')).toBe('STK:AAPL')
+    expect(buildIbkrConidCacheKey('ES', 'future')).toBe('FUT:ES')
+  })
+})
+
+describe('resolveIbkrConid', () => {
+  beforeEach(() => {
+    clearIbkrConidCache()
+  })
+
+  it('returns cached conid', () => {
+    cacheIbkrConid('STK:AAPL', 265598)
+    const resolution = resolveIbkrConid({ symbol: 'AAPL', assetClass: 'stock' })
+    expect(resolution).toEqual({ conid: 265598, conidSpec: 'STK' })
+  })
+
+  it('throws when conid is not cached', () => {
+    expect(() => resolveIbkrConid({ symbol: 'AAPL', assetClass: 'stock' })).toThrow(
+      'contract identifier not resolved'
+    )
+  })
+})
+
+describe('resolveIbkrConidFromApi', () => {
+  beforeEach(() => {
+    clearIbkrConidCache()
+  })
+
+  it('uses the cache when seeded', async () => {
+    cacheIbkrConid('STK:MSFT', 272093)
+    const resolution = await resolveIbkrConidFromApi({
+      symbol: 'MSFT',
+      assetClass: 'stock',
+      accessToken: 'token',
+    })
+    expect(resolution.conid).toBe(272093)
+  })
+
+  it('throws without an access token on cache miss', async () => {
+    await expect(resolveIbkrConidFromApi({ symbol: 'AAPL', assetClass: 'stock' })).rejects.toThrow(
+      'access token is required'
+    )
+  })
+})

--- a/apps/tradinggoose/providers/trading/ibkr/symbols.test.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/symbols.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cacheIbkrConid, clearIbkrConidCache } from '@/providers/trading/ibkr/client'
 import {
   buildIbkrConidCacheKey,
@@ -6,6 +6,37 @@ import {
   resolveIbkrConidFromApi,
   resolveIbkrConidSpec,
 } from '@/providers/trading/ibkr/symbols'
+import { fetchBrokerJson } from '@/providers/trading/portfolio-utils'
+
+vi.mock('@/providers/trading/portfolio-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/providers/trading/portfolio-utils')>()
+  return { ...actual, fetchBrokerJson: vi.fn() }
+})
+
+/**
+ * Trimmed from a real POST /iserver/secdef/search response: a BARE ARRAY, the
+ * conid as a string, and the available security types nested under `sections`.
+ */
+const aaplSecDefRows = [
+  {
+    conid: '265598',
+    symbol: 'AAPL',
+    description: 'NASDAQ',
+    sections: [{ secType: 'STK' }, { secType: 'OPT', months: 'SEP26' }, { secType: 'CFD' }],
+  },
+  {
+    conid: '532640894',
+    symbol: 'AAPL',
+    description: 'TSE',
+    sections: [{ secType: 'STK' }],
+  },
+  {
+    conid: '2147483647',
+    symbol: null,
+    description: null,
+    sections: [{ secType: 'BOND' }],
+  },
+]
 
 describe('resolveIbkrConidSpec', () => {
   it('maps asset classes to IBKR security types', () => {
@@ -47,6 +78,11 @@ describe('resolveIbkrConid', () => {
 describe('resolveIbkrConidFromApi', () => {
   beforeEach(() => {
     clearIbkrConidCache()
+    vi.mocked(fetchBrokerJson).mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
   })
 
   it('uses the cache when seeded', async () => {
@@ -59,9 +95,46 @@ describe('resolveIbkrConidFromApi', () => {
     expect(resolution.conid).toBe(272093)
   })
 
-  it('throws without an access token on cache miss', async () => {
+  it('resolves the primary listing from the bare-array response', async () => {
+    vi.stubEnv('IBKR_API_BASE_URL', 'http://host.containers.internal:5002/v1/api')
+    vi.mocked(fetchBrokerJson).mockResolvedValue(aaplSecDefRows as never)
+
+    const resolution = await resolveIbkrConidFromApi({ symbol: 'AAPL', assetClass: 'stock' })
+
+    expect(resolution).toEqual({ conid: 265598, conidSpec: 'STK' })
+    expect(fetchBrokerJson).toHaveBeenCalledTimes(1)
+  })
+
+  it('still accepts a wrapped { contracts } envelope', async () => {
+    vi.stubEnv('IBKR_API_BASE_URL', 'http://host.containers.internal:5002/v1/api')
+    vi.mocked(fetchBrokerJson).mockResolvedValue({
+      contracts: [{ conid: '272093', symbol: 'MSFT', sections: [{ secType: 'STK' }] }],
+    } as never)
+
+    const resolution = await resolveIbkrConidFromApi({ symbol: 'MSFT', assetClass: 'stock' })
+
+    expect(resolution.conid).toBe(272093)
+  })
+
+  it('ignores rows that do not offer the requested asset class', async () => {
+    // The bond row carries no STK section, so a stock lookup must not accept it.
+    vi.stubEnv('IBKR_API_BASE_URL', 'http://host.containers.internal:5002/v1/api')
+    vi.mocked(fetchBrokerJson).mockResolvedValue([
+      { conid: '2147483647', symbol: null, sections: [{ secType: 'BOND' }] },
+    ] as never)
+
     await expect(resolveIbkrConidFromApi({ symbol: 'AAPL', assetClass: 'stock' })).rejects.toThrow(
-      'access token is required'
+      'Unable to resolve IBKR contract identifier'
     )
+  })
+
+  it('requires an access token only against the hosted API', async () => {
+    vi.stubEnv('IBKR_API_BASE_URL', 'https://api.ibkr.com/v1/api')
+
+    await expect(resolveIbkrConidFromApi({ symbol: 'AAPL', assetClass: 'stock' })).rejects.toThrow(
+      'hosted API requires an access token'
+    )
+
+    expect(fetchBrokerJson).not.toHaveBeenCalled()
   })
 })

--- a/apps/tradinggoose/providers/trading/ibkr/symbols.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/symbols.ts
@@ -1,0 +1,125 @@
+import type { AssetClass } from '@/providers/market/types'
+import { buildIbkrAuthHeaders } from '@/providers/trading/ibkr/auth'
+import {
+  buildIbkrApiUrl,
+  cacheIbkrConid,
+  getCachedIbkrConid,
+} from '@/providers/trading/ibkr/client'
+import { fetchBrokerJson } from '@/providers/trading/portfolio-utils'
+
+export interface IbkrConidResolution {
+  conid: number
+  conidSpec: string
+}
+
+const ibkrSpecByAssetClass: Partial<Record<AssetClass, string>> = {
+  stock: 'STK',
+  etf: 'STK',
+  future: 'FUT',
+  currency: 'CASH',
+  indice: 'IND',
+  mutualfund: 'FUND',
+}
+
+export const resolveIbkrConidSpec = (assetClass?: AssetClass | null): string =>
+  (assetClass && ibkrSpecByAssetClass[assetClass]) || 'STK'
+
+export const buildIbkrConidCacheKey = (symbol: string, assetClass?: AssetClass | null): string =>
+  `${resolveIbkrConidSpec(assetClass)}:${symbol.trim().toUpperCase()}`
+
+interface SecDefResponseItem {
+  conid?: number | string
+  secType?: string
+}
+
+/**
+ * Resolve an IBKR contract identifier for a symbol and seed the in-memory
+ * conid cache. Call this ahead of order submission — the shared order pipeline
+ * is synchronous and reads conid values from the cache (see resolveIbkrConid).
+ */
+export async function resolveIbkrConidFromApi({
+  symbol,
+  assetClass,
+  accessToken,
+}: {
+  symbol: string
+  assetClass?: AssetClass | null
+  accessToken?: string
+}): Promise<IbkrConidResolution> {
+  const normalizedSymbol = symbol.trim().toUpperCase()
+  if (!normalizedSymbol) {
+    throw new Error('IBKR order requires a symbol')
+  }
+
+  const conidSpec = resolveIbkrConidSpec(assetClass)
+  const cacheKey = buildIbkrConidCacheKey(normalizedSymbol, assetClass)
+  const cachedConid = getCachedIbkrConid(cacheKey)
+  if (cachedConid !== undefined) {
+    return { conid: cachedConid, conidSpec }
+  }
+
+  if (!accessToken) {
+    throw new Error('IBKR access token is required to resolve contracts')
+  }
+
+  const searchParams = new URLSearchParams({ symbol: normalizedSymbol })
+  if (conidSpec !== 'STK') {
+    searchParams.set('secType', conidSpec)
+  }
+
+  const response = await fetchBrokerJson<{ contracts?: SecDefResponseItem[] }>({
+    providerId: 'ibkr',
+    url: `${buildIbkrApiUrl('/iserver/secdef/search')}?${searchParams.toString()}`,
+    init: {
+      method: 'POST',
+      headers: {
+        ...buildIbkrAuthHeaders({ accessToken }),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ symbol: normalizedSymbol }),
+    },
+  })
+
+  const contract = response?.contracts?.find((candidate) => {
+    if (conidSpec === 'STK') return true
+    return (candidate?.secType ?? '').toUpperCase() === conidSpec
+  })
+
+  const rawConid = contract?.conid
+  const conid = typeof rawConid === 'string' ? Number(rawConid) : rawConid
+  if (typeof conid !== 'number' || !Number.isFinite(conid)) {
+    throw new Error(`Unable to resolve IBKR contract identifier for symbol ${normalizedSymbol}`)
+  }
+
+  cacheIbkrConid(cacheKey, conid)
+  return { conid, conidSpec }
+}
+
+/**
+ * Synchronous conid lookup against the in-memory cache.
+ * See resolveIbkrConidFromApi for how the cache is seeded.
+ */
+export function resolveIbkrConid({
+  symbol,
+  assetClass,
+}: {
+  symbol: string
+  assetClass?: AssetClass | null
+}): IbkrConidResolution {
+  const normalizedSymbol = symbol.trim().toUpperCase()
+  if (!normalizedSymbol) {
+    throw new Error('IBKR order requires a symbol')
+  }
+
+  const conidSpec = resolveIbkrConidSpec(assetClass)
+  const cacheKey = buildIbkrConidCacheKey(normalizedSymbol, assetClass)
+  const cachedConid = getCachedIbkrConid(cacheKey)
+  if (cachedConid !== undefined) {
+    return { conid: cachedConid, conidSpec }
+  }
+
+  throw new Error(
+    `IBKR contract identifier not resolved for symbol ${normalizedSymbol}. ` +
+      'Run resolveIbkrConidFromApi first so the conid cache is seeded for order submission.'
+  )
+}

--- a/apps/tradinggoose/providers/trading/ibkr/symbols.ts
+++ b/apps/tradinggoose/providers/trading/ibkr/symbols.ts
@@ -1,5 +1,5 @@
 import type { AssetClass } from '@/providers/market/types'
-import { buildIbkrAuthHeaders } from '@/providers/trading/ibkr/auth'
+import { buildIbkrAuthHeaders, isIbkrHostedApi } from '@/providers/trading/ibkr/auth'
 import {
   buildIbkrApiUrl,
   cacheIbkrConid,
@@ -27,9 +27,23 @@ export const resolveIbkrConidSpec = (assetClass?: AssetClass | null): string =>
 export const buildIbkrConidCacheKey = (symbol: string, assetClass?: AssetClass | null): string =>
   `${resolveIbkrConidSpec(assetClass)}:${symbol.trim().toUpperCase()}`
 
+interface SecDefSection {
+  secType?: string
+  exchange?: string
+  conid?: string | number
+}
+
+/**
+ * A row of POST /iserver/secdef/search. The endpoint returns a BARE ARRAY of
+ * these (not an object) and nests the available security types under
+ * `sections`, with the conid delivered as a string.
+ */
 interface SecDefResponseItem {
   conid?: number | string
+  symbol?: string | null
+  description?: string | null
   secType?: string
+  sections?: SecDefSection[]
 }
 
 /**
@@ -58,8 +72,12 @@ export async function resolveIbkrConidFromApi({
     return { conid: cachedConid, conidSpec }
   }
 
-  if (!accessToken) {
-    throw new Error('IBKR access token is required to resolve contracts')
+  // The local Client Portal Gateway carries auth in its browser session, so no
+  // token is involved; only the hosted API needs one here. Requiring it
+  // unconditionally is what made gateway market data fail before the request
+  // was even sent.
+  if (isIbkrHostedApi() && !accessToken) {
+    throw new Error('IBKR hosted API requires an access token to resolve contracts')
   }
 
   const searchParams = new URLSearchParams({ symbol: normalizedSymbol })
@@ -67,7 +85,9 @@ export async function resolveIbkrConidFromApi({
     searchParams.set('secType', conidSpec)
   }
 
-  const response = await fetchBrokerJson<{ contracts?: SecDefResponseItem[] }>({
+  const response = await fetchBrokerJson<
+    SecDefResponseItem[] | { contracts?: SecDefResponseItem[] }
+  >({
     providerId: 'ibkr',
     url: `${buildIbkrApiUrl('/iserver/secdef/search')}?${searchParams.toString()}`,
     init: {
@@ -80,10 +100,21 @@ export async function resolveIbkrConidFromApi({
     },
   })
 
-  const contract = response?.contracts?.find((candidate) => {
-    if (conidSpec === 'STK') return true
-    return (candidate?.secType ?? '').toUpperCase() === conidSpec
-  })
+  // The live endpoint answers with a bare array; accept the wrapped shape too
+  // so a future/edge response cannot silently resolve to nothing.
+  const rows = Array.isArray(response) ? response : (response?.contracts ?? [])
+
+  // Sec types live under `sections` on the real payload; the flat `secType`
+  // field is kept for older shapes. A row matching no section is skipped.
+  const matchesRequestedSpec = (row: SecDefResponseItem): boolean => {
+    const sections = Array.isArray(row?.sections) ? row.sections : []
+    if (sections.length === 0) {
+      return (row?.secType ?? '').toUpperCase() === conidSpec
+    }
+    return sections.some((section) => (section?.secType ?? '').toUpperCase() === conidSpec)
+  }
+
+  const contract = rows.find(matchesRequestedSpec)
 
   const rawConid = contract?.conid
   const conid = typeof rawConid === 'string' ? Number(rawConid) : rawConid

--- a/apps/tradinggoose/providers/trading/index.ts
+++ b/apps/tradinggoose/providers/trading/index.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@/lib/logs/console/logger'
 import { alpacaProvider } from '@/providers/trading/alpaca'
+import { ibkrProvider } from '@/providers/trading/ibkr'
 import {
   getTradingProviderDefinition,
   type TradingProviderAdapter,
@@ -18,6 +19,7 @@ const logger = createLogger('TradingProviders')
 
 const providerAdapters: Record<string, TradingProviderAdapter> = {
   alpaca: alpacaProvider,
+  ibkr: ibkrProvider,
   tradier: tradierProvider,
 }
 

--- a/apps/tradinggoose/providers/trading/portfolio.ts
+++ b/apps/tradinggoose/providers/trading/portfolio.ts
@@ -1,6 +1,9 @@
 import { getAlpacaTradingAccounts } from '@/providers/trading/alpaca/accounts'
 import { getAlpacaTradingAccountPerformance } from '@/providers/trading/alpaca/performance'
 import { getAlpacaTradingAccountSnapshot } from '@/providers/trading/alpaca/snapshot'
+import { getIbkrTradingAccounts } from '@/providers/trading/ibkr/accounts'
+import { getIbkrTradingAccountPerformance } from '@/providers/trading/ibkr/performance'
+import { getIbkrTradingAccountSnapshot } from '@/providers/trading/ibkr/snapshot'
 import type { PortfolioDetail, PortfolioIdentity } from '@/providers/trading/portfolio-identity'
 import { getTradingPortfolioDetailCapabilities } from '@/providers/trading/providers'
 import { getTradierTradingAccounts } from '@/providers/trading/tradier/accounts'
@@ -31,6 +34,8 @@ export async function listPortfolioIdentities(
   switch (context.providerId) {
     case 'alpaca':
       return getAlpacaTradingAccounts(context)
+    case 'ibkr':
+      return getIbkrTradingAccounts(context)
     case 'tradier':
       return getTradierTradingAccounts(context)
     default:
@@ -44,6 +49,8 @@ export async function getPortfolioDetail(
   switch (context.providerId) {
     case 'alpaca':
       return getAlpacaTradingAccountSnapshot(context)
+    case 'ibkr':
+      return getIbkrTradingAccountSnapshot(context)
     case 'tradier':
       return getTradierTradingAccountSnapshot(context)
     default:
@@ -57,6 +64,8 @@ export async function getTradingAccountPerformance(
   switch (context.providerId) {
     case 'alpaca':
       return getAlpacaTradingAccountPerformance(context)
+    case 'ibkr':
+      return getIbkrTradingAccountPerformance(context)
     case 'tradier':
       return getTradierTradingAccountPerformance(context)
     default:

--- a/apps/tradinggoose/providers/trading/providers.ts
+++ b/apps/tradinggoose/providers/trading/providers.ts
@@ -5,6 +5,7 @@ import {
   alpacaTradingProviderConfig,
   buildAlpacaOrderDetailSiteUrl,
 } from '@/providers/trading/alpaca/config'
+import { ibkrTradingProviderConfig } from '@/providers/trading/ibkr/config'
 import { tradierTradingProviderConfig } from '@/providers/trading/tradier/config'
 import type {
   TradingAuthType,
@@ -146,6 +147,26 @@ export const TRADING_PROVIDER_DEFINITIONS: Record<string, TradingProviderDefinit
     },
     config: alpacaTradingProviderConfig,
     orderDetailSiteUrl: ({ providerOrderId }) => buildAlpacaOrderDetailSiteUrl(providerOrderId),
+  },
+  ibkr: {
+    id: 'ibkr',
+    name: 'IBKR',
+    description: 'Trading via Interactive Brokers Client Portal Web API.',
+    authType: 'oauth',
+    oauth: {
+      provider: 'ibkr',
+      services: [
+        { serviceId: 'ibkr-live', environment: 'live' },
+        { serviceId: 'ibkr-paper', environment: 'paper' },
+      ],
+      scopes: getCanonicalScopesForProvider('ibkr-live'),
+    },
+    defaults: {
+      orderSizingMode: 'quantity',
+      orderType: 'market',
+      timeInForce: 'day',
+    },
+    config: ibkrTradingProviderConfig,
   },
   tradier: {
     id: 'tradier',

--- a/apps/tradinggoose/socket-server/market/indicator-monitor-runtime.ts
+++ b/apps/tradinggoose/socket-server/market/indicator-monitor-runtime.ts
@@ -718,7 +718,7 @@ export class IndicatorMonitorRuntime {
 
   private async fetchMonitorBars(
     monitor: MonitorRuntimeConfig,
-    auth: { apiKey?: string; apiSecret?: string }
+    auth: { apiKey?: string; apiSecret?: string; accessToken?: string }
   ): Promise<BarMs[]> {
     const result = await executeProviderRequest(monitor.providerId, {
       kind: 'series',

--- a/apps/tradinggoose/socket-server/market/manager.ts
+++ b/apps/tradinggoose/socket-server/market/manager.ts
@@ -59,6 +59,7 @@ export interface MarketSubscribePayload {
   auth?: {
     apiKey?: string
     apiSecret?: string
+    accessToken?: string
   }
   providerParams?: Record<string, any>
 }

--- a/apps/tradinggoose/tools/kronos/forecast.ts
+++ b/apps/tradinggoose/tools/kronos/forecast.ts
@@ -1,0 +1,149 @@
+import type { ToolConfig, ToolResponse } from '@/tools/types'
+
+export interface KronosForecastParams {
+  workspaceId?: string
+  idempotencyKey?: string
+  listing?: unknown
+  marketSeries?: unknown
+  interval?: string
+  timezone?: string
+  normalizationMode?: string
+  horizonBars?: number
+  parameters?: {
+    temperature?: number
+    topP?: number
+    sampleCount?: number
+  }
+}
+
+export interface KronosForecastResponse extends ToolResponse {
+  output: {
+    forecast: Array<{
+      timestamp: string
+      open: number
+      high: number
+      low: number
+      close: number
+      volume: number
+      amount: number
+    }>
+    model: {
+      name: string
+      sourceRevision: string
+      modelRevision: string
+      tokenizerRevision: string
+      device: string
+      maxContext: number
+    }
+    input: {
+      listing: {
+        listingId: string
+        listingType: string
+      }
+      interval: string
+      timezone: string
+      normalizationMode: string
+      barCount: number
+      lastCompletedBarTimestamp: string
+    }
+    parameters: {
+      temperature: number
+      topP: number
+      sampleCount: number
+    }
+    diagnostics: {
+      volumeImputed: boolean
+      amountImputed: boolean
+      candleReconciliationCount: number
+      warnings: string[]
+    }
+    timingMs: {
+      queue: number
+      inference: number
+      total: number
+    }
+  }
+}
+
+export const kronosForecastTool: ToolConfig<KronosForecastParams, KronosForecastResponse> = {
+  id: 'kronos_forecast',
+  name: 'Kronos Forecast',
+  description: 'Generate a Kronos financial market forecast.',
+  version: '1.0.0',
+  execution: {
+    workspace: { required: true, access: 'read' },
+  },
+  params: {
+    listing: {
+      type: 'json',
+      required: true,
+      visibility: 'user-only',
+      description: 'Canonical listing payload from the Historical Data block.',
+    },
+    marketSeries: {
+      type: 'json',
+      required: true,
+      visibility: 'user-only',
+      description: 'Normalized market series from the Historical Data block.',
+    },
+    interval: {
+      type: 'string',
+      required: true,
+      visibility: 'user-or-llm',
+      description: 'Series interval/timeframe (e.g. 5m, 1h, 1d).',
+    },
+    timezone: {
+      type: 'string',
+      required: true,
+      visibility: 'user-or-llm',
+      description: 'IANA timezone for the listing (e.g. America/New_York).',
+    },
+    normalizationMode: {
+      type: 'string',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Normalization mode used when fetching the series.',
+    },
+    horizonBars: {
+      type: 'number',
+      required: true,
+      visibility: 'user-or-llm',
+      description: 'Number of future bars to forecast.',
+    },
+    parameters: {
+      type: 'json',
+      required: false,
+      visibility: 'user-or-llm',
+      description: 'Optional sampling parameters (temperature, topP, sampleCount).',
+    },
+  },
+  request: {
+    url: '/api/providers/kronos/forecast',
+    method: 'POST',
+    headers: () => ({ 'Content-Type': 'application/json' }),
+    body: (params) => ({
+      listing: params.listing,
+      marketSeries: params.marketSeries,
+      interval: params.interval,
+      timezone: params.timezone,
+      normalizationMode: params.normalizationMode,
+      horizonBars: params.horizonBars,
+      parameters: params.parameters,
+    }),
+  },
+  transformResponse: async (response) => {
+    const data = await response.json()
+    return {
+      success: true,
+      output: data,
+    }
+  },
+  outputs: {
+    forecast: { type: 'json', description: 'Forecasted OHLCV points.' },
+    model: { type: 'json', description: 'Model provenance metadata.' },
+    input: { type: 'json', description: 'Input metadata for the forecast.' },
+    parameters: { type: 'json', description: 'Effective sampling parameters.' },
+    diagnostics: { type: 'json', description: 'Forecast diagnostics and warnings.' },
+    timingMs: { type: 'json', description: 'Request timing in milliseconds.' },
+  },
+}

--- a/apps/tradinggoose/tools/kronos/index.ts
+++ b/apps/tradinggoose/tools/kronos/index.ts
@@ -1,0 +1,3 @@
+import { kronosForecastTool } from './forecast'
+
+export { kronosForecastTool }

--- a/apps/tradinggoose/tools/registry.ts
+++ b/apps/tradinggoose/tools/registry.ts
@@ -111,6 +111,7 @@ import {
   queryTool as mongodbQueryTool,
   updateTool as mongodbUpdateTool,
 } from '@/tools/mongodb'
+import { kronosForecastTool } from '@/tools/kronos'
 import {
   deleteTool as mysqlDeleteTool,
   executeTool as mysqlExecuteTool,
@@ -312,6 +313,7 @@ export const tools: Record<string, ToolConfig> = {
   google_search: googleSearchTool,
   guardrails_validate: guardrailsValidateTool,
   jina_read_url: readUrlTool,
+  kronos_forecast: kronosForecastTool,
   linkup_search: linkupSearchTool,
   resend_send: mailSendTool,
   sms_send: smsSendTool,

--- a/apps/tradinggoose/widgets/widgets/data_chart/hooks/use-live-bars.ts
+++ b/apps/tradinggoose/widgets/widgets/data_chart/hooks/use-live-bars.ts
@@ -39,7 +39,7 @@ type UseLiveBarsArgs = {
   listing: ListingIdentity | null
   interval?: string | null
   providerParams?: Record<string, unknown>
-  auth?: { apiKey?: string; apiSecret?: string }
+  auth?: { apiKey?: string; apiSecret?: string; accessToken?: string }
   enabled?: boolean
   candleType?: DataChartCandleType | string
   mainSeriesRef: MutableRefObject<

--- a/services/kronos-inference/.gitignore
+++ b/services/kronos-inference/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.venv/
+.uv/

--- a/services/kronos-inference/Dockerfile
+++ b/services/kronos-inference/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certifi
 ENV PATH="/root/.local/bin:${PATH}"
 
 COPY pyproject.toml uv.lock ./
-RUN uv pip install --system --index-url https://download.pytorch.org/whl/cpu .
+RUN uv pip install --system --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match .
 
 COPY src ./src
 COPY third_party/kronos/model ./third_party/kronos/model

--- a/services/kronos-inference/Dockerfile
+++ b/services/kronos-inference/Dockerfile
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim AS builder
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_NO_CACHE=1 \
+    UV_INDEX_STRATEGY=unsafe-best-match
+
+WORKDIR /build
+
+RUN curl -fsSL https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:${PATH}"
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --no-dev --frozen --index-url https://download.pytorch.org/whl/cpu
+
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PATH="/app/.venv/bin:${PATH}" \
+    HF_HUB_OFFLINE=1 \
+    TORCH_HOME=/models
+
+WORKDIR /app
+
+COPY --from=builder /build/.venv /app/.venv
+COPY src ./src
+COPY third_party/kronos/model ./third_party/kronos/model
+COPY third_party/kronos/LICENSE ./third_party/kronos/LICENSE
+COPY third_party/kronos/UPSTREAM_REVISION ./third_party/kronos/UPSTREAM_REVISION
+
+RUN mkdir -p /models/kronos-base /models/kronos-tokenizer-base \
+ && python -c "from huggingface_hub import snapshot_download; snapshot_download('NeoQuasar/Kronos-base', revision='2b554741eca47781b64468546e77fef3e85130e6', local_dir='/models/kronos-base', local_dir_use_symlinks=False)" \
+ && python -c "from huggingface_hub import snapshot_download; snapshot_download('NeoQuasar/Kronos-Tokenizer-base', revision='0e0117387f39004a9016484a186a908917e22426', local_dir='/models/kronos-tokenizer-base', local_dir_use_symlinks=False)" \
+ && python -c "from model import Kronos, KronosTokenizer, KronosPredictor; import torch; t=KronosTokenizer.from_pretrained('/models/kronos-tokenizer-base'); m=Kronos.from_pretrained('/models/kronos-base'); print('Kronos-base loaded:', sum(p.numel() for p in m.parameters()), 'parameters')" \
+ && apt-get purge -y --auto-remove curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/* /root/.cache
+
+LABEL org.opencontainers.image.title="TradingGoose Kronos Inference" \
+      org.opencontainers.image.description="Private Kronos-base forecasting service for TradingGoose" \
+      kronos.source.revision="67b630e67f6a18c9e9be918d9b4337c960db1e9a" \
+      kronos.model.name="NeoQuasar/Kronos-base" \
+      kronos.model.revision="2b554741eca47781b64468546e77fef3e85130e6" \
+      kronos.tokenizer.revision="0e0117387f39004a9016484a186a908917e22426"
+
+RUN useradd --create-home appuser
+USER appuser
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health/ready')" || exit 1
+
+CMD ["uvicorn", "kronos_api.main:create_app", "--host", "0.0.0.0", "--port", "8000", "--factory"]

--- a/services/kronos-inference/Dockerfile
+++ b/services/kronos-inference/Dockerfile
@@ -1,12 +1,16 @@
 # syntax=docker/dockerfile:1
-FROM python:3.11-slim AS builder
+FROM python:3.11-slim
 
-ENV UV_COMPILE_BYTECODE=1 \
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
     UV_NO_CACHE=1 \
-    UV_INDEX_STRATEGY=unsafe-best-match
+    UV_INDEX_STRATEGY=unsafe-best-match \
+    HF_HUB_OFFLINE=1 \
+    TORCH_HOME=/models
 
-WORKDIR /build
+WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && \
     curl -fsSL https://astral.sh/uv/install.sh | sh && \
@@ -15,19 +19,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certifi
 ENV PATH="/root/.local/bin:${PATH}"
 
 COPY pyproject.toml uv.lock ./
-RUN uv sync --no-dev --frozen --index-url https://download.pytorch.org/whl/cpu
+RUN uv pip install --system --no-dev --frozen --index-url https://download.pytorch.org/whl/cpu
 
-FROM python:3.11-slim
-
-ENV PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1 \
-    PATH="/app/.venv/bin:${PATH}" \
-    HF_HUB_OFFLINE=1 \
-    TORCH_HOME=/models
-
-WORKDIR /app
-
-COPY --from=builder /build/.venv /app/.venv
 COPY src ./src
 COPY third_party/kronos/model ./third_party/kronos/model
 COPY third_party/kronos/LICENSE ./third_party/kronos/LICENSE

--- a/services/kronos-inference/Dockerfile
+++ b/services/kronos-inference/Dockerfile
@@ -37,9 +37,6 @@ COPY third_party/kronos/UPSTREAM_REVISION ./third_party/kronos/UPSTREAM_REVISION
 COPY models/kronos-base /models/kronos-base
 COPY models/kronos-tokenizer-base /models/kronos-tokenizer-base
 
-RUN python -c "from model import Kronos, KronosTokenizer, KronosPredictor; import torch; t=KronosTokenizer.from_pretrained('/models/kronos-tokenizer-base'); m=Kronos.from_pretrained('/models/kronos-base'); print('Kronos-base loaded:', sum(p.numel() for p in m.parameters()), 'parameters')" \
- && rm -rf /root/.cache
-
 LABEL org.opencontainers.image.title="TradingGoose Kronos Inference" \
       org.opencontainers.image.description="Private Kronos-base forecasting service for TradingGoose" \
       kronos.source.revision="67b630e67f6a18c9e9be918d9b4337c960db1e9a" \

--- a/services/kronos-inference/Dockerfile
+++ b/services/kronos-inference/Dockerfile
@@ -8,7 +8,10 @@ ENV UV_COMPILE_BYTECODE=1 \
 
 WORKDIR /build
 
-RUN curl -fsSL https://astral.sh/uv/install.sh | sh
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && \
+    curl -fsSL https://astral.sh/uv/install.sh | sh && \
+    apt-get purge -y --auto-remove curl ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 ENV PATH="/root/.local/bin:${PATH}"
 
 COPY pyproject.toml uv.lock ./
@@ -34,8 +37,7 @@ RUN mkdir -p /models/kronos-base /models/kronos-tokenizer-base \
  && python -c "from huggingface_hub import snapshot_download; snapshot_download('NeoQuasar/Kronos-base', revision='2b554741eca47781b64468546e77fef3e85130e6', local_dir='/models/kronos-base', local_dir_use_symlinks=False)" \
  && python -c "from huggingface_hub import snapshot_download; snapshot_download('NeoQuasar/Kronos-Tokenizer-base', revision='0e0117387f39004a9016484a186a908917e22426', local_dir='/models/kronos-tokenizer-base', local_dir_use_symlinks=False)" \
  && python -c "from model import Kronos, KronosTokenizer, KronosPredictor; import torch; t=KronosTokenizer.from_pretrained('/models/kronos-tokenizer-base'); m=Kronos.from_pretrained('/models/kronos-base'); print('Kronos-base loaded:', sum(p.numel() for p in m.parameters()), 'parameters')" \
- && apt-get purge -y --auto-remove curl ca-certificates \
- && rm -rf /var/lib/apt/lists/* /root/.cache
+ && rm -rf /root/.cache
 
 LABEL org.opencontainers.image.title="TradingGoose Kronos Inference" \
       org.opencontainers.image.description="Private Kronos-base forecasting service for TradingGoose" \

--- a/services/kronos-inference/Dockerfile
+++ b/services/kronos-inference/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certifi
 ENV PATH="/root/.local/bin:${PATH}"
 
 COPY pyproject.toml uv.lock ./
-RUN uv pip install --system --no-dev --frozen --index-url https://download.pytorch.org/whl/cpu
+RUN uv pip install --system --index-url https://download.pytorch.org/whl/cpu .
 
 COPY src ./src
 COPY third_party/kronos/model ./third_party/kronos/model

--- a/services/kronos-inference/Dockerfile
+++ b/services/kronos-inference/Dockerfile
@@ -6,7 +6,6 @@ ENV PYTHONUNBUFFERED=1 \
     UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
     UV_NO_CACHE=1 \
-    UV_INDEX_STRATEGY=unsafe-best-match \
     HF_HUB_OFFLINE=1 \
     TORCH_HOME=/models
 
@@ -17,9 +16,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certifi
     apt-get purge -y --auto-remove curl ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 ENV PATH="/root/.local/bin:${PATH}"
+ENV PYTHONPATH="/app/src:/app/third_party/kronos"
 
 COPY pyproject.toml uv.lock ./
-RUN uv pip install --system --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match .
+RUN uv pip install --system --index https://download.pytorch.org/whl/cpu --default-index https://pypi.org/simple .
 
 COPY src ./src
 COPY third_party/kronos/model ./third_party/kronos/model

--- a/services/kronos-inference/Dockerfile
+++ b/services/kronos-inference/Dockerfile
@@ -33,10 +33,11 @@ COPY third_party/kronos/model ./third_party/kronos/model
 COPY third_party/kronos/LICENSE ./third_party/kronos/LICENSE
 COPY third_party/kronos/UPSTREAM_REVISION ./third_party/kronos/UPSTREAM_REVISION
 
-RUN mkdir -p /models/kronos-base /models/kronos-tokenizer-base \
- && python -c "from huggingface_hub import snapshot_download; snapshot_download('NeoQuasar/Kronos-base', revision='2b554741eca47781b64468546e77fef3e85130e6', local_dir='/models/kronos-base', local_dir_use_symlinks=False)" \
- && python -c "from huggingface_hub import snapshot_download; snapshot_download('NeoQuasar/Kronos-Tokenizer-base', revision='0e0117387f39004a9016484a186a908917e22426', local_dir='/models/kronos-tokenizer-base', local_dir_use_symlinks=False)" \
- && python -c "from model import Kronos, KronosTokenizer, KronosPredictor; import torch; t=KronosTokenizer.from_pretrained('/models/kronos-tokenizer-base'); m=Kronos.from_pretrained('/models/kronos-base'); print('Kronos-base loaded:', sum(p.numel() for p in m.parameters()), 'parameters')" \
+# Copy model weights from local cache (pre-downloaded by setup script)
+COPY models/kronos-base /models/kronos-base
+COPY models/kronos-tokenizer-base /models/kronos-tokenizer-base
+
+RUN python -c "from model import Kronos, KronosTokenizer, KronosPredictor; import torch; t=KronosTokenizer.from_pretrained('/models/kronos-tokenizer-base'); m=Kronos.from_pretrained('/models/kronos-base'); print('Kronos-base loaded:', sum(p.numel() for p in m.parameters()), 'parameters')" \
  && rm -rf /root/.cache
 
 LABEL org.opencontainers.image.title="TradingGoose Kronos Inference" \

--- a/services/kronos-inference/pyproject.toml
+++ b/services/kronos-inference/pyproject.toml
@@ -21,16 +21,6 @@ dev = [
   "pytest>=8.4,<10",
 ]
 
-[[tool.uv.index]]
-name = "pytorch-cpu"
-url = "https://download.pytorch.org/whl/cpu"
-explicit = true
-
-[tool.uv.sources]
-torch = [
-  { index = "pytorch-cpu", marker = "sys_platform == 'linux'" },
-]
-
 [tool.pytest.ini_options]
 addopts = "-q"
 pythonpath = ["src", "third_party/kronos"]

--- a/services/kronos-inference/pyproject.toml
+++ b/services/kronos-inference/pyproject.toml
@@ -1,0 +1,37 @@
+[project]
+name = "tradinggoose-kronos-inference"
+version = "0.1.0"
+description = "Private Kronos forecasting service for TradingGoose"
+requires-python = ">=3.11,<3.13"
+dependencies = [
+  "einops==0.8.1",
+  "fastapi>=0.116,<1",
+  "huggingface-hub>=0.33,<2",
+  "numpy>=2.0,<3",
+  "pandas>=2.2,<3",
+  "pydantic-settings>=2.10,<3",
+  "safetensors>=0.6,<1",
+  "torch>=2.6,<3",
+  "uvicorn>=0.35,<1",
+]
+
+[dependency-groups]
+dev = [
+  "httpx>=0.28,<1",
+  "pytest>=8.4,<10",
+]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
+
+[tool.uv.sources]
+torch = [
+  { index = "pytorch-cpu", marker = "sys_platform == 'linux'" },
+]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+pythonpath = ["src", "third_party/kronos"]
+testpaths = ["tests"]

--- a/services/kronos-inference/src/kronos_api/__init__.py
+++ b/services/kronos-inference/src/kronos_api/__init__.py
@@ -1,0 +1,1 @@
+"""TradingGoose Kronos inference service."""

--- a/services/kronos-inference/src/kronos_api/config.py
+++ b/services/kronos-inference/src/kronos_api/config.py
@@ -1,0 +1,19 @@
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="KRONOS_", extra="ignore")
+
+    api_token: str = Field(min_length=32)
+    model_path: str = "/models/kronos-base"
+    tokenizer_path: str = "/models/kronos-tokenizer-base"
+    model_name: str = "NeoQuasar/Kronos-base"
+    model_revision: str = "2b554741eca47781b64468546e77fef3e85130e6"
+    tokenizer_revision: str = "0e0117387f39004a9016484a186a908917e22426"
+    source_revision: str = "67b630e67f6a18c9e9be918d9b4337c960db1e9a"
+    device: str = "cpu"
+    max_context: int = Field(default=512, ge=32, le=2048)
+    max_queue: int = Field(default=8, ge=0, le=64)
+    inference_concurrency: int = Field(default=1, ge=1, le=4)
+    warmup: bool = True

--- a/services/kronos-inference/src/kronos_api/main.py
+++ b/services/kronos-inference/src/kronos_api/main.py
@@ -1,0 +1,161 @@
+import asyncio
+import hmac
+from contextlib import asynccontextmanager
+from time import perf_counter
+from typing import Any
+
+from fastapi import Depends, FastAPI, Header, HTTPException
+from fastapi.concurrency import run_in_threadpool
+
+from kronos_api.config import Settings
+from kronos_api.runtime import KronosRuntime
+from kronos_api.schemas import (
+    ForecastDiagnostics,
+    ForecastInputMetadata,
+    ForecastPoint,
+    ForecastRequest,
+    ForecastResponse,
+    ForecastTiming,
+    ModelMetadata,
+)
+
+
+class QueueFullError(RuntimeError):
+    pass
+
+
+class InferenceGate:
+    def __init__(self, concurrency: int, max_queue: int):
+        self._semaphore = asyncio.Semaphore(concurrency)
+        self._max_queue = max_queue
+        self._waiting = 0
+        self._counter_lock = asyncio.Lock()
+
+    @asynccontextmanager
+    async def enter(self):
+        queued = self._semaphore.locked()
+        if queued:
+            async with self._counter_lock:
+                if self._waiting >= self._max_queue:
+                    raise QueueFullError("Kronos inference queue is full")
+                self._waiting += 1
+        started = perf_counter()
+        try:
+            await self._semaphore.acquire()
+            yield (perf_counter() - started) * 1000
+        finally:
+            if queued:
+                async with self._counter_lock:
+                    self._waiting -= 1
+            if self._semaphore.locked():
+                self._semaphore.release()
+
+
+def reconcile_points(raw_points: list[dict[str, Any]]) -> tuple[list[ForecastPoint], int]:
+    points: list[ForecastPoint] = []
+    reconciled = 0
+    for raw in raw_points:
+        point = ForecastPoint.model_validate(raw)
+        high = max(point.high, point.open, point.close)
+        low = min(point.low, point.open, point.close)
+        if high != point.high or low != point.low:
+            reconciled += 1
+            point = point.model_copy(update={"high": high, "low": low})
+        if min(point.open, point.high, point.low, point.close) <= 0:
+            raise ValueError("Kronos returned non-positive forecast prices")
+        points.append(point)
+    return points, reconciled
+
+
+def create_app(settings: Settings | None = None, runtime: Any | None = None) -> FastAPI:
+    configured = settings or Settings()
+    model_runtime = runtime or KronosRuntime(configured)
+    gate = InferenceGate(configured.inference_concurrency, configured.max_queue)
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI):
+        if runtime is None:
+            await run_in_threadpool(model_runtime.load)
+        yield
+
+    app = FastAPI(
+        title="TradingGoose Kronos Inference",
+        version="0.1.0",
+        docs_url=None,
+        redoc_url=None,
+        lifespan=lifespan,
+    )
+
+    def authorize(authorization: str | None = Header(default=None)) -> None:
+        expected = f"Bearer {configured.api_token}"
+        if authorization is None or not hmac.compare_digest(authorization, expected):
+            raise HTTPException(status_code=401, detail="Unauthorized")
+
+    @app.get("/health/live")
+    async def live():
+        return {"status": "alive"}
+
+    @app.get("/health/ready")
+    async def ready():
+        if not model_runtime.ready:
+            raise HTTPException(status_code=503, detail="Kronos model is not ready")
+        return {"status": "ready", "model": model_runtime.metadata}
+
+    @app.post("/v1/forecast", response_model=ForecastResponse)
+    async def forecast(request: ForecastRequest, _authorized: None = Depends(authorize)):
+        if not model_runtime.ready:
+            raise HTTPException(status_code=503, detail="Kronos model is not ready")
+
+        total_started = perf_counter()
+        try:
+            async with gate.enter() as queue_ms:
+                inference_started = perf_counter()
+                raw_points = await run_in_threadpool(model_runtime.predict, request)
+                inference_ms = (perf_counter() - inference_started) * 1000
+        except QueueFullError as error:
+            raise HTTPException(status_code=429, detail=str(error)) from error
+        except Exception as error:
+            raise HTTPException(status_code=502, detail="Kronos inference failed") from error
+
+        try:
+            points, reconciliation_count = reconcile_points(raw_points)
+        except (ValueError, TypeError) as error:
+            raise HTTPException(status_code=502, detail="Kronos returned invalid forecast data") from error
+        if len(points) != len(request.future_timestamps):
+            raise HTTPException(status_code=502, detail="Kronos returned an unexpected forecast length")
+
+        warnings: list[str] = []
+        volume_imputed = request.history[0].volume is None
+        amount_imputed = request.history[0].amount is None
+        if volume_imputed:
+            warnings.append("volume_imputed")
+        if reconciliation_count:
+            warnings.append("forecast_candles_reconciled")
+
+        return ForecastResponse(
+            request_id=request.request_id,
+            forecast=points,
+            model=ModelMetadata.model_validate(model_runtime.metadata),
+            input=ForecastInputMetadata(
+                listing=request.listing,
+                interval=request.interval,
+                timezone=request.timezone,
+                normalization_mode=request.normalization_mode,
+                bar_count=len(request.history),
+                last_completed_bar_timestamp=request.history[-1].timestamp,
+            ),
+            parameters=request.parameters,
+            diagnostics=ForecastDiagnostics(
+                volume_imputed=volume_imputed,
+                amount_imputed=amount_imputed,
+                candle_reconciliation_count=reconciliation_count,
+                warnings=warnings,
+            ),
+            timing_ms=ForecastTiming(
+                queue=queue_ms,
+                inference=inference_ms,
+                total=(perf_counter() - total_started) * 1000,
+            ),
+        )
+
+    return app

--- a/services/kronos-inference/src/kronos_api/runtime.py
+++ b/services/kronos-inference/src/kronos_api/runtime.py
@@ -1,0 +1,114 @@
+import math
+from typing import Any
+
+import pandas as pd
+
+from kronos_api.config import Settings
+from kronos_api.schemas import ForecastRequest
+
+
+class KronosRuntime:
+    def __init__(self, settings: Settings):
+        self.settings = settings
+        self.ready = False
+        self._predictor = None
+        self.metadata = {
+            "name": settings.model_name,
+            "sourceRevision": settings.source_revision,
+            "modelRevision": settings.model_revision,
+            "tokenizerRevision": settings.tokenizer_revision,
+            "device": settings.device,
+            "maxContext": settings.max_context,
+        }
+
+    def load(self) -> None:
+        from model import Kronos, KronosPredictor, KronosTokenizer
+
+        tokenizer = KronosTokenizer.from_pretrained(self.settings.tokenizer_path)
+        model = Kronos.from_pretrained(self.settings.model_path)
+        tokenizer.eval()
+        model.eval()
+        self._predictor = KronosPredictor(
+            model,
+            tokenizer,
+            device=self.settings.device,
+            max_context=self.settings.max_context,
+        )
+        if self.settings.warmup:
+            self._warmup()
+        self.ready = True
+
+    def _warmup(self) -> None:
+        start = pd.Timestamp("2026-01-02T09:30:00", tz="America/New_York")
+        timestamps = pd.Series(pd.date_range(start=start, periods=32, freq="5min"))
+        future = pd.Series([timestamps.iloc[-1] + pd.Timedelta(minutes=5)])
+        values = [100.0 + index * 0.1 for index in range(32)]
+        frame = pd.DataFrame(
+            {
+                "open": values,
+                "high": [value + 0.2 for value in values],
+                "low": [value - 0.2 for value in values],
+                "close": [value + 0.1 for value in values],
+                "volume": [1000.0] * 32,
+            }
+        )
+        self._predictor.predict(
+            df=frame,
+            x_timestamp=timestamps,
+            y_timestamp=future,
+            pred_len=1,
+            T=1.0,
+            top_p=0.9,
+            sample_count=1,
+            verbose=False,
+        )
+
+    def predict(self, request: ForecastRequest) -> list[dict[str, Any]]:
+        if not self.ready or self._predictor is None:
+            raise RuntimeError("Kronos model is not ready")
+
+        records: dict[str, list[float]] = {
+            "open": [bar.open for bar in request.history],
+            "high": [bar.high for bar in request.history],
+            "low": [bar.low for bar in request.history],
+            "close": [bar.close for bar in request.history],
+        }
+        if request.history[0].volume is not None:
+            records["volume"] = [float(bar.volume) for bar in request.history]
+        if request.history[0].amount is not None:
+            records["amount"] = [float(bar.amount) for bar in request.history]
+
+        frame = pd.DataFrame(records)
+        historical = pd.Series(pd.to_datetime([bar.timestamp for bar in request.history], utc=True))
+        future = pd.Series(pd.to_datetime(request.future_timestamps, utc=True))
+        historical_local = historical.dt.tz_convert(request.timezone)
+        future_local = future.dt.tz_convert(request.timezone)
+
+        predicted = self._predictor.predict(
+            df=frame,
+            x_timestamp=historical_local,
+            y_timestamp=future_local,
+            pred_len=len(future_local),
+            T=request.parameters.temperature,
+            top_p=request.parameters.top_p,
+            sample_count=request.parameters.sample_count,
+            verbose=False,
+        )
+
+        points: list[dict[str, Any]] = []
+        for timestamp, row in zip(future, predicted.itertuples(index=False)):
+            values = [row.open, row.high, row.low, row.close, row.volume, row.amount]
+            if not all(math.isfinite(float(value)) for value in values):
+                raise RuntimeError("Kronos returned non-finite forecast values")
+            points.append(
+                {
+                    "timestamp": timestamp.to_pydatetime(),
+                    "open": float(row.open),
+                    "high": float(row.high),
+                    "low": float(row.low),
+                    "close": float(row.close),
+                    "volume": max(0.0, float(row.volume)),
+                    "amount": max(0.0, float(row.amount)),
+                }
+            )
+        return points

--- a/services/kronos-inference/src/kronos_api/schemas.py
+++ b/services/kronos-inference/src/kronos_api/schemas.py
@@ -1,0 +1,164 @@
+import math
+from datetime import datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+def to_camel(value: str) -> str:
+    head, *tail = value.split("_")
+    return head + "".join(part.capitalize() for part in tail)
+
+
+class ApiModel(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+
+class ListingIdentity(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    listing_id: str = Field(min_length=1, max_length=255)
+    listing_type: str = Field(min_length=1, max_length=64)
+
+
+class MarketBar(ApiModel):
+    timestamp: datetime
+    open: float = Field(gt=0)
+    high: float = Field(gt=0)
+    low: float = Field(gt=0)
+    close: float = Field(gt=0)
+    volume: float | None = Field(default=None, ge=0)
+    amount: float | None = Field(default=None, ge=0)
+
+    @field_validator("timestamp")
+    @classmethod
+    def timestamp_must_have_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("timestamp must include a timezone offset")
+        return value
+
+    @field_validator("open", "high", "low", "close", "volume", "amount")
+    @classmethod
+    def number_must_be_finite(cls, value: float | None) -> float | None:
+        if value is not None and not math.isfinite(value):
+            raise ValueError("market values must be finite")
+        return value
+
+    @model_validator(mode="after")
+    def validate_candle(self):
+        if self.high < max(self.open, self.close):
+            raise ValueError("high must be greater than or equal to open and close")
+        if self.low > min(self.open, self.close):
+            raise ValueError("low must be less than or equal to open and close")
+        if self.low > self.high:
+            raise ValueError("low must not exceed high")
+        return self
+
+
+class ForecastParameters(ApiModel):
+    temperature: float = Field(default=1.0, gt=0, le=5)
+    top_p: float = Field(default=0.9, gt=0, le=1)
+    sample_count: int = Field(default=1, ge=1, le=1)
+
+
+class ForecastRequest(ApiModel):
+    request_id: str = Field(min_length=1, max_length=255)
+    listing: ListingIdentity
+    interval: str = Field(min_length=1, max_length=16)
+    timezone: str = Field(min_length=1, max_length=64)
+    normalization_mode: str = Field(default="raw", min_length=1, max_length=32)
+    history: list[MarketBar] = Field(min_length=32, max_length=512)
+    future_timestamps: list[datetime] = Field(min_length=1, max_length=32)
+    parameters: ForecastParameters = Field(default_factory=ForecastParameters)
+
+    @field_validator("timezone")
+    @classmethod
+    def timezone_must_exist(cls, value: str) -> str:
+        try:
+            ZoneInfo(value)
+        except ZoneInfoNotFoundError as error:
+            raise ValueError("timezone must be a valid IANA timezone") from error
+        return value
+
+    @field_validator("future_timestamps")
+    @classmethod
+    def future_timestamps_need_offsets(cls, values: list[datetime]) -> list[datetime]:
+        if any(value.tzinfo is None or value.utcoffset() is None for value in values):
+            raise ValueError("future timestamps must include timezone offsets")
+        return values
+
+    @model_validator(mode="after")
+    def timestamps_must_be_ordered(self):
+        history = [bar.timestamp for bar in self.history]
+        if any(current <= previous for previous, current in zip(history, history[1:])):
+            raise ValueError("historical timestamps must be strictly increasing")
+        if any(
+            current <= previous
+            for previous, current in zip(self.future_timestamps, self.future_timestamps[1:])
+        ):
+            raise ValueError("future timestamps must be strictly increasing")
+        if self.future_timestamps[0] <= history[-1]:
+            raise ValueError("future timestamps must be after the final historical timestamp")
+
+        has_volume = [bar.volume is not None for bar in self.history]
+        has_amount = [bar.amount is not None for bar in self.history]
+        if any(has_volume) and not all(has_volume):
+            raise ValueError("volume must be present for every bar or omitted for every bar")
+        if any(has_amount) and not all(has_amount):
+            raise ValueError("amount must be present for every bar or omitted for every bar")
+        return self
+
+
+class ForecastPoint(ApiModel):
+    timestamp: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+    amount: float
+
+
+class ModelMetadata(ApiModel):
+    name: str
+    source_revision: str
+    model_revision: str
+    tokenizer_revision: str
+    device: str
+    max_context: int
+
+
+class ForecastInputMetadata(ApiModel):
+    listing: ListingIdentity
+    interval: str
+    timezone: str
+    normalization_mode: str
+    bar_count: int
+    last_completed_bar_timestamp: datetime
+
+
+class ForecastDiagnostics(ApiModel):
+    volume_imputed: bool
+    amount_imputed: bool
+    candle_reconciliation_count: int
+    warnings: list[str]
+
+
+class ForecastTiming(ApiModel):
+    queue: float
+    inference: float
+    total: float
+
+
+class ForecastResponse(ApiModel):
+    request_id: str
+    forecast: list[ForecastPoint]
+    model: ModelMetadata
+    input: ForecastInputMetadata
+    parameters: ForecastParameters
+    diagnostics: ForecastDiagnostics
+    timing_ms: ForecastTiming

--- a/services/kronos-inference/tests/test_api.py
+++ b/services/kronos-inference/tests/test_api.py
@@ -1,0 +1,154 @@
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from kronos_api.config import Settings
+from kronos_api.main import create_app
+
+
+TOKEN = "test-token-that-is-at-least-thirty-two-characters"
+
+
+class FakeRuntime:
+    ready = True
+    metadata = {
+        "name": "NeoQuasar/Kronos-base",
+        "sourceRevision": "source-revision",
+        "modelRevision": "model-revision",
+        "tokenizerRevision": "tokenizer-revision",
+        "device": "cpu",
+        "maxContext": 512,
+    }
+
+    def predict(self, request):
+        close = request.history[-1].close
+        return [
+            {
+                "timestamp": timestamp,
+                "open": close,
+                "high": close + 1,
+                "low": close - 1,
+                "close": close + 0.5,
+                "volume": 100.0,
+                "amount": 10_000.0,
+            }
+            for timestamp in request.future_timestamps
+        ]
+
+
+def settings() -> Settings:
+    return Settings(
+        api_token=TOKEN,
+        model_path="/models/kronos-base",
+        tokenizer_path="/models/kronos-tokenizer-base",
+    )
+
+
+def bars(count: int = 32):
+    start = datetime(2026, 1, 2, 14, 30, tzinfo=timezone.utc)
+    return [
+        {
+            "timestamp": (start + timedelta(minutes=5 * i)).isoformat(),
+            "open": 100 + i,
+            "high": 102 + i,
+            "low": 99 + i,
+            "close": 101 + i,
+            "volume": 1000 + i,
+        }
+        for i in range(count)
+    ]
+
+
+def valid_request():
+    history = bars()
+    last = datetime.fromisoformat(history[-1]["timestamp"])
+    return {
+        "requestId": "workflow-1:block-1:execution-1",
+        "listing": {"listing_id": "listing-1", "listing_type": "stock"},
+        "interval": "5m",
+        "timezone": "America/New_York",
+        "normalizationMode": "raw",
+        "history": history,
+        "futureTimestamps": [
+            (last + timedelta(minutes=5 * i)).isoformat() for i in range(1, 4)
+        ],
+        "parameters": {"temperature": 1.0, "topP": 0.9, "sampleCount": 1},
+    }
+
+
+def client(runtime=None):
+    return TestClient(create_app(settings=settings(), runtime=runtime or FakeRuntime()))
+
+
+def test_liveness_and_readiness_expose_pinned_model_metadata():
+    with client() as test_client:
+        live = test_client.get("/health/live")
+        ready = test_client.get("/health/ready")
+
+    assert live.status_code == 200
+    assert live.json() == {"status": "alive"}
+    assert ready.status_code == 200
+    assert ready.json()["status"] == "ready"
+    assert ready.json()["model"]["name"] == "NeoQuasar/Kronos-base"
+
+
+def test_forecast_requires_the_internal_bearer_token():
+    with client() as test_client:
+        response = test_client.post("/v1/forecast", json=valid_request())
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Unauthorized"}
+
+
+def test_forecast_rejects_invalid_historical_candles():
+    request = valid_request()
+    request["history"][-1]["high"] = request["history"][-1]["close"] - 1
+
+    with client() as test_client:
+        response = test_client.post(
+            "/v1/forecast",
+            headers={"Authorization": f"Bearer {TOKEN}"},
+            json=request,
+        )
+
+    assert response.status_code == 422
+
+
+def test_forecast_returns_validated_points_and_provenance():
+    with client() as test_client:
+        response = test_client.post(
+            "/v1/forecast",
+            headers={"Authorization": f"Bearer {TOKEN}"},
+            json=valid_request(),
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["requestId"] == "workflow-1:block-1:execution-1"
+    assert len(payload["forecast"]) == 3
+    assert payload["model"]["modelRevision"] == "model-revision"
+    assert payload["input"]["barCount"] == 32
+    assert payload["input"]["timezone"] == "America/New_York"
+    assert payload["diagnostics"] == {
+        "amountImputed": True,
+        "candleReconciliationCount": 0,
+        "volumeImputed": False,
+        "warnings": [],
+    }
+    assert payload["timingMs"]["total"] >= 0
+
+
+def test_not_ready_service_fails_closed():
+    runtime = FakeRuntime()
+    runtime.ready = False
+
+    with client(runtime) as test_client:
+        ready = test_client.get("/health/ready")
+        forecast = test_client.post(
+            "/v1/forecast",
+            headers={"Authorization": f"Bearer {TOKEN}"},
+            json=valid_request(),
+        )
+
+    assert ready.status_code == 503
+    assert forecast.status_code == 503

--- a/services/kronos-inference/tests/test_container_packaging.py
+++ b/services/kronos-inference/tests/test_container_packaging.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+DOCKERFILE = Path(__file__).parents[1] / "Dockerfile"
+
+
+def test_runtime_pythonpath_includes_app_and_vendored_model() -> None:
+    text = DOCKERFILE.read_text()
+    pythonpath_line = next(
+        line for line in text.splitlines() if line.startswith("ENV PYTHONPATH=")
+    )
+
+    assert "/app/src" in pythonpath_line
+    assert "/app/third_party/kronos" in pythonpath_line
+
+
+def test_cpu_pytorch_index_has_priority_without_unsafe_resolution() -> None:
+    text = DOCKERFILE.read_text()
+    install_line = next(
+        line for line in text.splitlines() if line.startswith("RUN uv pip install")
+    )
+
+    assert "--index https://download.pytorch.org/whl/cpu" in install_line
+    assert "--default-index https://pypi.org/simple" in install_line
+    assert "unsafe-best-match" not in text

--- a/services/kronos-inference/tests/test_schemas.py
+++ b/services/kronos-inference/tests/test_schemas.py
@@ -1,0 +1,56 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from kronos_api.schemas import ForecastRequest
+
+
+def request_data():
+    start = datetime(2026, 1, 2, 14, 30, tzinfo=timezone.utc)
+    history = []
+    for i in range(32):
+        history.append(
+            {
+                "timestamp": (start + timedelta(minutes=5 * i)).isoformat(),
+                "open": 100 + i,
+                "high": 102 + i,
+                "low": 99 + i,
+                "close": 101 + i,
+                "volume": 1000 + i,
+            }
+        )
+    return {
+        "requestId": "request-1",
+        "listing": {"listing_id": "listing-1", "listing_type": "stock"},
+        "interval": "5m",
+        "timezone": "America/New_York",
+        "normalizationMode": "raw",
+        "history": history,
+        "futureTimestamps": [
+            (start + timedelta(minutes=5 * (32 + i))).isoformat() for i in range(3)
+        ],
+    }
+
+
+def test_request_rejects_duplicate_timestamps():
+    data = request_data()
+    data["history"][-1]["timestamp"] = data["history"][-2]["timestamp"]
+
+    with pytest.raises(ValueError, match="strictly increasing"):
+        ForecastRequest.model_validate(data)
+
+
+def test_request_rejects_future_timestamp_before_last_bar():
+    data = request_data()
+    data["futureTimestamps"][0] = data["history"][-1]["timestamp"]
+
+    with pytest.raises(ValueError, match="after the final historical timestamp"):
+        ForecastRequest.model_validate(data)
+
+
+def test_request_rejects_unknown_fields():
+    data = request_data()
+    data["modelUrl"] = "http://attacker.invalid/model"
+
+    with pytest.raises(ValueError):
+        ForecastRequest.model_validate(data)

--- a/services/kronos-inference/third_party/kronos/LICENSE
+++ b/services/kronos-inference/third_party/kronos/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 ShiYu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/services/kronos-inference/third_party/kronos/UPSTREAM_REVISION
+++ b/services/kronos-inference/third_party/kronos/UPSTREAM_REVISION
@@ -1,0 +1,2 @@
+source=https://github.com/shiyu-coder/Kronos
+revision=67b630e67f6a18c9e9be918d9b4337c960db1e9a

--- a/services/kronos-inference/third_party/kronos/model/__init__.py
+++ b/services/kronos-inference/third_party/kronos/model/__init__.py
@@ -1,0 +1,17 @@
+from .kronos import KronosTokenizer, Kronos, KronosPredictor
+
+model_dict = {
+    'kronos_tokenizer': KronosTokenizer,
+    'kronos': Kronos,
+    'kronos_predictor': KronosPredictor
+}
+
+
+def get_model_class(model_name):
+    if model_name in model_dict:
+        return model_dict[model_name]
+    else:
+        print(f"Model {model_name} not found in model_dict")
+        raise NotImplementedError
+
+

--- a/services/kronos-inference/third_party/kronos/model/kronos.py
+++ b/services/kronos-inference/third_party/kronos/model/kronos.py
@@ -1,0 +1,662 @@
+import numpy as np
+import pandas as pd
+import torch
+from huggingface_hub import PyTorchModelHubMixin
+import sys
+
+from tqdm import trange
+
+sys.path.append("../")
+from model.module import *
+
+
+class KronosTokenizer(nn.Module, PyTorchModelHubMixin):
+    """
+    KronosTokenizer module for tokenizing input data using a hybrid quantization approach.
+
+    This tokenizer utilizes a combination of encoder and decoder Transformer blocks
+    along with the Binary Spherical Quantization (BSQuantizer) to compress and decompress input data.
+
+    Args:
+           d_in (int): Input dimension.
+           d_model (int): Model dimension.
+           n_heads (int): Number of attention heads.
+           ff_dim (int): Feed-forward dimension.
+           n_enc_layers (int): Number of encoder layers.
+           n_dec_layers (int): Number of decoder layers.
+           ffn_dropout_p (float): Dropout probability for feed-forward networks.
+           attn_dropout_p (float): Dropout probability for attention mechanisms.
+           resid_dropout_p (float): Dropout probability for residual connections.
+           s1_bits (int): Number of bits for the pre token in BSQuantizer.
+           s2_bits (int): Number of bits for the post token in BSQuantizer.
+           beta (float): Beta parameter for BSQuantizer.
+           gamma0 (float): Gamma0 parameter for BSQuantizer.
+           gamma (float): Gamma parameter for BSQuantizer.
+           zeta (float): Zeta parameter for BSQuantizer.
+           group_size (int): Group size parameter for BSQuantizer.
+
+    """
+
+    def __init__(self, d_in, d_model, n_heads, ff_dim, n_enc_layers, n_dec_layers, ffn_dropout_p, attn_dropout_p, resid_dropout_p, s1_bits, s2_bits, beta, gamma0, gamma, zeta, group_size):
+
+        super().__init__()
+        self.d_in = d_in
+        self.d_model = d_model
+        self.n_heads = n_heads
+        self.ff_dim = ff_dim
+        self.enc_layers = n_enc_layers
+        self.dec_layers = n_dec_layers
+        self.ffn_dropout_p = ffn_dropout_p
+        self.attn_dropout_p = attn_dropout_p
+        self.resid_dropout_p = resid_dropout_p
+
+        self.s1_bits = s1_bits
+        self.s2_bits = s2_bits
+        self.codebook_dim = s1_bits + s2_bits # Total dimension of the codebook after quantization
+        self.embed = nn.Linear(self.d_in, self.d_model)
+        self.head = nn.Linear(self.d_model, self.d_in)
+
+        # Encoder Transformer Blocks
+        self.encoder = nn.ModuleList([
+            TransformerBlock(self.d_model, self.n_heads, self.ff_dim, self.ffn_dropout_p, self.attn_dropout_p, self.resid_dropout_p)
+            for _ in range(self.enc_layers - 1)
+        ])
+        # Decoder Transformer Blocks
+        self.decoder = nn.ModuleList([
+            TransformerBlock(self.d_model, self.n_heads, self.ff_dim, self.ffn_dropout_p, self.attn_dropout_p, self.resid_dropout_p)
+            for _ in range(self.dec_layers - 1)
+        ])
+        self.quant_embed = nn.Linear(in_features=self.d_model, out_features=self.codebook_dim) # Linear layer before quantization
+        self.post_quant_embed_pre = nn.Linear(in_features=self.s1_bits, out_features=self.d_model) # Linear layer after quantization (pre part - s1 bits)
+        self.post_quant_embed = nn.Linear(in_features=self.codebook_dim, out_features=self.d_model) # Linear layer after quantization (full codebook)
+        self.tokenizer = BSQuantizer(self.s1_bits, self.s2_bits, beta, gamma0, gamma, zeta, group_size) # BSQuantizer module
+
+    def forward(self, x):
+        """
+        Forward pass of the KronosTokenizer.
+
+        Args:
+            x (torch.Tensor): Input tensor of shape (batch_size, seq_len, d_in).
+
+        Returns:
+            tuple: A tuple containing:
+                - tuple: (z_pre, z) - Reconstructed outputs from decoder with s1_bits and full codebook respectively,
+                         both of shape (batch_size, seq_len, d_in).
+                - torch.Tensor: bsq_loss - Loss from the BSQuantizer.
+                - torch.Tensor: quantized - Quantized representation from BSQuantizer.
+                - torch.Tensor: z_indices - Indices from the BSQuantizer.
+        """
+        z = self.embed(x)
+
+        for layer in self.encoder:
+            z = layer(z)
+
+        z = self.quant_embed(z) # (B, T, codebook)
+
+        bsq_loss, quantized, z_indices = self.tokenizer(z)
+
+        quantized_pre = quantized[:, :, :self.s1_bits] # Extract the first part of quantized representation (s1_bits)
+        z_pre = self.post_quant_embed_pre(quantized_pre)
+
+        z = self.post_quant_embed(quantized)
+
+        # Decoder layers (for pre part - s1 bits)
+        for layer in self.decoder:
+            z_pre = layer(z_pre)
+        z_pre = self.head(z_pre)
+
+        # Decoder layers (for full codebook)
+        for layer in self.decoder:
+            z = layer(z)
+        z = self.head(z)
+
+        return (z_pre, z), bsq_loss, quantized, z_indices
+
+    def indices_to_bits(self, x, half=False):
+        """
+        Converts indices to bit representations and scales them.
+
+        Args:
+            x (torch.Tensor): Indices tensor.
+            half (bool, optional): Whether to process only half of the codebook dimension. Defaults to False.
+
+        Returns:
+            torch.Tensor: Bit representation tensor.
+        """
+        if half:
+            x1 = x[0] # Assuming x is a tuple of indices if half is True
+            x2 = x[1]
+            mask = 2 ** torch.arange(self.codebook_dim//2, device=x1.device, dtype=torch.long) # Create a mask for bit extraction
+            x1 = (x1.unsqueeze(-1) & mask) != 0 # Extract bits for the first half
+            x2 = (x2.unsqueeze(-1) & mask) != 0 # Extract bits for the second half
+            x = torch.cat([x1, x2], dim=-1) # Concatenate the bit representations
+        else:
+            mask = 2 ** torch.arange(self.codebook_dim, device=x.device, dtype=torch.long) # Create a mask for bit extraction
+            x = (x.unsqueeze(-1) & mask) != 0 # Extract bits
+
+        x = x.float() * 2 - 1 # Convert boolean to bipolar (-1, 1)
+        q_scale = 1. / (self.codebook_dim ** 0.5) # Scaling factor
+        x = x * q_scale
+        return x
+
+    def encode(self, x, half=False):
+        """
+        Encodes the input data into quantized indices.
+
+        Args:
+            x (torch.Tensor): Input tensor of shape (batch_size, seq_len, d_in).
+            half (bool, optional): Whether to use half quantization in BSQuantizer. Defaults to False.
+
+        Returns:
+            torch.Tensor: Quantized indices from BSQuantizer.
+        """
+        z = self.embed(x)
+        for layer in self.encoder:
+            z = layer(z)
+        z = self.quant_embed(z)
+
+        bsq_loss, quantized, z_indices = self.tokenizer(z, half=half, collect_metrics=False)
+        return z_indices
+
+    def decode(self, x, half=False):
+        """
+        Decodes quantized indices back to the input data space.
+
+        Args:
+            x (torch.Tensor): Quantized indices tensor.
+            half (bool, optional): Whether the indices were generated with half quantization. Defaults to False.
+
+        Returns:
+            torch.Tensor: Reconstructed output tensor of shape (batch_size, seq_len, d_in).
+        """
+        quantized = self.indices_to_bits(x, half)
+        z = self.post_quant_embed(quantized)
+        for layer in self.decoder:
+            z = layer(z)
+        z = self.head(z)
+        return z
+
+
+class Kronos(nn.Module, PyTorchModelHubMixin):
+    """
+    Kronos Model.
+
+    Args:
+        s1_bits (int): Number of bits for pre tokens.
+        s2_bits (int): Number of bits for post tokens.
+        n_layers (int): Number of Transformer blocks.
+        d_model (int): Dimension of the model's embeddings and hidden states.
+        n_heads (int): Number of attention heads in the MultiheadAttention layers.
+        ff_dim (int): Dimension of the feedforward network in the Transformer blocks.
+        ffn_dropout_p (float): Dropout probability for the feedforward network.
+        attn_dropout_p (float): Dropout probability for the attention layers.
+        resid_dropout_p (float): Dropout probability for residual connections.
+        token_dropout_p (float): Dropout probability for token embeddings.
+        learn_te (bool): Whether to use learnable temporal embeddings.
+    """
+
+    def __init__(self, s1_bits, s2_bits, n_layers, d_model, n_heads, ff_dim, ffn_dropout_p, attn_dropout_p, resid_dropout_p, token_dropout_p, learn_te):
+        super().__init__()
+        self.s1_bits = s1_bits
+        self.s2_bits = s2_bits
+        self.n_layers = n_layers
+        self.d_model = d_model
+        self.n_heads = n_heads
+        self.learn_te = learn_te
+        self.ff_dim = ff_dim
+        self.ffn_dropout_p = ffn_dropout_p
+        self.attn_dropout_p = attn_dropout_p
+        self.resid_dropout_p = resid_dropout_p
+        self.token_dropout_p = token_dropout_p
+
+        self.s1_vocab_size = 2 ** self.s1_bits
+        self.token_drop = nn.Dropout(self.token_dropout_p)
+        self.embedding = HierarchicalEmbedding(self.s1_bits, self.s2_bits, self.d_model)
+        self.time_emb = TemporalEmbedding(self.d_model, self.learn_te)
+        self.transformer = nn.ModuleList([
+            TransformerBlock(self.d_model, self.n_heads, self.ff_dim, self.ffn_dropout_p, self.attn_dropout_p, self.resid_dropout_p)
+            for _ in range(self.n_layers)
+        ])
+        self.norm = RMSNorm(self.d_model)
+        self.dep_layer = DependencyAwareLayer(self.d_model)
+        self.head = DualHead(self.s1_bits, self.s2_bits, self.d_model)
+        self.apply(self._init_weights)
+
+    def _init_weights(self, module):
+
+        if isinstance(module, nn.Linear):
+            nn.init.xavier_normal_(module.weight)
+            if module.bias is not None:
+                nn.init.zeros_(module.bias)
+        elif isinstance(module, nn.Embedding):
+            nn.init.normal_(module.weight, mean=0, std=self.embedding.d_model ** -0.5)
+        elif isinstance(module, nn.LayerNorm):
+            nn.init.ones_(module.weight)
+            nn.init.zeros_(module.bias)
+        elif isinstance(module, RMSNorm):
+            nn.init.ones_(module.weight)
+
+    def forward(self, s1_ids, s2_ids, stamp=None, padding_mask=None, use_teacher_forcing=False, s1_targets=None):
+        """
+        Args:
+            s1_ids (torch.Tensor): Input tensor of s1 token IDs. Shape: [batch_size, seq_len]
+            s2_ids (torch.Tensor): Input tensor of s2 token IDs. Shape: [batch_size, seq_len]
+            stamp (torch.Tensor, optional): Temporal stamp tensor. Shape: [batch_size, seq_len]. Defaults to None.
+            padding_mask (torch.Tensor, optional): Mask for padding tokens. Shape: [batch_size, seq_len]. Defaults to None.
+            use_teacher_forcing (bool, optional): Whether to use teacher forcing for s1 decoding. Defaults to False.
+            s1_targets (torch.Tensor, optional): Target s1 token IDs for teacher forcing. Shape: [batch_size, seq_len]. Defaults to None.
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]:
+                - s1 logits: Logits for s1 token predictions. Shape: [batch_size, seq_len, s1_vocab_size]
+                - s2_logits: Logits for s2 token predictions, conditioned on s1. Shape: [batch_size, seq_len, s2_vocab_size]
+        """
+        x = self.embedding([s1_ids, s2_ids])
+        if stamp is not None:
+            time_embedding = self.time_emb(stamp)
+            x = x + time_embedding
+        x = self.token_drop(x)
+
+        for layer in self.transformer:
+            x = layer(x, key_padding_mask=padding_mask)
+
+        x = self.norm(x)
+
+        s1_logits = self.head(x)
+
+        if use_teacher_forcing:
+            sibling_embed = self.embedding.emb_s1(s1_targets)
+        else:
+            s1_probs = F.softmax(s1_logits.detach(), dim=-1)
+            sample_s1_ids = torch.multinomial(s1_probs.view(-1, self.s1_vocab_size), 1).view(s1_ids.shape)
+            sibling_embed = self.embedding.emb_s1(sample_s1_ids)
+
+        x2 = self.dep_layer(x, sibling_embed, key_padding_mask=padding_mask) # Dependency Aware Layer: Condition on s1 embeddings
+        s2_logits = self.head.cond_forward(x2)
+        return s1_logits, s2_logits
+
+    def decode_s1(self, s1_ids, s2_ids, stamp=None, padding_mask=None):
+        """
+        Decodes only the s1 tokens.
+
+        This method performs a forward pass to predict only s1 tokens. It returns the s1 logits
+        and the context representation from the Transformer, which can be used for subsequent s2 decoding.
+
+        Args:
+            s1_ids (torch.Tensor): Input tensor of s1 token IDs. Shape: [batch_size, seq_len]
+            s2_ids (torch.Tensor): Input tensor of s2 token IDs. Shape: [batch_size, seq_len]
+            stamp (torch.Tensor, optional): Temporal stamp tensor. Shape: [batch_size, seq_len]. Defaults to None.
+            padding_mask (torch.Tensor, optional): Mask for padding tokens. Shape: [batch_size, seq_len]. Defaults to None.
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]:
+                - s1 logits: Logits for s1 token predictions. Shape: [batch_size, seq_len, s1_vocab_size]
+                - context: Context representation from the Transformer. Shape: [batch_size, seq_len, d_model]
+        """
+        x = self.embedding([s1_ids, s2_ids])
+        if stamp is not None:
+            time_embedding = self.time_emb(stamp)
+            x = x + time_embedding
+        x = self.token_drop(x)
+
+        for layer in self.transformer:
+            x = layer(x, key_padding_mask=padding_mask)
+
+        x = self.norm(x)
+
+        s1_logits = self.head(x)
+        return s1_logits, x
+
+    def decode_s2(self, context, s1_ids, padding_mask=None):
+        """
+        Decodes the s2 tokens, conditioned on the context and s1 tokens.
+
+        This method decodes s2 tokens based on a pre-computed context representation (typically from `decode_s1`)
+        and the s1 token IDs. It uses the dependency-aware layer and the conditional s2 head to predict s2 tokens.
+
+        Args:
+            context (torch.Tensor): Context representation from the transformer (output of decode_s1).
+                                     Shape: [batch_size, seq_len, d_model]
+            s1_ids (torch.Tensor): Input tensor of s1 token IDs. Shape: [batch_size, seq_len]
+            padding_mask (torch.Tensor, optional): Mask for padding tokens. Shape: [batch_size, seq_len]. Defaults to None.
+
+        Returns:
+            torch.Tensor: s2 logits. Shape: [batch_size, seq_len, s2_vocab_size]
+        """
+        sibling_embed = self.embedding.emb_s1(s1_ids)
+        x2 = self.dep_layer(context, sibling_embed, key_padding_mask=padding_mask)
+        return self.head.cond_forward(x2)
+
+
+def top_k_top_p_filtering(
+        logits,
+        top_k: int = 0,
+        top_p: float = 1.0,
+        filter_value: float = -float("Inf"),
+        min_tokens_to_keep: int = 1,
+):
+    """Filter a distribution of logits using top-k and/or nucleus (top-p) filtering
+    Args:
+        logits: logits distribution shape (batch size, vocabulary size)
+        if top_k > 0: keep only top k tokens with highest probability (top-k filtering).
+        if top_p < 1.0: keep the top tokens with cumulative probability >= top_p (nucleus filtering).
+            Nucleus filtering is described in Holtzman et al. (http://arxiv.org/abs/1904.09751)
+        Make sure we keep at least min_tokens_to_keep per batch example in the output
+    From: https://gist.github.com/thomwolf/1a5a29f6962089e871b94cbd09daf317
+    """
+    if top_k > 0:
+        top_k = min(max(top_k, min_tokens_to_keep), logits.size(-1))  # Safety check
+        # Remove all tokens with a probability less than the last token of the top-k
+        indices_to_remove = logits < torch.topk(logits, top_k)[0][..., -1, None]
+        logits[indices_to_remove] = filter_value
+        return logits
+
+    if top_p < 1.0:
+        sorted_logits, sorted_indices = torch.sort(logits, descending=True)
+        cumulative_probs = torch.cumsum(F.softmax(sorted_logits, dim=-1), dim=-1)
+
+        # Remove tokens with cumulative probability above the threshold (token with 0 are kept)
+        sorted_indices_to_remove = cumulative_probs > top_p
+        if min_tokens_to_keep > 1:
+            # Keep at least min_tokens_to_keep (set to min_tokens_to_keep-1 because we add the first one below)
+            sorted_indices_to_remove[..., :min_tokens_to_keep] = 0
+        # Shift the indices to the right to keep also the first token above the threshold
+        sorted_indices_to_remove[..., 1:] = sorted_indices_to_remove[..., :-1].clone()
+        sorted_indices_to_remove[..., 0] = 0
+
+        # scatter sorted tensors to original indexing
+        indices_to_remove = sorted_indices_to_remove.scatter(1, sorted_indices, sorted_indices_to_remove)
+        logits[indices_to_remove] = filter_value
+        return logits
+
+
+def sample_from_logits(logits, temperature=1.0, top_k=None, top_p=None, sample_logits=True):
+    logits = logits / temperature
+    if top_k is not None or top_p is not None:
+        if top_k > 0 or top_p < 1.0:
+            logits = top_k_top_p_filtering(logits, top_k=top_k, top_p=top_p)
+
+    probs = F.softmax(logits, dim=-1)
+
+    if not sample_logits:
+        _, x = torch.topk(probs, k=1, dim=-1)
+    else:
+        x = torch.multinomial(probs, num_samples=1)
+
+    return x
+
+
+def auto_regressive_inference(tokenizer, model, x, x_stamp, y_stamp, max_context, pred_len, clip=5, T=1.0, top_k=0, top_p=0.99, sample_count=5, verbose=False):
+    with torch.no_grad():
+        x = torch.clip(x, -clip, clip)
+
+        device = x.device
+        x = x.unsqueeze(1).repeat(1, sample_count, 1, 1).reshape(-1, x.size(1), x.size(2)).to(device)
+        x_stamp = x_stamp.unsqueeze(1).repeat(1, sample_count, 1, 1).reshape(-1, x_stamp.size(1), x_stamp.size(2)).to(device)
+        y_stamp = y_stamp.unsqueeze(1).repeat(1, sample_count, 1, 1).reshape(-1, y_stamp.size(1), y_stamp.size(2)).to(device)
+
+        x_token = tokenizer.encode(x, half=True)
+        
+        initial_seq_len = x.size(1)
+        batch_size = x_token[0].size(0)
+        total_seq_len = initial_seq_len + pred_len
+        full_stamp = torch.cat([x_stamp, y_stamp], dim=1)
+
+        generated_pre = x_token[0].new_empty(batch_size, pred_len)
+        generated_post = x_token[1].new_empty(batch_size, pred_len)
+
+        pre_buffer = x_token[0].new_zeros(batch_size, max_context)
+        post_buffer = x_token[1].new_zeros(batch_size, max_context)
+        buffer_len = min(initial_seq_len, max_context)
+        if buffer_len > 0:
+            start_idx = max(0, initial_seq_len - max_context)
+            pre_buffer[:, :buffer_len] = x_token[0][:, start_idx:start_idx + buffer_len]
+            post_buffer[:, :buffer_len] = x_token[1][:, start_idx:start_idx + buffer_len]
+
+        if verbose:
+            ran = trange
+        else:
+            ran = range
+        for i in ran(pred_len):
+            current_seq_len = initial_seq_len + i
+            window_len = min(current_seq_len, max_context)
+
+            if current_seq_len <= max_context:
+                input_tokens = [
+                    pre_buffer[:, :window_len],
+                    post_buffer[:, :window_len]
+                ]
+            else:
+                input_tokens = [pre_buffer, post_buffer]
+
+            context_end = current_seq_len
+            context_start = max(0, context_end - max_context)
+            current_stamp = full_stamp[:, context_start:context_end, :].contiguous()
+
+            s1_logits, context = model.decode_s1(input_tokens[0], input_tokens[1], current_stamp)
+            s1_logits = s1_logits[:, -1, :]
+            sample_pre = sample_from_logits(s1_logits, temperature=T, top_k=top_k, top_p=top_p, sample_logits=True)
+
+            s2_logits = model.decode_s2(context, sample_pre)
+            s2_logits = s2_logits[:, -1, :]
+            sample_post = sample_from_logits(s2_logits, temperature=T, top_k=top_k, top_p=top_p, sample_logits=True)
+
+            generated_pre[:, i] = sample_pre.squeeze(-1)
+            generated_post[:, i] = sample_post.squeeze(-1)
+
+            if current_seq_len < max_context:
+                pre_buffer[:, current_seq_len] = sample_pre.squeeze(-1)
+                post_buffer[:, current_seq_len] = sample_post.squeeze(-1)
+            else:
+                pre_buffer.copy_(torch.roll(pre_buffer, shifts=-1, dims=1))
+                post_buffer.copy_(torch.roll(post_buffer, shifts=-1, dims=1))
+                pre_buffer[:, -1] = sample_pre.squeeze(-1)
+                post_buffer[:, -1] = sample_post.squeeze(-1)
+
+        full_pre = torch.cat([x_token[0], generated_pre], dim=1)
+        full_post = torch.cat([x_token[1], generated_post], dim=1)
+
+        context_start = max(0, total_seq_len - max_context)
+        input_tokens = [
+            full_pre[:, context_start:total_seq_len].contiguous(),
+            full_post[:, context_start:total_seq_len].contiguous()
+        ]
+        z = tokenizer.decode(input_tokens, half=True)
+        z = z.reshape(-1, sample_count, z.size(1), z.size(2))
+        preds = z.cpu().numpy()
+        preds = np.mean(preds, axis=1)
+
+        return preds
+
+
+def calc_time_stamps(x_timestamp):
+    time_df = pd.DataFrame()
+    time_df['minute'] = x_timestamp.dt.minute
+    time_df['hour'] = x_timestamp.dt.hour
+    time_df['weekday'] = x_timestamp.dt.weekday
+    time_df['day'] = x_timestamp.dt.day
+    time_df['month'] = x_timestamp.dt.month
+    return time_df
+
+
+class KronosPredictor:
+
+    def __init__(self, model, tokenizer, device=None, max_context=512, clip=5):
+        self.tokenizer = tokenizer
+        self.model = model
+        self.max_context = max_context
+        self.clip = clip
+        self.price_cols = ['open', 'high', 'low', 'close']
+        self.vol_col = 'volume'
+        self.amt_vol = 'amount'
+        self.time_cols = ['minute', 'hour', 'weekday', 'day', 'month']
+        
+        # Auto-detect device if not specified
+        if device is None:
+            if torch.cuda.is_available():
+                device = "cuda:0"
+            elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+                device = "mps"
+            else:
+                device = "cpu"
+        
+        self.device = device
+
+        self.tokenizer = self.tokenizer.to(self.device)
+        self.model = self.model.to(self.device)
+
+    def generate(self, x, x_stamp, y_stamp, pred_len, T, top_k, top_p, sample_count, verbose):
+
+        x_tensor = torch.from_numpy(np.array(x).astype(np.float32)).to(self.device)
+        x_stamp_tensor = torch.from_numpy(np.array(x_stamp).astype(np.float32)).to(self.device)
+        y_stamp_tensor = torch.from_numpy(np.array(y_stamp).astype(np.float32)).to(self.device)
+
+        preds = auto_regressive_inference(self.tokenizer, self.model, x_tensor, x_stamp_tensor, y_stamp_tensor, self.max_context, pred_len,
+                                          self.clip, T, top_k, top_p, sample_count, verbose)
+        preds = preds[:, -pred_len:, :]
+        return preds
+
+    def predict(self, df, x_timestamp, y_timestamp, pred_len, T=1.0, top_k=0, top_p=0.9, sample_count=1, verbose=True):
+
+        if not isinstance(df, pd.DataFrame):
+            raise ValueError("Input must be a pandas DataFrame.")
+
+        if not all(col in df.columns for col in self.price_cols):
+            raise ValueError(f"Price columns {self.price_cols} not found in DataFrame.")
+
+        df = df.copy()
+        if self.vol_col not in df.columns:
+            df[self.vol_col] = 0.0  # Fill missing volume with zeros
+            df[self.amt_vol] = 0.0  # Fill missing amount with zeros
+        if self.amt_vol not in df.columns and self.vol_col in df.columns:
+            df[self.amt_vol] = df[self.vol_col] * df[self.price_cols].mean(axis=1)
+
+        if df[self.price_cols + [self.vol_col, self.amt_vol]].isnull().values.any():
+            raise ValueError("Input DataFrame contains NaN values in price or volume columns.")
+
+        x_time_df = calc_time_stamps(x_timestamp)
+        y_time_df = calc_time_stamps(y_timestamp)
+
+        x = df[self.price_cols + [self.vol_col, self.amt_vol]].values.astype(np.float32)
+        x_stamp = x_time_df.values.astype(np.float32)
+        y_stamp = y_time_df.values.astype(np.float32)
+
+        x_mean, x_std = np.mean(x, axis=0), np.std(x, axis=0)
+
+        x = (x - x_mean) / (x_std + 1e-5)
+        x = np.clip(x, -self.clip, self.clip)
+
+        x = x[np.newaxis, :]
+        x_stamp = x_stamp[np.newaxis, :]
+        y_stamp = y_stamp[np.newaxis, :]
+
+        preds = self.generate(x, x_stamp, y_stamp, pred_len, T, top_k, top_p, sample_count, verbose)
+
+        preds = preds.squeeze(0)
+        preds = preds * (x_std + 1e-5) + x_mean
+
+        pred_df = pd.DataFrame(preds, columns=self.price_cols + [self.vol_col, self.amt_vol], index=y_timestamp)
+        return pred_df
+
+
+    def predict_batch(self, df_list, x_timestamp_list, y_timestamp_list, pred_len, T=1.0, top_k=0, top_p=0.9, sample_count=1, verbose=True):
+        """
+        Perform parallel (batch) prediction on multiple time series. All series must have the same historical length and prediction length (pred_len).
+
+        Args:
+            df_list (List[pd.DataFrame]): List of input DataFrames, each containing price columns and optional volume/amount columns.
+            x_timestamp_list (List[pd.DatetimeIndex or Series]): List of timestamps corresponding to historical data, length should match the number of rows in each DataFrame.
+            y_timestamp_list (List[pd.DatetimeIndex or Series]): List of future prediction timestamps, length should equal pred_len.
+            pred_len (int): Number of prediction steps.
+            T (float): Sampling temperature.
+            top_k (int): Top-k filtering threshold.
+            top_p (float): Top-p (nucleus sampling) threshold.
+            sample_count (int): Number of parallel samples per series, automatically averaged internally.
+            verbose (bool): Whether to display autoregressive progress.
+
+        Returns:
+            List[pd.DataFrame]: List of prediction results in the same order as input, each DataFrame contains
+                                `open, high, low, close, volume, amount` columns, indexed by corresponding `y_timestamp`.
+        """
+        # Basic validation
+        if not isinstance(df_list, (list, tuple)) or not isinstance(x_timestamp_list, (list, tuple)) or not isinstance(y_timestamp_list, (list, tuple)):
+            raise ValueError("df_list, x_timestamp_list, y_timestamp_list must be list or tuple types.")
+        if not (len(df_list) == len(x_timestamp_list) == len(y_timestamp_list)):
+            raise ValueError("df_list, x_timestamp_list, y_timestamp_list must have consistent lengths.")
+
+        num_series = len(df_list)
+
+        x_list = []
+        x_stamp_list = []
+        y_stamp_list = []
+        means = []
+        stds = []
+        seq_lens = []
+        y_lens = []
+
+        for i in range(num_series):
+            df = df_list[i]
+            if not isinstance(df, pd.DataFrame):
+                raise ValueError(f"Input at index {i} is not a pandas DataFrame.")
+            if not all(col in df.columns for col in self.price_cols):
+                raise ValueError(f"DataFrame at index {i} is missing price columns {self.price_cols}.")
+
+            df = df.copy()
+            if self.vol_col not in df.columns:
+                df[self.vol_col] = 0.0
+                df[self.amt_vol] = 0.0
+            if self.amt_vol not in df.columns and self.vol_col in df.columns:
+                df[self.amt_vol] = df[self.vol_col] * df[self.price_cols].mean(axis=1)
+
+            if df[self.price_cols + [self.vol_col, self.amt_vol]].isnull().values.any():
+                raise ValueError(f"DataFrame at index {i} contains NaN values in price or volume columns.")
+
+            x_timestamp = x_timestamp_list[i]
+            y_timestamp = y_timestamp_list[i]
+
+            x_time_df = calc_time_stamps(x_timestamp)
+            y_time_df = calc_time_stamps(y_timestamp)
+
+            x = df[self.price_cols + [self.vol_col, self.amt_vol]].values.astype(np.float32)
+            x_stamp = x_time_df.values.astype(np.float32)
+            y_stamp = y_time_df.values.astype(np.float32)
+
+            if x.shape[0] != x_stamp.shape[0]:
+                raise ValueError(f"Inconsistent lengths at index {i}: x has {x.shape[0]} vs x_stamp has {x_stamp.shape[0]}.")
+            if y_stamp.shape[0] != pred_len:
+                raise ValueError(f"y_timestamp length at index {i} should equal pred_len={pred_len}, got {y_stamp.shape[0]}.")
+
+            x_mean, x_std = np.mean(x, axis=0), np.std(x, axis=0)
+            x_norm = (x - x_mean) / (x_std + 1e-5)
+            x_norm = np.clip(x_norm, -self.clip, self.clip)
+
+            x_list.append(x_norm)
+            x_stamp_list.append(x_stamp)
+            y_stamp_list.append(y_stamp)
+            means.append(x_mean)
+            stds.append(x_std)
+
+            seq_lens.append(x_norm.shape[0])
+            y_lens.append(y_stamp.shape[0])
+
+        # Require all series to have consistent historical and prediction lengths for batch processing
+        if len(set(seq_lens)) != 1:
+            raise ValueError(f"Parallel prediction requires all series to have consistent historical lengths, got: {seq_lens}")
+        if len(set(y_lens)) != 1:
+            raise ValueError(f"Parallel prediction requires all series to have consistent prediction lengths, got: {y_lens}")
+
+        x_batch = np.stack(x_list, axis=0).astype(np.float32)           # (B, seq_len, feat)
+        x_stamp_batch = np.stack(x_stamp_list, axis=0).astype(np.float32) # (B, seq_len, time_feat)
+        y_stamp_batch = np.stack(y_stamp_list, axis=0).astype(np.float32) # (B, pred_len, time_feat)
+
+        preds = self.generate(x_batch, x_stamp_batch, y_stamp_batch, pred_len, T, top_k, top_p, sample_count, verbose)
+        # preds: (B, pred_len, feat)
+
+        pred_dfs = []
+        for i in range(num_series):
+            preds_i = preds[i] * (stds[i] + 1e-5) + means[i]
+            pred_df = pd.DataFrame(preds_i, columns=self.price_cols + [self.vol_col, self.amt_vol], index=y_timestamp_list[i])
+            pred_dfs.append(pred_df)
+
+        return pred_dfs
+

--- a/services/kronos-inference/third_party/kronos/model/module.py
+++ b/services/kronos-inference/third_party/kronos/model/module.py
@@ -1,0 +1,570 @@
+import math
+
+from einops import rearrange, reduce
+import torch
+import torch.nn as nn
+from torch.autograd import Function
+import torch.nn.functional as F
+
+
+class DifferentiableEntropyFunction(Function):
+    @staticmethod
+    def forward(ctx, zq, basis, K, eps):
+        zb = (zq + 1) / 2
+        zi = ((zb * basis).sum(-1)).to(torch.int64)
+        cnt = torch.scatter_reduce(torch.zeros(2 ** K, device=zq.device, dtype=zq.dtype),
+                                   0,
+                                   zi.flatten(),
+                                   torch.ones_like(zi.flatten()).to(zq.dtype),
+                                   'sum')
+        prob = (cnt + eps) / (cnt + eps).sum()
+        H = -(prob * torch.log(prob)).sum()
+        ctx.save_for_backward(zq, zi, prob)
+        ctx.K = K
+        return H
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        zq, zi, prob = ctx.saved_tensors
+        grad_array = -grad_output * (torch.log(prob) + 1) / zi.numel() / ctx.K
+        reord_grad = grad_array[zi.flatten()].reshape(zi.shape)
+        grad_input = reord_grad.unsqueeze(-1) * zq
+        return grad_input, None, None, None, None
+
+
+def codebook_entropy(zq, basis, K, eps=1e-4):
+    return DifferentiableEntropyFunction.apply(zq, basis, K, eps)
+
+
+class BinarySphericalQuantizer(nn.Module):
+    def __init__(self, embed_dim, beta, gamma0, gamma, zeta,
+                 input_format='bchw',
+                 soft_entropy=True, group_size=9,
+                 persample_entropy_compute='analytical',
+                 cb_entropy_compute='group',
+                 l2_norm=True,
+                 inv_temperature=1):
+        """
+        Paper link: https://arxiv.org/pdf/2406.07548.pdf
+        Here we use the official implementation of the BinarySphericalQuantizer.
+        """
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.beta = beta  # loss weight for commit loss
+        self.gamma0 = gamma0  # loss weight for entropy penalty
+        self.gamma = gamma  # loss weight for entropy penalty
+        self.zeta = zeta  # loss weight for entire entropy penalty
+        self.input_format = input_format
+        assert self.embed_dim % group_size == 0, "embed_dim must be divisible by group_size"
+        self.num_groups = self.embed_dim // group_size
+        self.group_size = group_size
+        assert persample_entropy_compute in ['group', 'analytical'], "persample_entropy_compute must be either 'group' or 'analytical'"
+        assert cb_entropy_compute in ['group', 'nce'], "cb_entropy_compute must be either 'group' or 'nce'"
+        self.persample_entropy_compute = persample_entropy_compute
+        self.cb_entropy_compute = cb_entropy_compute
+        self.l2_norm = l2_norm
+        self.inv_temperature = inv_temperature
+
+        self.register_buffer('basis', 2 ** torch.arange(embed_dim - 1, -1, -1))
+        self.register_buffer('group_basis', 2 ** torch.arange(group_size - 1, -1, -1))
+
+        self.num_dimensions = 2 ** embed_dim
+        self.bits_per_index = embed_dim
+
+        # we only need to keep the codebook portion up to the group size
+        # because we approximate the H loss with this subcode
+        group_codes = torch.arange(2 ** self.group_size)
+        group_codebook = self.indexes_to_codes(group_codes).float()[:, -group_size:]
+        self.register_buffer('group_codebook', group_codebook, persistent=False)
+
+        self.soft_entropy = soft_entropy  # soft_entropy: Sec 3.2 of https://arxiv.org/pdf/1911.05894.pdf
+
+    def quantize(self, z):
+        assert z.shape[-1] == self.embed_dim, f"Expected {self.embed_dim} dimensions, got {z.shape[-1]}"
+
+        zhat = torch.where(z > 0,
+                           torch.tensor(1, dtype=z.dtype, device=z.device),
+                           torch.tensor(-1, dtype=z.dtype, device=z.device))
+        return z + (zhat - z).detach()
+
+    def forward(self, z, collect_metrics=True):
+        # if self.input_format == 'bchw':
+        #     z = rearrange(z, 'b c h w -> b h w c')
+        zq = self.quantize(z)
+
+        q_scale = 1. / (self.embed_dim ** 0.5) if self.l2_norm else 1.
+
+        zq = zq * q_scale
+
+        if not collect_metrics:
+            return zq, zq.new_zeros(()), {}
+
+        indices = self.codes_to_indexes(zq.detach())
+        group_indices = self.codes_to_group_indexes(zq.detach())
+        if not self.training:
+            used_codes = torch.unique(indices, return_counts=False)
+        else:
+            used_codes = None
+
+        if self.soft_entropy:
+            persample_entropy, cb_entropy, avg_prob = self.soft_entropy_loss(z)
+            entropy_penalty = self.gamma0 * persample_entropy - self.gamma * cb_entropy
+        else:
+            zb_by_sample = ((zq + 1) / 2).reshape(z.shape[0], -1, z.shape[-1]).to(torch.float32)
+            persample_entropy = self.get_hard_per_sample_entropy(zb_by_sample)
+            cb_entropy = codebook_entropy(zq, self.basis, self.embed_dim)
+            entropy_penalty = self.gamma0 * persample_entropy - self.gamma * cb_entropy
+
+        # commit loss
+        commit_loss = self.beta * torch.mean(((zq.detach() - z) ** 2).sum(dim=-1))
+
+        # if self.input_format == 'bchw':
+        #     zq = rearrange(zq, 'b h w c -> b c h w')
+
+        return (
+            zq,
+            commit_loss + self.zeta * entropy_penalty / self.inv_temperature,
+            {"H": cb_entropy, "used_codes": used_codes, "indices": indices, "group_indices": group_indices,
+             "avg_prob": avg_prob}
+        )
+
+    def soft_entropy_loss(self, z):
+        # if we divide the code in subgroups of size group_size, the codebook will be of size 2 ** group_size
+        # the sub-code is the last group_size bits of the full code
+        group_code_book = self.group_codebook / (self.embed_dim ** 0.5 if self.l2_norm else 1)
+        divided_z = rearrange(z, '... (g c) -> ... g c', c=self.group_size)
+
+        # we calculate the distance between the divided_z and the codebook for each subgroup
+        distance = - 2 * torch.einsum('... g c, d c ->... g d', divided_z, group_code_book)
+        prob = (-distance * self.inv_temperature).softmax(dim=-1)
+        if self.persample_entropy_compute == 'analytical':
+            if self.l2_norm:
+                p = torch.sigmoid(-4 * z / (self.embed_dim ** 0.5) * self.inv_temperature)
+            else:
+                p = torch.sigmoid(-4 * z * self.inv_temperature)
+            prob = torch.stack([p, 1 - p], dim=-1)
+            per_sample_entropy = self.get_entropy(prob, dim=-1, normalize=False).sum(dim=-1).mean()
+        else:
+            per_sample_entropy = self.get_entropy(prob, dim=-1, normalize=False).sum(dim=-1).mean()
+
+        # macro average of the probability of each subgroup
+        avg_prob = reduce(prob, '... g d ->g d', 'mean')
+        codebook_entropy = self.get_entropy(avg_prob, dim=-1, normalize=False)
+
+        # the approximation of the entropy is the sum of the entropy of each subgroup
+        return per_sample_entropy, codebook_entropy.sum(), avg_prob
+
+    def get_hard_per_sample_entropy(self, zb_by_sample):
+        probs_per_dim = zb_by_sample.sum(1) / zb_by_sample.shape[1]
+        persample_entropy = - probs_per_dim * torch.log(probs_per_dim + 1e-8) - (1 - probs_per_dim) * torch.log(1 - probs_per_dim + 1e-8)
+        persample_entropy = persample_entropy.sum(-1)
+        return persample_entropy.mean()
+
+    def codes_to_indexes(self, zhat):
+        """Converts a `code` to an index in the codebook.
+        Args:
+            zhat: A tensor of shape (B, ..., C) containing the codes. must be in {-1, 1}
+        """
+        assert zhat.shape[-1] == self.embed_dim, f"Expected {self.embed_dim} dimensions, got {zhat.shape[-1]}"
+        return ((zhat + 1) / 2 * self.basis).sum(axis=-1).to(torch.int64)
+
+    def codes_to_group_indexes(self, zhat):
+        """Converts a `code` to a list of indexes (in groups) in the codebook.
+        Args:
+            zhat: A tensor of shape (B, ..., C) containing the codes. must be in {-1, 1}
+        """
+        zhat_in_group = rearrange(zhat, 'b ... (g c) -> b ... g c', c=self.group_size)
+        return ((zhat_in_group + 1) / 2 * self.group_basis).sum(axis=-1).to(torch.int64)
+
+    def indexes_to_codes(self, indices):
+        """Inverse of `indexes_to_codes`."""
+        indices = indices.unsqueeze(-1)
+        codes_non_centered = torch.remainder(
+            torch.floor_divide(indices, self.basis), 2
+        )
+        return codes_non_centered * 2 - 1
+
+    def group_indexes_to_codes(self, group_indices):
+        """Inverse of `group_indexes_to_codes`."""
+        group_indices = group_indices.unsqueeze(-1)
+        codes_non_centered = torch.remainder(
+            torch.floor_divide(group_indices, self.group_basis), 2
+        )
+        codes_non_centered = rearrange(codes_non_centered, 'b ... g c -> b ... (g c)')
+        return codes_non_centered * 2 - 1
+
+    def get_entropy(self, count, dim=-1, eps=1e-4, normalize=True):
+        if normalize:
+            probs = (count + eps) / (count + eps).sum(dim=dim, keepdim=True)
+        else:
+            probs = count
+        H = -(probs * torch.log(probs + 1e-8)).sum(dim=dim)
+        return H
+
+    def get_group_codebook_entry(self, group_indices):
+        z_q = self.group_indexes_to_codes(group_indices)
+        q_scale = 1. / (self.embed_dim ** 0.5) if self.l2_norm else 1.
+        z_q = z_q * q_scale
+        if self.input_format == 'bchw':
+            h, w = int(z_q.shape[1] ** 0.5)
+            assert h * w == z_q.shape[1], 'Invalid sequence length'
+            z_q = rearrange(z_q, 'b (h w) c -> b c h w', h=h)
+        return z_q
+
+    def get_codebook_entry(self, indices):
+        z_q = self.indexes_to_codes(indices)
+        q_scale = 1. / (self.embed_dim ** 0.5) if self.l2_norm else 1.
+        z_q = z_q * q_scale
+        if self.input_format == 'bchw':
+            h, w = int(z_q.shape[1] ** 0.5)
+            assert h * w == z_q.shape[1], 'Invalid sequence length'
+            z_q = rearrange(z_q, 'b (h w) c -> b c h w', h=h)
+        return z_q
+
+
+class BSQuantizer(nn.Module):
+
+    def __init__(self, s1_bits, s2_bits, beta, gamma0, gamma, zeta, group_size):
+        super().__init__()
+        self.codebook_dim = s1_bits + s2_bits
+        self.s1_bits = s1_bits
+        self.s2_bits = s2_bits
+        self.bsq = BinarySphericalQuantizer(self.codebook_dim, beta, gamma0, gamma, zeta, group_size=group_size)
+
+    def bits_to_indices(self, bits):
+        bits = (bits >= 0).to(torch.long)
+        indices = 2 ** torch.arange(
+            0,
+            bits.shape[-1],
+            1,
+            dtype=torch.long,
+            device=bits.device,
+        )
+        return (bits * indices).sum(-1)
+
+    def forward(self, z, half=False, collect_metrics=True):
+        z = F.normalize(z, dim=-1)
+        quantized, bsq_loss, metrics = self.bsq(z, collect_metrics=collect_metrics)
+        if half:
+            q_pre = quantized[:, :, :self.s1_bits]
+            q_post = quantized[:, :, self.s1_bits:]
+            z_indices = [self.bits_to_indices(q_pre), self.bits_to_indices(q_post)]
+        else:
+            z_indices = self.bits_to_indices(quantized)
+        return bsq_loss, quantized, z_indices
+
+
+class RMSNorm(torch.nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-5):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def _norm(self, x):
+        return x * torch.rsqrt(torch.mean(x * x, dim=-1, keepdim=True) + self.eps)
+
+    def forward(self, x):
+        output = self._norm(x.float()).type_as(x)
+        return output * self.weight
+
+
+class FeedForward(nn.Module):
+    def __init__(self, d_model, ff_dim, ffn_dropout_p=0.0):
+        super().__init__()
+
+        self.w1 = nn.Linear(d_model, ff_dim, bias=False)
+        self.w3 = nn.Linear(d_model, ff_dim, bias=False)
+        self.w2 = nn.Linear(ff_dim, d_model, bias=False)
+        self.ffn_dropout = nn.Dropout(ffn_dropout_p)
+
+    def forward(self, x):
+        return self.ffn_dropout(self.w2(F.silu(self.w1(x)) * self.w3(x)))
+
+
+class RotaryPositionalEmbedding(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        inv_freq = 1.0 / (10000 ** (torch.arange(0, dim, 2).float() / dim))
+        self.register_buffer("inv_freq", inv_freq)
+        self.seq_len_cached = None
+        self.cos_cached = None
+        self.sin_cached = None
+
+    def _update_cos_sin_cache(self, x, seq_len):
+        if seq_len != self.seq_len_cached:
+            self.seq_len_cached = seq_len
+            t = torch.arange(seq_len, device=x.device).type_as(self.inv_freq)
+            freqs = torch.einsum('i,j->ij', t, self.inv_freq)
+            emb = torch.cat((freqs, freqs), dim=-1).to(x.device)
+            self.cos_cached = emb.cos()[None, None, :, :]
+            self.sin_cached = emb.sin()[None, None, :, :]
+        return self.cos_cached, self.sin_cached
+
+    def forward(self, q, k):
+        cos, sin = self._update_cos_sin_cache(q, q.shape[-2])
+        return (
+            (q * cos) + (self._rotate_half(q) * sin),
+            (k * cos) + (self._rotate_half(k) * sin),
+        )
+
+    def _rotate_half(self, x):
+        x1, x2 = x.chunk(2, dim=-1)
+        return torch.cat((-x2, x1), dim=-1)
+
+
+class MultiHeadAttentionWithRoPE(nn.Module):
+    def __init__(self, d_model, n_heads, attn_dropout_p=0.0, resid_dropout_p=0.0):
+        super().__init__()
+        self.d_model = d_model
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.q_proj = nn.Linear(d_model, d_model)
+        self.k_proj = nn.Linear(d_model, d_model)
+        self.v_proj = nn.Linear(d_model, d_model)
+        self.out_proj = nn.Linear(d_model, d_model)
+        self.rotary = RotaryPositionalEmbedding(self.head_dim)
+        self.attn_dropout_p = attn_dropout_p
+        self.resid_dropout = nn.Dropout(resid_dropout_p)
+
+    def forward(self, x, key_padding_mask=None):
+        batch_size, seq_len, _ = x.shape
+
+        q = self.q_proj(x).view(batch_size, seq_len, self.n_heads, self.head_dim).transpose(1, 2)
+        k = self.k_proj(x).view(batch_size, seq_len, self.n_heads, self.head_dim).transpose(1, 2)
+        v = self.v_proj(x).view(batch_size, seq_len, self.n_heads, self.head_dim).transpose(1, 2)
+
+        q, k = self.rotary(q, k)
+
+        if key_padding_mask is not None:
+            attn_mask = key_padding_mask.unsqueeze(1).unsqueeze(2)  # [batch, 1, 1, seq_len]
+            attn_mask = attn_mask.expand(-1, self.n_heads, seq_len, -1)  # [batch, n_heads, q_len, k_len]
+        else:
+            attn_mask = None
+
+        attn_output = F.scaled_dot_product_attention(
+            q, k, v,
+            attn_mask=attn_mask,
+            dropout_p=self.attn_dropout_p if self.training else 0.0,
+            is_causal=True
+        )
+
+        attn_output = attn_output.transpose(1, 2).contiguous().view(batch_size, seq_len, self.d_model)
+        return self.resid_dropout(self.out_proj(attn_output))
+
+
+class MultiHeadCrossAttentionWithRoPE(nn.Module):
+    def __init__(self, d_model, n_heads, attn_dropout_p=0.0, resid_dropout=0.0):
+        super().__init__()
+        self.d_model = d_model
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.q_proj = nn.Linear(d_model, d_model)
+        self.k_proj = nn.Linear(d_model, d_model)
+        self.v_proj = nn.Linear(d_model, d_model)
+        self.out_proj = nn.Linear(d_model, d_model)
+        self.rotary = RotaryPositionalEmbedding(self.head_dim)
+        self.attn_dropout_p = attn_dropout_p
+        self.resid_dropout = nn.Dropout(resid_dropout)
+
+    def forward(self, query, key, value, key_padding_mask=None):
+        batch_size, q_len, _ = query.shape
+        _, seq_len, _ = key.shape
+
+        q = self.q_proj(query).view(batch_size, q_len, self.n_heads, self.head_dim).transpose(1, 2)
+        k = self.k_proj(key).view(batch_size, seq_len, self.n_heads, self.head_dim).transpose(1, 2)
+        v = self.v_proj(value).view(batch_size, seq_len, self.n_heads, self.head_dim).transpose(1, 2)
+
+        q, k = self.rotary(q, k)
+
+        if key_padding_mask is not None:
+            attn_mask = key_padding_mask.unsqueeze(1).unsqueeze(2)
+            attn_mask = attn_mask.expand(-1, self.n_heads, q_len, -1)
+        else:
+            attn_mask = None
+
+        is_causal_flag = self.training
+
+        attn_output = F.scaled_dot_product_attention(
+            q, k, v,
+            attn_mask=attn_mask,
+            dropout_p=self.attn_dropout_p if self.training else 0.0,
+            is_causal=is_causal_flag
+        )
+
+        attn_output = attn_output.transpose(1, 2).contiguous().view(batch_size, q_len, self.d_model)
+        return self.resid_dropout(self.out_proj(attn_output))
+
+
+class HierarchicalEmbedding(nn.Module):
+    def __init__(self, s1_bits, s2_bits, d_model=256):
+        super().__init__()
+        self.s1_bits = s1_bits
+        self.s2_bits = s2_bits
+
+        vocab_s1 = 2 ** s1_bits
+        vocab_s2 = 2 ** s2_bits
+
+        self.emb_s1 = nn.Embedding(vocab_s1, d_model)
+        self.emb_s2 = nn.Embedding(vocab_s2, d_model)
+        self.d_model = d_model
+        self.fusion_proj = nn.Linear(d_model * 2, d_model)
+
+        nn.init.normal_(self.emb_s1.weight, mean=0, std=d_model ** -0.5)
+        nn.init.normal_(self.emb_s2.weight, mean=0, std=d_model ** -0.5)
+
+    def split_token(self, token_ids: torch.Tensor, s2_bits: int):
+        """Inputs:
+            token_ids (torch.Tensor): Composite token IDs of shape [batch_size, seq_len] or [N], each in range [0, 2^(s1_bits + s2_bits) - 1].
+            s2_bits (int): Number of low bits used for the fine token (s2).
+        """
+        assert isinstance(s2_bits, int) and s2_bits > 0, "s2_bits must be a positive integer"
+
+        t = token_ids.long()
+        mask = (1 << s2_bits) - 1
+        s2_ids = t & mask           # extract low bits
+        s1_ids = t >> s2_bits       # extract high bits
+        return s1_ids, s2_ids
+
+    def forward(self, token_ids):
+        """Inputs:
+        token_ids:
+            - tuple or list: (s1_ids, s2_ids), each of shape [batch_size, seq_len], or
+            - torch.Tensor: composite token IDs of shape [batch_size, seq_len], which will be split into (s1_ids, s2_ids) internally.
+        Output: [batch_size, seq_len, d_model]
+        """
+        if isinstance(token_ids, tuple) or isinstance(token_ids, list):
+            s1_ids, s2_ids = token_ids
+        else:
+            s1_ids, s2_ids = self.split_token(token_ids, self.s2_bits)
+        s1_emb = self.emb_s1(s1_ids) * math.sqrt(self.d_model)
+        s2_emb = self.emb_s2(s2_ids) * math.sqrt(self.d_model)
+        return self.fusion_proj(torch.cat([s1_emb, s2_emb], dim=-1))
+
+
+class DependencyAwareLayer(nn.Module):
+    def __init__(self, d_model, n_heads=4, attn_dropout_p=0.0, resid_dropout=0.0):
+        super().__init__()
+        self.cross_attn = MultiHeadCrossAttentionWithRoPE(d_model, n_heads, attn_dropout_p, resid_dropout)
+        self.norm = RMSNorm(d_model)
+
+    def forward(self, hidden_states, sibling_embed, key_padding_mask=None):
+        """hidden_states: [batch, seq_len, d_model]
+        sibling_embed: Embedding from another subtoken
+        """
+        attn_out = self.cross_attn(
+            query=sibling_embed,
+            key=hidden_states,
+            value=hidden_states,
+            key_padding_mask=key_padding_mask
+        )
+        return self.norm(hidden_states + attn_out)
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, d_model, n_heads, ff_dim=1024, ffn_dropout_p=0.0, attn_dropout_p=0.0, resid_dropout_p=0.0):
+        super().__init__()
+        self.norm1 = RMSNorm(d_model)
+        self.self_attn = MultiHeadAttentionWithRoPE(d_model, n_heads, attn_dropout_p, resid_dropout_p)
+        self.norm2 = RMSNorm(d_model)
+        self.ffn = FeedForward(d_model, ff_dim, ffn_dropout_p)
+
+    def forward(self, x, key_padding_mask=None):
+        residual = x
+        x = self.norm1(x)
+        attn_out = self.self_attn(x, key_padding_mask=key_padding_mask)
+        x = residual + attn_out
+
+        residual = x
+        x = self.norm2(x)
+        ffn_out = self.ffn(x)
+        x = residual + ffn_out
+        return x
+
+
+class DualHead(nn.Module):
+    def __init__(self, s1_bits, s2_bits, d_model):
+        super().__init__()
+        self.vocab_s1 = 2 ** s1_bits
+        self.vocab_s2 = 2 ** s2_bits
+        self.proj_s1 = nn.Linear(d_model, self.vocab_s1)
+        self.proj_s2 = nn.Linear(d_model, self.vocab_s2)
+
+    def compute_loss(self, s1_logits, s2_logits, s1_targets, s2_targets, padding_mask=None):
+        if padding_mask is not None:
+            valid_mask = (padding_mask == 0)
+            s1_logits = s1_logits[valid_mask]
+            s2_logits = s2_logits[valid_mask]
+            s1_targets = s1_targets[valid_mask]
+            s2_targets = s2_targets[valid_mask]
+            ce_s1 = F.cross_entropy(s1_logits, s1_targets)
+            ce_s2 = F.cross_entropy(s2_logits, s2_targets)
+        else:
+            ce_s1 = F.cross_entropy(s1_logits.reshape(-1, self.vocab_s1), s1_targets.reshape(-1))
+            ce_s2 = F.cross_entropy(s2_logits.reshape(-1, self.vocab_s2), s2_targets.reshape(-1))
+        ce_loss = (ce_s1 + ce_s2) / 2
+        return ce_loss, ce_s1, ce_s2
+
+    def forward(self, x):
+        return self.proj_s1(x)
+
+    def cond_forward(self, x2):
+        return self.proj_s2(x2)
+
+
+class FixedEmbedding(nn.Module):
+    def __init__(self, c_in, d_model):
+        super(FixedEmbedding, self).__init__()
+
+        w = torch.zeros(c_in, d_model).float()
+        w.require_grad = False
+
+        position = torch.arange(0, c_in).float().unsqueeze(1)
+        div_term = (torch.arange(0, d_model, 2).float() * -(math.log(10000.0) / d_model)).exp()
+
+        w[:, 0::2] = torch.sin(position * div_term)
+        w[:, 1::2] = torch.cos(position * div_term)
+
+        self.emb = nn.Embedding(c_in, d_model)
+        self.emb.weight = nn.Parameter(w, requires_grad=False)
+
+    def forward(self, x):
+        return self.emb(x).detach()
+
+
+class TemporalEmbedding(nn.Module):
+    def __init__(self, d_model, learn_pe):
+        super(TemporalEmbedding, self).__init__()
+
+        minute_size = 60
+        hour_size = 24
+        weekday_size = 7
+        day_size = 32
+        month_size = 13
+
+        Embed = FixedEmbedding if not learn_pe else nn.Embedding
+        self.minute_embed = Embed(minute_size, d_model)
+        self.hour_embed = Embed(hour_size, d_model)
+        self.weekday_embed = Embed(weekday_size, d_model)
+        self.day_embed = Embed(day_size, d_model)
+        self.month_embed = Embed(month_size, d_model)
+
+    def forward(self, x):
+        x = x.long()
+
+        minute_x = self.minute_embed(x[:, :, 0])
+        hour_x = self.hour_embed(x[:, :, 1])
+        weekday_x = self.weekday_embed(x[:, :, 2])
+        day_x = self.day_embed(x[:, :, 3])
+        month_x = self.month_embed(x[:, :, 4])
+
+        return hour_x + weekday_x + day_x + month_x + minute_x
+
+
+
+
+
+
+
+

--- a/services/kronos-inference/uv.lock
+++ b/services/kronos-inference/uv.lock
@@ -1,0 +1,756 @@
+version = 1
+revision = 3
+requires-python = ">=3.11, <3.13"
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and sys_platform != 'linux'",
+    "python_full_version < '3.12' and sys_platform != 'linux'",
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/d2/f4d173e22df740bc37b1db102b386ba719b66e95b0f0d751f556b387e6d2/anyio-4.15.1.tar.gz", hash = "sha256:9f28306018cbd6d329e64a36d58256edff76dd996fe423bc957326e578b82a94", size = 276966, upload-time = "2026-09-05T10:42:39.44Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b8/4bd346e22b28902df4d651910f5242c28d84e4a5c2435ca5c3f797ed7e2e/anyio-4.15.1-py3-none-any.whl", hash = "sha256:6152fdbbf9a77fdec97731721bebf7c4c44f7c29b424b0065826173efc7ed101", size = 132079, upload-time = "2026-09-05T10:42:37.923Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "einops"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/81/df4fbe24dff8ba3934af99044188e20a98ed441ad17a274539b74e82e126/einops-0.8.1.tar.gz", hash = "sha256:de5d960a7a761225532e0f1959e5315ebeafc0cd43394732f103ca44b9837e84", size = 54805, upload-time = "2025-02-09T03:17:00.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/62/9773de14fe6c45c23649e98b83231fffd7b9892b6cf863251dc2afa73643/einops-0.8.1-py3-none-any.whl", hash = "sha256:919387eb55330f5757c6bea9165c5ff5cfe63a642682ea788a6d472576d81737", size = 64359, upload-time = "2025-02-09T03:17:01.998Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.141.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.32.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/46/126b1831dca12060d4a8296bf9c4fe5c93c4f22197fa239cb0cc82042bba/filelock-3.32.6.tar.gz", hash = "sha256:a3f55a18af3652a94d8f47d6055df434f254ca1d02ef2524850c6d249ca2512c", size = 225172, upload-time = "2026-09-08T22:57:11.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/06/4f138f618dbea66803291274f228f01daf29f306fe8b96bc30dab765df75/filelock-3.32.6-py3-none-any.whl", hash = "sha256:3f16ecd0117feae0dfc147e8c62eb5daeccd8bd800378c3ddf416de9b4feb6b1", size = 100189, upload-time = "2026-09-08T22:57:10.182Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/78/f34251dadb8f3921264a1d9b8946f5e542014ee2614b285261b4e40e6775/fsspec-2026.7.0.tar.gz", hash = "sha256:c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88", size = 317040, upload-time = "2026-07-28T16:34:51.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl", hash = "sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279", size = 206583, upload-time = "2026-07-28T16:34:49.538Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/ab/522a2ab67f27971a9d48ca666d4fca85ef7d5282d142e31fd087e27b1bbe/hf_xet-1.6.0.tar.gz", hash = "sha256:2e58454a340b3556dfa4972d5451aff4fba8dd42a236600ba1a1d2b1514f0fef", size = 920527, upload-time = "2026-08-03T22:33:13.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/50/7afa2c9c787405864fc47a0d1bbc02c62e9101947ed43c1f43899fc7d91d/hf_xet-1.6.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:633dc0cd71d32da58ab8c03ad38e2fac452c15c2b0a2866ebf6ededfe0a5061d", size = 4071729, upload-time = "2026-08-03T22:33:00.721Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/69/55b8dcf636142ae660fec1869fcac14c4da2e8412e14d6eee1523be77e9f/hf_xet-1.6.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0906082d9932ae0c0057fa194041c22b4e2cdb46b2592ef3b91f020d62a081a", size = 3876287, upload-time = "2026-08-03T22:33:02.251Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4e/a28359bf1c1ecf11eba22123168c138698f7cb576ac678f5a2e16cd5da08/hf_xet-1.6.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d62671bb130879cef0ee4c9ebe47a14af6c66ec53e6d84dc15936e5ffdfac82f", size = 4464663, upload-time = "2026-08-03T22:33:03.802Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/69/1f0cbc2fb22ae6082d094f743d1b8945a3f36f6089cb95f42b7ee348cda7/hf_xet-1.6.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0e6e21fa3cdfcdcd76748564bf593870a5e013f47d97cf10aed63aa222cff5b7", size = 4262538, upload-time = "2026-08-03T22:33:05.287Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3a/4f4f2301ade26e404462d3336fa11f7958d914cabbabdd6e03c3c5d5658c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4fc74352a17015bd0ee90038bc9efe38db894cde45f268b6712b04fce8cd0acb", size = 4460520, upload-time = "2026-08-03T22:33:06.81Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/311725e2a905534dfee2dcb5b08414f249147f1f12252bfc2bd24caa075c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8fb4f71cba6129110c3374a33f919001ff130488fc23553698e34cc1c2a1198c", size = 4675937, upload-time = "2026-08-03T22:33:08.616Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b7/8c59a66d15205024662f1d66968136f13893f96df1ddc5087e2e281fc95f/hf_xet-1.6.0-cp38-abi3-win_amd64.whl", hash = "sha256:fb4fadde1b2b70bf4c0c14a6dccbe7194b1c28947fefd5bbe3fed9d940676c3b", size = 4033128, upload-time = "2026-08-03T22:33:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/73/63/ca511b6f802f28cf3489b280fe77475bcca8de85e81a6299d7916b5b5555/hf_xet-1.6.0-cp38-abi3-win_arm64.whl", hash = "sha256:3dc3e35441ba395006af5aaacc40ef2e603c51ef46c3530b9156185f00935ea3", size = 3859359, upload-time = "2026-08-03T22:33:11.725Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/97/2eb4abaa5b969ed385066a0496a3823b3ff467fc1082e2202955f1867d60/huggingface_hub-1.30.0.tar.gz", hash = "sha256:e6a6120bc8c8e2723d03648434ee247088cceb55ba7067e7d34d692cad5fdb57", size = 964291, upload-time = "2026-09-03T10:05:14.053Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/0e/3e45bbe0dd48f4e56b1d46649d342de853cd1c7e815323472ab62687f153/huggingface_hub-1.30.0-py3-none-any.whl", hash = "sha256:96ae0a8e99a234374a6fe43e989ebd21c04640b91ab2927e7e5773ba1131ca59", size = 796795, upload-time = "2026-09-03T10:05:12.21Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform != 'linux'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/49/ec46835a70be8fa6446c495126ac84fdb28cb2558e1620ffb87a10c8b64c/numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4", size = 16969194, upload-time = "2026-05-18T23:33:13.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0d/f5957185c0ee2f3e12f78715aa9e3b353fd83633316c8532b38faa37e3f6/numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d", size = 14964111, upload-time = "2026-05-18T23:33:17.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/40/40a40ee0ddf7ceb782c49af278894b686e586d65d8c1889c8b5da01a3d7d/numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8", size = 5469159, upload-time = "2026-05-18T23:33:20.654Z" },
+    { url = "https://files.pythonhosted.org/packages/63/13/f9a8046535cb21deae82f8d03de9617e08882d274fad2539630761888228/numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538", size = 6798936, upload-time = "2026-05-18T23:33:22.987Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a8/6fa8c1a345a8c85dbb21932c447bee07c30a2c2a3f31e369c0a84b300147/numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47", size = 15966692, upload-time = "2026-05-18T23:33:26.62Z" },
+    { url = "https://files.pythonhosted.org/packages/02/03/74fe2a4cb3817d94d86402f2506554130a2f01414e299b5a843e5a8a957f/numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93", size = 16918164, upload-time = "2026-05-18T23:33:29.955Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/80/3615be3313f7e7696609bc194b9f0101da809df79e859bdb84e0cd043f46/numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8", size = 17322877, upload-time = "2026-05-18T23:33:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/a691e0fe2675e370d0e08ff905adc49a1c8830e8cae03efe4477e92cd55d/numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6", size = 18651487, upload-time = "2026-05-18T23:33:38.217Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a7/9bc1cd626d7bf6869bfedf27b91b6ab5dd607758bf8e959d6fa80c6a59cb/numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8", size = 6233945, upload-time = "2026-05-18T23:33:41.331Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/7fc6239c12bce7e931463251cca4426c465e1876ba3cc785402ef4dd8f4e/numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147", size = 12608406, upload-time = "2026-05-18T23:33:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/27/83/140f85a466595a16382996a1bf06b2b54bcd597488921b0c9daaeeda72af/numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577", size = 10479528, upload-time = "2026-05-18T23:33:50.725Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/de/12/b422cc84439adc0d00de605bf4a308890ae5c26f2c71fbd73e5d08fbb0dd/numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662", size = 16847511, upload-time = "2026-05-18T23:36:50.673Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/f481bef68011740f8849418d82db07230e825013f31f4eef5ba5b805316a/numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7", size = 14889064, upload-time = "2026-05-18T23:36:53.879Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/57/42ed575c10ced8af951d426bc4e1f8aff16fd851db33f067036215a7f860/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f", size = 5394157, upload-time = "2026-05-18T23:36:57.194Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ef/f66cc724fcc36c1e364c67f51ae9146090b8b584f27d58b97fdae3edd737/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c", size = 6708728, upload-time = "2026-05-18T23:36:59.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9c/c531f2293b91265d8b48e9b329f54fdd7ffae73cb4134ea10cca4237e9cc/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0", size = 15798374, upload-time = "2026-05-18T23:37:02.674Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b0/413077f6b1153ed3cba361401c6783bbad6114804a000cc22eb71c13e190/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02", size = 16747286, upload-time = "2026-05-18T23:37:06.327Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ce/e5ec180bc41812edcd8daeb8639d205622c0e8c02259d8ab25a0201b3c2a/numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73", size = 12504263, upload-time = "2026-05-18T23:37:09.715Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and sys_platform != 'linux'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/01/11703282db468b85f6f7b8c7f22d058de5970d5c7e60a3a8aaa313c3de36/numpy-2.5.3.tar.gz", hash = "sha256:df2d5874ff183595a4ba404edd04f6bd9b5505c1d7708573f6a6c17489a67563", size = 20791231, upload-time = "2026-09-06T16:27:47.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/50/8fdbb16af64895706a45f06a4068e29db732ec180f3c1375f14123359138/numpy-2.5.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cb189f09db39283b26bfd061ec16189e14f71c6755207f72a0f7540867afe5b9", size = 16994982, upload-time = "2026-09-06T16:24:29.244Z" },
+    { url = "https://files.pythonhosted.org/packages/60/39/789131c1188c078dcb3a1692e72e1e050c68b88ffe72c9ccaac9bcd7a9cd/numpy-2.5.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f59a878c33d6b88122d80d239bb3b845d58708750b0cb06a09aebb9b18ec696c", size = 12009327, upload-time = "2026-09-06T16:24:32.491Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/a312e95696e5f601914dd8b6dd844692ba61670807417e24b68e337b5c70/numpy-2.5.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:a72f874bc9e10e4b8f80426fb49716d5141f64442a0c8418065093ec8017fbb0", size = 5445405, upload-time = "2026-09-06T16:24:35.071Z" },
+    { url = "https://files.pythonhosted.org/packages/30/d0/5623a1707ed4fe16e3909fe3cf5ee3da004ae677ad23d83bbf3adf1a6faf/numpy-2.5.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:fc36dc566135b5eceec4cf89758fcb719266a019ef07dae1754ae7c9f617ef3e", size = 6783213, upload-time = "2026-09-06T16:24:37.253Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/32/84146fc020ad3c25f805f70ab60da46fe3c540a21369754a7e4369754b6f/numpy-2.5.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76c2c1e6bfa5c84adc6434dfbf013aa92096a7985221762c8f11fedfd20fff58", size = 15687872, upload-time = "2026-09-06T16:24:39.751Z" },
+    { url = "https://files.pythonhosted.org/packages/65/af/aa78d1a88805456e212b65461354cd943197fb9acecc4c90fd12295123a3/numpy-2.5.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b7e18c623bb5c95acb3b3328861272816ba199fb531921c5d6d0b675f1fde9e3", size = 16717410, upload-time = "2026-09-06T16:24:42.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/24/faa79d865e69a97ba17473b23a1b74094b2259c03e820c70297293b9ea49/numpy-2.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4f8929ee6c96bfbd7b4ed2032e0c03af86fe1826740ab61ddabf9072d06e57ff", size = 17040975, upload-time = "2026-09-06T16:24:45.961Z" },
+    { url = "https://files.pythonhosted.org/packages/62/4a/8877e629445a7176297dffcaf9c485faa96a95d81728a62521ad55bd4c0f/numpy-2.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b5d93cf48f687479941d12b69c873ad2cc76bbd487f0091c2200636497f34034", size = 18476479, upload-time = "2026-09-06T16:24:49.35Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/db/35e1c2d38b04cbd5b731f9d71495e055e813197669d22b612f11748d2ff9/numpy-2.5.3-cp312-cp312-win32.whl", hash = "sha256:bf63afbe037eb5d2fe87fbcc7778e61da53ebaf21d938a4515aa73b62532a5d4", size = 6133378, upload-time = "2026-09-06T16:24:51.915Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/accf6d4f0c80c5d9ba9735d6b1550e444180599f34dec69ca01360f717ad/numpy-2.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:0a59a421a32580a009e8a1751345bf829631b990dc1794b80514ab722b435def", size = 12567828, upload-time = "2026-09-06T16:24:54.255Z" },
+    { url = "https://files.pythonhosted.org/packages/22/43/1764aff32e4652526ae2f71fa8b3efd8d25c8a3d6926914454e47138ed1e/numpy-2.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:ccb32e0525d29e8b0572eb84c9a57af0e7a4e615726927506f55063c62414034", size = 10485432, upload-time = "2026-09-06T16:24:57.278Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "2.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/fa/7ac648108144a095b4fb6aa3de1954689f7af60a14cf25583f4960ecb878/pandas-2.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:602b8615ebcc4a0c1751e71840428ddebeb142ec02c786e8ad6b1ce3c8dec523", size = 11578790, upload-time = "2025-09-29T23:18:30.065Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/35/74442388c6cf008882d4d4bdfc4109be87e9b8b7ccd097ad1e7f006e2e95/pandas-2.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8fe25fc7b623b0ef6b5009149627e34d2a4657e880948ec3c840e9402e5c1b45", size = 10833831, upload-time = "2025-09-29T23:38:56.071Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e4/de154cbfeee13383ad58d23017da99390b91d73f8c11856f2095e813201b/pandas-2.3.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b468d3dad6ff947df92dcb32ede5b7bd41a9b3cceef0a30ed925f6d01fb8fa66", size = 12199267, upload-time = "2025-09-29T23:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c9/63f8d545568d9ab91476b1818b4741f521646cbdd151c6efebf40d6de6f7/pandas-2.3.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b98560e98cb334799c0b07ca7967ac361a47326e9b4e5a7dfb5ab2b1c9d35a1b", size = 12789281, upload-time = "2025-09-29T23:18:56.834Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/a5ac8c7a0e67fd1a6059e40aa08fa1c52cc00709077d2300e210c3ce0322/pandas-2.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37b5848ba49824e5c30bedb9c830ab9b7751fd049bc7914533e01c65f79791", size = 13240453, upload-time = "2025-09-29T23:19:09.247Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4d/5c23a5bc7bd209231618dd9e606ce076272c9bc4f12023a70e03a86b4067/pandas-2.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db4301b2d1f926ae677a751eb2bd0e8c5f5319c9cb3f88b0becbbb0b07b34151", size = 13890361, upload-time = "2025-09-29T23:19:25.342Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/59/712db1d7040520de7a4965df15b774348980e6df45c129b8c64d0dbe74ef/pandas-2.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:f086f6fe114e19d92014a1966f43a3e62285109afe874f067f5abbdcbb10e59c", size = 11348702, upload-time = "2025-09-29T23:19:38.296Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/fb/231d89e8637c808b997d172b18e9d4a4bc7bf31296196c260526055d1ea0/pandas-2.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d21f6d74eb1725c2efaa71a2bfc661a0689579b58e9c0ca58a739ff0b002b53", size = 11597846, upload-time = "2025-09-29T23:19:48.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/bd/bf8064d9cfa214294356c2d6702b716d3cf3bb24be59287a6a21e24cae6b/pandas-2.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3fd2f887589c7aa868e02632612ba39acb0b8948faf5cc58f0850e165bd46f35", size = 10729618, upload-time = "2025-09-29T23:39:08.659Z" },
+    { url = "https://files.pythonhosted.org/packages/57/56/cf2dbe1a3f5271370669475ead12ce77c61726ffd19a35546e31aa8edf4e/pandas-2.3.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecaf1e12bdc03c86ad4a7ea848d66c685cb6851d807a26aa245ca3d2017a1908", size = 11737212, upload-time = "2025-09-29T23:19:59.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/63/cd7d615331b328e287d8233ba9fdf191a9c2d11b6af0c7a59cfcec23de68/pandas-2.3.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3d11d2fda7eb164ef27ffc14b4fcab16a80e1ce67e9f57e19ec0afaf715ba89", size = 12362693, upload-time = "2025-09-29T23:20:14.098Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/de/8b1895b107277d52f2b42d3a6806e69cfef0d5cf1d0ba343470b9d8e0a04/pandas-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a68e15f780eddf2b07d242e17a04aa187a7ee12b40b930bfdd78070556550e98", size = 12771002, upload-time = "2025-09-29T23:20:26.76Z" },
+    { url = "https://files.pythonhosted.org/packages/87/21/84072af3187a677c5893b170ba2c8fbe450a6ff911234916da889b698220/pandas-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:371a4ab48e950033bcf52b6527eccb564f52dc826c02afd9a1bc0ab731bba084", size = 13450971, upload-time = "2025-09-29T23:20:41.344Z" },
+    { url = "https://files.pythonhosted.org/packages/86/41/585a168330ff063014880a80d744219dbf1dd7a1c706e75ab3425a987384/pandas-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:a16dcec078a01eeef8ee61bf64074b4e524a2a3f4b3be9326420cabe59c4778b", size = 10992722, upload-time = "2025-09-29T23:20:54.139Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/ef/fc4f868f4e2cee79f863883abffceff107875f569b848507319842d2a681/pydantic-2.13.5.tar.gz", hash = "sha256:51a9c5f7b2f8e636f04c6cada605d9b6a3bf1348fdf945a3d8869b19bba0ee08", size = 845750, upload-time = "2026-08-28T14:04:00.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/47/c95ffc2009878c7aac0c5e08528022dcb885933252a88b5f170058014464/pydantic-2.13.5-py3-none-any.whl", hash = "sha256:346a034f080da3755d8e9cb5e00e8b07de1d39e4f6e2c87d8ab7cafa0b269a73", size = 472589, upload-time = "2026-08-28T14:03:59.136Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/f9/8a06bea35ef8daf588f707784c973a7046e0034c8d8cfb08828eeffb8b75/pydantic_core-2.46.5.tar.gz", hash = "sha256:10416c15b8839ecc4ef4d0885da76da6fd0f67333a0eb8aff6d93c4b8f2910fc", size = 472262, upload-time = "2026-08-28T10:01:31.677Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/b6/81d2d19ea0be2c03664381b59f65fa72fc7969decedae00bc2c4ad835708/pydantic_core-2.46.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a1dee1b804ff4d11c663636cf15d2ea47e9f79cd56c033fb1cbf08924842a48f", size = 2074737, upload-time = "2026-08-28T09:57:57.711Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/18/b70da8300e292df4099684ea11b1958043580d2f50d2dc8bf7e542bdd84a/pydantic_core-2.46.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d625a186a65201c23a9e3b8ed9c47e90a026e03256608cc91851c6709096844f", size = 1921751, upload-time = "2026-08-28T09:57:59.265Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/1a/0d590341b6ffa4b4aca83508e6b8db4761aaeacfc15a25ca3815876d4797/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f8507560a9284e1370bb048ed4282012fbef4e8d109875b95e884d228552061", size = 1948231, upload-time = "2026-08-28T09:58:00.678Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/02eb35761c51f2f7b1b042d6ab4cda6600f0c8c88a2243b3f734376201e5/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f93c5fe914d75fbec9a49209b00da5f08e9e467d69da2b1510c81940cfd10be", size = 2020708, upload-time = "2026-08-28T09:58:02.267Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ea/f86073830e35d508cc8ddf9c3d9e6e6840fcb88d34bf726b0b4710186f27/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c767f552b21b10f774aeac128e828eafb796adfa1b666a18bf6321453c3a", size = 2194914, upload-time = "2026-08-28T09:58:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d7/fc36240d7791ce90939e51608568c33bfdae26202016f9770c229a487d86/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:701b2e04b560eeb4bddf7a25ab8ca476176e34fdbd9a0e18196f0d12d4685f0b", size = 2235622, upload-time = "2026-08-28T09:58:05.516Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/bc/3fa2d76b83162820a17da7f645b28d1cba99fc8e1e5fc6517067ec450fa1/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49776eab08766a08dfff7012f8b422dcd7e25e43b316eedf0477c24fcfa84b7c", size = 2062091, upload-time = "2026-08-28T09:58:07.135Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/9a/095d557bb492c90cd8a70a6dd048bf793d433d03d86c81c11e912e4cd049/pydantic_core-2.46.5-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:a2468d93d181667a7abd66e1b64bb9f76f361b0fef8faddf687456453576f5ee", size = 2089904, upload-time = "2026-08-28T09:58:08.814Z" },
+    { url = "https://files.pythonhosted.org/packages/24/98/7b76b1ad10a19a617a52aaa1d80e159115af939b095e86f8e756fd52e0df/pydantic_core-2.46.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:53feb344243bb9510a9dec7bf3cf1b64d88a98af5dc7872a5160465f8b198c8e", size = 2132244, upload-time = "2026-08-28T09:58:10.435Z" },
+    { url = "https://files.pythonhosted.org/packages/20/32/7d6ca365fadba186a0c8f85de1a701663bce81efd309d9479be58687622f/pydantic_core-2.46.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:cd5214352ae68f3b5e9af7768bdc5253695ee069675db3480518420b3be881f2", size = 2143901, upload-time = "2026-08-28T09:58:12.033Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/09/eb9a6aa57f22fd1541a9c0aa2a1f3aeef3ec65347d33e10a6da2f43e0ee9/pydantic_core-2.46.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:9432f3598db432cb51c5b37fdbf29a60fcccc79e30d37a05022776a6bc4ab689", size = 2299425, upload-time = "2026-08-28T09:58:13.614Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f9/548a5bb9d4ba8cd26e26daf48052236f6b38bb61e7b7241fbc3c995719eb/pydantic_core-2.46.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8feeac04b5794e513e710af2f9c87d49f31a6dc47967bb264a1fed61a8989bec", size = 2318566, upload-time = "2026-08-28T09:58:15.199Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/20/06454d18834c02c406c9133f1a3b485305fd9ee984f9636c2f730bef6a9d/pydantic_core-2.46.5-cp311-cp311-win32.whl", hash = "sha256:892a881d5f68c2b9ea304b7a6c2c60d9343df578a311b0f86b94bc8f1ffe8129", size = 1954258, upload-time = "2026-08-28T09:58:16.813Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/718b9deb4b72453b5d8c7447a3b14cb77bef36917ef5f514e0948a4096a0/pydantic_core-2.46.5-cp311-cp311-win_amd64.whl", hash = "sha256:40375c2d05acec10323e45dfe2077ac44bc74659008614af5069034e2cfc781c", size = 2041030, upload-time = "2026-08-28T09:58:18.288Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ea/c1d1a5b72d6e1ff7f377a4d9199f6591f095beb5b409a8a5d89f7238d939/pydantic_core-2.46.5-cp311-cp311-win_arm64.whl", hash = "sha256:28a6a556cd3b6066bea827857f9d9cce027c96f776e512f544a581f9e42161f8", size = 2009234, upload-time = "2026-08-28T09:58:19.929Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3f/76358795aa7a8c6d4f36e2cb828ad1c90ee118e1393a9281664f5aade9d4/pydantic_core-2.46.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b9fe6fb92520e3fd61f2e49000b6911b188824f089b75973ea06d6267f0b476d", size = 2076516, upload-time = "2026-08-28T09:58:21.576Z" },
+    { url = "https://files.pythonhosted.org/packages/db/50/26b091836076ce4cb2fac264186936acc069e0595772cfd02a563bc4761a/pydantic_core-2.46.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a39ac25a9a2fa4072efdb429833c4a4c8009a51ff9eea3eeae131713cd27991e", size = 1922874, upload-time = "2026-08-28T09:58:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/09/f0/2a8ce3849e299d44e2d2c196b6082643a3235565a735cb51db7a6261f614/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4fdc8b93a41521988916eeaa271173fcca7fa0803d62f87675aac8dcec1c8e29", size = 1951772, upload-time = "2026-08-28T09:58:25.435Z" },
+    { url = "https://files.pythonhosted.org/packages/87/46/ac0dc8bdd9e6048183a14eb127764e7ad9240021c17513074a4711b0e31e/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b98134087d9de723658d17a42c7d0da8d6e2ef08015dee7dc93889047315f5e4", size = 2031832, upload-time = "2026-08-28T09:58:27.102Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/339de5bef7be36301a2231eaa52e62163742c2281f11b5f4892bc79785cd/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e652ab17569c94bff5475520f907b7148b8c24036a8ebbe5cf7cf7493d28579a", size = 2208645, upload-time = "2026-08-28T09:58:28.948Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a0/9ff22b797724262da14427abaed4dd1d864a139693fc5e7809114376a716/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d925f3d9afd05a8c0fb3a1031463a8d59ebe5e2afad297e29c78be19e13b4e62", size = 2265935, upload-time = "2026-08-28T09:58:30.625Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a4/eb9409ec0736e50aa70a412f16c204ed149516846912f7e6724d4c73ee53/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fc5be0abd4a407e200d844b404e33639a554e7bd0d448e7b9ae181be4789ac2", size = 2066284, upload-time = "2026-08-28T09:58:32.289Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/02/7f6156ffc926857f1c37c07d9a388682865a81830ab6a1b637082c25e399/pydantic_core-2.46.5-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:816ff0a6550ffc06c098ccd2e0698600f9aa7da192a79eaa6f9af504a35db869", size = 2105889, upload-time = "2026-08-28T09:58:33.986Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/e781d357ebe09fc929f995700f1b3503e8897f1cece183ecb1300d4d67e9/pydantic_core-2.46.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c7ea57fc63aa7da93a1bd2d644e6577befae10c52c4e36377635eea1056a74f5", size = 2158006, upload-time = "2026-08-28T09:58:35.647Z" },
+    { url = "https://files.pythonhosted.org/packages/70/0a/644597d84ab400e50609c192120b85c9681c22d3a20461b9060a79be0a7a/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:efd62a42486f1bda5d24cb4f63d15a3c7768375fe83d36f9417b4ad7a2fb20b3", size = 2158408, upload-time = "2026-08-28T09:58:37.38Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/ee/ca3b7b3a4b3769ffe9ce9432a7c9be755de9593a46d3b0d54d0409323e44/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:2bc9419666990c06d7397831f2126a1ecc3594aaa3ff7de5bf2d066802f4e07b", size = 2309609, upload-time = "2026-08-28T09:58:39.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/52/39fa1f451486019524ca685020390e7ca351832fd874530ba30c8628e6dc/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:18a09e1e1011b462f2e32774f25859ef1223d5c2b0546a633cf56654710721e0", size = 2342618, upload-time = "2026-08-28T09:58:40.89Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5e/468fc630568c61dcef3cd47ad32ffbeed9af643f49208d1ea86ab4f890c4/pydantic_core-2.46.5-cp312-cp312-win32.whl", hash = "sha256:5cb482e9e84c851f4e623fe4acc1ced89168cf1fe18f7089db4548c8f5bbb65b", size = 1939475, upload-time = "2026-08-28T09:58:42.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c9/4c19f41b84cf6b622a72fbeed7665b25d47a187d68d47d0d430c07f23268/pydantic_core-2.46.5-cp312-cp312-win_amd64.whl", hash = "sha256:5e81740c09e310f5aa5cbd3e434a01c154d4bef93241c7877b39f211d2b78ba8", size = 2043140, upload-time = "2026-08-28T09:58:44.272Z" },
+    { url = "https://files.pythonhosted.org/packages/af/dd/0c1a050299147c746e5256db16d645ab5efd4f78c59937d581a0524e74a2/pydantic_core-2.46.5-cp312-cp312-win_arm64.whl", hash = "sha256:f7b0ec93a2893de856652154d73b7ba622f26fa97726487dcac373de5f4c6084", size = 1997729, upload-time = "2026-08-28T09:58:46.13Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1e/ecca01fce348f7e8afa9572441ff6f7d1cc70d21e4859f33944d10877e1e/pydantic_core-2.46.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:c14ad3bdc85ee7f318742c457ca3968a92126d144b15721c759033bfb06296c2", size = 2075342, upload-time = "2026-08-28T10:00:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/4c/af80c7a8032dfc897040ad5cb772bebde529a381186499e6e29987f23f8c/pydantic_core-2.46.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0bddb4020d8f04175865ccd17eff3040874fc11fb593f424edb452653b4b947c", size = 1907219, upload-time = "2026-08-28T10:00:53.438Z" },
+    { url = "https://files.pythonhosted.org/packages/be/3e/54d89e2b092e778716bf6153634ef479e955f48c261090be23aa1e0fb0b5/pydantic_core-2.46.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2471fd51c61c610e1dcf7de44d7299283661654d11264ab4802b303368d69c47", size = 1953393, upload-time = "2026-08-28T10:00:55.58Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/89/828ee90cda28ce17bdefaa3a6eaf74fe430e113295a10e6126beca559d6c/pydantic_core-2.46.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b10ec717381bdbfafef34607824db4c91de69ff085e4fca3b2af91b4fa17e68a", size = 2099024, upload-time = "2026-08-28T10:00:57.794Z" },
+    { url = "https://files.pythonhosted.org/packages/df/dd/053c2e4303f791f3b8f8a14ab0b22008e8eb21d868c0c90b4f9be705b76a/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:013d6f3483d81e02e7c328831808f336c8596ee33b4bd4026b9ffb1e960b8942", size = 2062540, upload-time = "2026-08-28T10:01:00.318Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/dd/a18df751a5e37dd51bfad7f68e766999125bebe68c9e1d10a493ad01bd63/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:e9c134bb666dd54b778b9fc0d2b50cbb7f979b9e3716f26a88c9ab3b6fc1dd0f", size = 1902040, upload-time = "2026-08-28T10:01:02.529Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/13/01d40f9d07ce8a779fd6e0bd8ad4fba91309500dd67b869e2e219d261a6d/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:347ec774390c87326a2e4929d58d3f7e8763a104d5d35f4cd595a4c952366433", size = 1967479, upload-time = "2026-08-28T10:01:05.004Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/04/c81d4841331c2178b6fb09ae225425e110ed72d990c9fe556c4ec03d1013/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e24d8f05fa2d28513d94e877e9c75ad66175376209b3977f916e240e623193c", size = 2111034, upload-time = "2026-08-28T10:01:07.345Z" },
+    { url = "https://files.pythonhosted.org/packages/20/21/22102e9950b3049526d20e811b95396508377d87651edd2b80d2b3d28659/pydantic_core-2.46.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ab4b66edffb32d9e951efb3814bd104b8367a7501b81b955cacb5726d897389f", size = 2071333, upload-time = "2026-08-28T10:01:09.636Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/18/87aefa427d191e6d3ab1447f1efc1cdcac86af1069239b133e8a0fd7f7c9/pydantic_core-2.46.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:337639ba62a11acde6ef3aeb08c8ea755f8ef1fe5e513356c0f36a2b0d7568b0", size = 1912713, upload-time = "2026-08-28T10:01:12.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/93/fd89e9ad49b1805ca94d24ce1088b7d305f05c35ffafcedb9819d03588a0/pydantic_core-2.46.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:413a717a410d0c817ef5b786a059415550b3794e1d0c2abffd9efb93a3d9f7b4", size = 2090926, upload-time = "2026-08-28T10:01:15.19Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/45/8e59dab6acf8d35f02f0a958980074f31038968bdb2c983fcae9d1efee03/pydantic_core-2.46.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e449def1945a462c464331254e5a44fca7c3b4f9aedf59ec2f50f8066dd8e25", size = 2131303, upload-time = "2026-08-28T10:01:17.937Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a5/e1d4dc5180dd887a9522efc1f8716b8692b7606b1d3273d7862eaf66be44/pydantic_core-2.46.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:a445486499897b88a7d6c310c88ed64dd37b1b59bfd7ae9107490bbb362f47d6", size = 2145128, upload-time = "2026-08-28T10:01:20.694Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d7/ad493864a7fb21c0c4df98f965e2db430cb25a9d7369b5778d5016c09fd9/pydantic_core-2.46.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:2d330aaba8621b1edcec8ae2c4050f63b84ccf6d98723a8f212e9684713abf0e", size = 2294560, upload-time = "2026-08-28T10:01:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8e/b41c84c913f29973a268e6c2b5bbf13c95adb9956c126d10da11ba3b2bef/pydantic_core-2.46.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:b6acfb46a814762367fb7ba0828b0a17d441b92ce249a0e007474c9072662dda", size = 2317531, upload-time = "2026-08-28T10:01:26.334Z" },
+    { url = "https://files.pythonhosted.org/packages/db/1d/068464f23075f66a8f1b806935e9cd9363ee446636ea70d2c22ee8659dbf/pydantic_core-2.46.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d0a24b40877af2de4950252be9d21eaf7fb07660f3c2cae1f56c6b599ada5266", size = 2140686, upload-time = "2026-08-28T10:01:28.947Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/53/ed9d74092561d4b01a2ef1349d52cdbc135e526c245f366b089cfca6de49/python_dotenv-1.2.3.tar.gz", hash = "sha256:a20a594dabeaa385725aa239d5244871c143ecb356add8a20fcf23773a6c3a35", size = 58945, upload-time = "2026-08-16T16:54:54.067Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl", hash = "sha256:904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9", size = 22780, upload-time = "2026-08-16T16:54:52.473Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.3.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/48/fb042503b6ca6cd271261dc559fd6432f7d8c713153e9ec5c591af4dfc1c/pytz-2026.3.post1.tar.gz", hash = "sha256:2211d3fcf9a797d3405cac96ac7f61d80e6a644f72a3309607282fe8a2010c5d", size = 319745, upload-time = "2026-07-25T15:12:07.385Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/7b/39c34ca613b0b198cb866466651b26b045e2009864c5183c979a3b83f383/pytz-2026.3.post1-py2.py3-none-any.whl", hash = "sha256:dd95840dd199baea12d9cc096a1d452caa6596a1c1e4b5f3dbd1541855d5e815", size = 508283, upload-time = "2026-07-25T15:12:05.782Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+]
+
+[[package]]
+name = "safetensors"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/06/f955dbbb1859e3bd23c8ac6141af5106e7ad5fedec4a3a6e3d60f94b7001/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/a0/f718cda65b05407d228f97602cf60dca269c979867aa5beb25410de26cd3/safetensors-0.8.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c554f85858e05226d3c2828e32395e677434685d6d94594a41643361c5e837f0", size = 473568, upload-time = "2026-06-09T07:52:18.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b1/fa7c600e7dceae12e9606c7578cbc9ff1e1ed55844883ee5c92205e86226/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/65a7de0af421317bb36a067241e4235fff194eed60b961ed6d3f59a3fc60/safetensors-0.8.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a46e5ff292c356d6991e60942ba7f79817682d3a2cef0702136448cb9c4d235", size = 502844, upload-time = "2026-06-09T07:52:07.624Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4f/3175c9d75634e0e0dda0082794193521035edd7c70a6f212bf33ca06ddf4/safetensors-0.8.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4124502b78f03534117c848f87a39b8f31e577b15eff423bf8bfb95f2a8c30d0", size = 511823, upload-time = "2026-06-09T07:52:09.565Z" },
+    { url = "https://files.pythonhosted.org/packages/20/87/846c289e7aa2299eff406335717cf43ce8777194ece8aad75772e0411615/safetensors-0.8.0-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bc0a787ba8a35be368ee3574edfa2b1ad389eebd0a72e482ae275490e3f6c98", size = 633461, upload-time = "2026-06-09T07:52:11.128Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/8d64d9df2c45d5ded401df889d0ad90882804ca172d79ec4f0df8f727fe0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:040070828e36dc8e122178bbbd5830ff9e97920affb84cbe0f46442497bed358", size = 545148, upload-time = "2026-06-09T07:52:13.603Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/f203ff3a3ddfe19308efc83c5a3a29ed02bf786732ec35e68bf9162f3365/safetensors-0.8.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd6f3f93c9a0a7cc2788ee63fb763353d4bd2e89b0751bc78fcf7dda00bea774", size = 516040, upload-time = "2026-06-09T07:52:16.29Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fb/cdaed17ceb2948784fd9c36b6fd3e951b608547cea81a48e8ee6f8cfdfcb/safetensors-0.8.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:fcdd41ec4628fee5799f807c73c353629130fbd942aa23d83c623dd6c9d52d78", size = 513832, upload-time = "2026-06-09T07:52:12.37Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/49/1e15de264dcc3b77943d2d0c56a95809956883b1c2d6d585c792523f180b/safetensors-0.8.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8e9f537aa183a38ace122d27303dcd986b26bd2a7591f9181d7f0c396f4677ca", size = 559930, upload-time = "2026-06-09T07:52:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/43/bf38443278eab4b1be1fce2931e2b012ad9cb7df52ada751d0aab8f7659a/safetensors-0.8.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87eec7ffed2b809f05a398a8becb7d013f19f7837cd15d9748580d6cf30dbaf4", size = 678670, upload-time = "2026-06-09T07:52:20.032Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e3/68cd3fa5b48488e84add63e04cb12f3bc28ae4638c06d4508c6e88823d0e/safetensors-0.8.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4a95ae2b05d7726d751da4ebf626a2ca782b706e101bd894c95bc2450b1cffcc", size = 786679, upload-time = "2026-06-09T07:52:21.322Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/1c19c509d56e01f4fbb3d0a2e597450f6cc04d1d56cf52defb0a62dfd715/safetensors-0.8.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae091f16662658bdc019a4ff6cb4c085bb7d725eb5978b183ffd265863b6d2d", size = 765683, upload-time = "2026-06-09T07:52:22.594Z" },
+    { url = "https://files.pythonhosted.org/packages/27/43/41c1621732edd934d868a00d1b891584c892a7b62a9aab82ea5a0a5623ee/safetensors-0.8.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e080062fcde23be189565e1c3305d16751a218ecf9412c8601e64204eb6f846", size = 722361, upload-time = "2026-06-09T07:52:23.924Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3f/73ccf82579412b4a71c4ca673f10b5f1f888d7cf5af7fe24f27d30307be4/safetensors-0.8.0-cp310-abi3-win32.whl", hash = "sha256:2ddf52eac562eda224f99acfa7889d02968c1fd59a5b011ae7d8137c37e9c02d", size = 342401, upload-time = "2026-06-09T07:52:28.895Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6d/3fba214c1e5e0f69991677ec3bc17023f0421776975e1de0c682dca475e2/safetensors-0.8.0-cp310-abi3-win_amd64.whl", hash = "sha256:096ec1a98435df7beb08853bb5aa9081a84f23d0adc67ed1a0a10550f608373f", size = 355540, upload-time = "2026-06-09T07:52:27.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fc/7eedc3510d97878876e32774eebbeb61c43f148a96e915c84229a3e967aa/safetensors-0.8.0-cp310-abi3-win_arm64.whl", hash = "sha256:f7838e5135a406ad3e02efdcb8cf2e5397d368b0154537c4fec682dbc544d452", size = 340500, upload-time = "2026-06-09T07:52:26.745Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "84.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73", size = 1168449, upload-time = "2026-08-08T18:27:58.365Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670", size = 818216, upload-time = "2026-08-08T18:27:56.719Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'linux'",
+    "python_full_version < '3.12' and sys_platform != 'linux'",
+]
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/2c/0c9757a1ea1fff8ccc4faff1d1c87e98a69542b5d4b606e50f7518f72e58/torch-2.14.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:ae530ddd3f3b94248b77f1fd3313c4f3405bd0d17283d505b81574816767133a", size = 127277244, upload-time = "2026-09-02T13:42:57.855Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/5b/ed9d177f6a133389d5fa89e298f3e2a879b62952aa928ac6ddd04467f225/torch-2.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:6981872df75eb5409c439050d36b67cb57d88b4e11080516e2aa7410f6730705", size = 124096356, upload-time = "2026-09-02T13:43:02.941Z" },
+    { url = "https://files.pythonhosted.org/packages/17/76/bb4770f56cf6d8971671dbcbb7493e5a6a15ad2825f4e359b02c27c38297/torch-2.14.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:c1f844f1c750e87df4b68bc3afbc0e2b0c7ef19d7b8f666e48bdcf6a0c4f0056", size = 127303200, upload-time = "2026-09-02T13:43:20.311Z" },
+    { url = "https://files.pythonhosted.org/packages/be/16/9489b137112040f9911d7527e452854f21cc4e499ce0da79864e6a7451a7/torch-2.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:cad84f41bbdf3dcf333ce394aeeaf25237c4d94fd6b659ba5eb813c829978823", size = 124114011, upload-time = "2026-09-02T13:43:55.034Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.14.0+cpu"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+]
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:3fa39713d13f23563ad11636bfff76b677ab4addbc240c54e6b7e47622e8973d", upload-time = "2026-09-02T18:31:08Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:08894195f84541edcbd09072e6c53b791d4cdd09f650b05473f35718a848fd7b", upload-time = "2026-09-02T18:31:13Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:673dbf5c9bbadfffab7a386b6dd7a0c219f1408a328b7b4e86d0ae551cdafa42", upload-time = "2026-09-02T18:31:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:07aefe1a437b6f1b41b0cba15e16583e2f43549ec9d062fcea8e7981a78e014a", upload-time = "2026-09-02T18:31:32Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:da8140c3d4a41500d29710e35bf8e66a4295ec31026487c69f54a3f583310f8d", upload-time = "2026-09-02T18:31:37Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a09987c95ec4cffdb6df798d3d641558110a334cfccce22f2f046d83142bc260", upload-time = "2026-09-02T18:31:42Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
+]
+
+[[package]]
+name = "tradinggoose-kronos-inference"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "einops" },
+    { name = "fastapi" },
+    { name = "huggingface-hub" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "pandas" },
+    { name = "pydantic-settings" },
+    { name = "safetensors" },
+    { name = "torch", version = "2.14.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "torch", version = "2.14.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'linux'" },
+    { name = "uvicorn" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "einops", specifier = "==0.8.1" },
+    { name = "fastapi", specifier = ">=0.116,<1" },
+    { name = "huggingface-hub", specifier = ">=0.33,<2" },
+    { name = "numpy", specifier = ">=2.0,<3" },
+    { name = "pandas", specifier = ">=2.2,<3" },
+    { name = "pydantic-settings", specifier = ">=2.10,<3" },
+    { name = "safetensors", specifier = ">=0.6,<1" },
+    { name = "torch", marker = "sys_platform != 'linux'", specifier = ">=2.6,<3" },
+    { name = "torch", marker = "sys_platform == 'linux'", specifier = ">=2.6,<3", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "uvicorn", specifier = ">=0.35,<1" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx", specifier = ">=0.28,<1" },
+    { name = "pytest", specifier = ">=8.4,<10" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.52.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1", size = 79871, upload-time = "2026-08-19T06:27:40.36Z" },
+]

--- a/services/kronos-inference/uv.lock
+++ b/services/kronos-inference/uv.lock
@@ -2,10 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.11, <3.13"
 resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and sys_platform == 'linux'",
-    "python_full_version >= '3.12' and sys_platform != 'linux'",
-    "python_full_version < '3.12' and sys_platform != 'linux'",
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
 ]
 
 [[package]]
@@ -64,6 +62,77 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cuda-bindings"
+version = "13.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/45/57fb37fea9200d854960e36c2181675f92d16bfd7012cc5a95b153e782f0/cuda_bindings-13.4.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:56c1552e207b291c321cef9952fbfaf8591c2a14d9c6e5215071020f541a04e5", size = 6484208, upload-time = "2026-09-10T01:16:46.069Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/00/15dc1b8f2e5e98975107c366ec5671256d32b8e5c5ed6c1bb3a90a64f035/cuda_bindings-13.4.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e5dc0f13cfd14cd62206fede462f91c497d0c484b8236f4158531d20377066cd", size = 7159324, upload-time = "2026-09-10T01:16:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d0/76d0e45d98bf4933bf48eac6bbeb17464684540f69edec41fc37c7a422b0/cuda_bindings-13.4.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:84ee88862e2e6ac39a5434c061f7f4389fbefbc418487d0670c86601d517d038", size = 6479976, upload-time = "2026-09-10T01:16:54.622Z" },
+    { url = "https://files.pythonhosted.org/packages/43/56/d7b219516980f3333e232c13d727e8f4dc59afc5381cbbcfbc1215014c81/cuda_bindings-13.4.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f444d7e488cbc47e79b7be0d1cfe97201f3e1f186a18ee10f2e4da3265975b16", size = 7170956, upload-time = "2026-09-10T01:16:56.854Z" },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.8.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/e6/22df83f82f9bc26cb1c42265cf14d34d4908dba2a0f261bd7b28244acb00/cuda_pathfinder-1.8.1-py3-none-any.whl", hash = "sha256:ae0137ff9e56ea97499bcbf54f5f2778ec25f3266715ac86da192a795af982a8", size = 62552, upload-time = "2026-09-02T16:55:28.64Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.3.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/c7/a79086a62c98befcdb8349656c6f114e2db3b8b2422f6e25c97a7f2a9a3c/cuda_toolkit-13.0.3.0-py2.py3-none-any.whl", hash = "sha256:d693caaa261214ddd7dbb60d68e71cbed884e68c2be7509778f3051da0b91c3f", size = 2512, upload-time = "2026-04-14T00:50:08.173Z" },
+]
+
+[package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cusolver = [
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -265,8 +334,7 @@ name = "numpy"
 version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.12' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and sys_platform != 'linux'",
+    "python_full_version < '3.12'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
@@ -306,8 +374,7 @@ name = "numpy"
 version = "2.5.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform == 'linux'",
-    "python_full_version >= '3.12' and sys_platform != 'linux'",
+    "python_full_version >= '3.12'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/01/11703282db468b85f6f7b8c7f22d058de5970d5c7e60a3a8aaa313c3de36/numpy-2.5.3.tar.gz", hash = "sha256:df2d5874ff183595a4ba404edd04f6bd9b5505c1d7708573f6a6c17489a67563", size = 20791231, upload-time = "2026-09-06T16:27:47.073Z" }
 wheels = [
@@ -322,6 +389,158 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/db/35e1c2d38b04cbd5b731f9d71495e055e813197669d22b612f11748d2ff9/numpy-2.5.3-cp312-cp312-win32.whl", hash = "sha256:bf63afbe037eb5d2fe87fbcc7778e61da53ebaf21d938a4515aa73b62532a5d4", size = 6133378, upload-time = "2026-09-06T16:24:51.915Z" },
     { url = "https://files.pythonhosted.org/packages/3c/a1/accf6d4f0c80c5d9ba9735d6b1550e444180599f34dec69ca01360f717ad/numpy-2.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:0a59a421a32580a009e8a1751345bf829631b990dc1794b80514ab722b435def", size = 12567828, upload-time = "2026-09-06T16:24:54.255Z" },
     { url = "https://files.pythonhosted.org/packages/22/43/1764aff32e4652526ae2f71fa8b3efd8d25c8a3d6926914454e47138ed1e/numpy-2.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:ccb32e0525d29e8b0572eb84c9a57af0e7a4e615726927506f55063c62414034", size = 10485432, upload-time = "2026-09-06T16:24:57.278Z" },
+]
+
+[[package]]
+name = "nvidia-cublas"
+version = "13.1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.24.0.43"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/30/7c257e3d5cb4fecb147b93895c66e29c93f8e76d74b45bb418ff0587c4ec/nvidia_cudnn_cu13-9.24.0.43-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:a6812a554a1ff0413e9c52b84c26c050380649ab9615f9c16bded368ce9f421f", size = 650976863, upload-time = "2026-07-02T16:23:39.248Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ba/791cffd048fe5b044e620df55267e3e95c0e6e07d50b41e377c03dfc910f/nvidia_cudnn_cu13-9.24.0.43-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:71f181cd810e90f9b6023b01186fe82d13d65f0ec098581ee201d39fad769e4b", size = 553099438, upload-time = "2026-07-02T16:27:42.58Z" },
+]
+
+[[package]]
+name = "nvidia-cufft"
+version = "12.0.0.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+]
+
+[[package]]
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu13"
+version = "2.30.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/21/a73174c6157101bdf1ffc22b517f76ff0082613989dd9bc8f43e8034caac/nvidia_nccl_cu13-2.30.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:ca786ffa5a647c75d4d1f5cc72a6c4f537947e2ba8823d7c8aaf768e7a7b9f77", size = 215983881, upload-time = "2026-06-09T03:23:15.633Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/34/c500f90c7ae641b8e0f98965b36b8a7ac79cc8b296e8d251fe3eb592ee54/nvidia_nccl_cu13-2.30.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:cefa7fdb9710efd0f39c5f1be1d61ff6fc9a996c451265bd7fbdcf9455ed4b50", size = 215965170, upload-time = "2026-06-09T03:23:39.73Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink"
+version = "13.4.52"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/c1/091f198d7f87e31d67fa9680eec8f8e4c6f889881f729b759db36ff01612/nvidia_nvjitlink-13.4.52-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:90401db7e5a580a5067a468b3086e0b65f3b96ab3c42524afd741efc8a0e150a", size = 42452221, upload-time = "2026-09-09T18:01:32.895Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a9/225ff51e80de170be880cb88e992193bc8134a51059cc0a3952f967f62c5/nvidia_nvjitlink-13.4.52-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3a589e3732140839349545efd0db67426523459b12e6952c3c73b6d55900f200", size = 40419746, upload-time = "2026-09-09T18:01:25.103Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu13"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
 ]
 
 [[package]]
@@ -610,50 +829,31 @@ wheels = [
 name = "torch"
 version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform != 'linux'",
-    "python_full_version < '3.12' and sys_platform != 'linux'",
-]
 dependencies = [
+    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
     { name = "setuptools" },
     { name = "sympy" },
+    { name = "triton", marker = "sys_platform == 'linux'" },
     { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/2c/0c9757a1ea1fff8ccc4faff1d1c87e98a69542b5d4b606e50f7518f72e58/torch-2.14.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:ae530ddd3f3b94248b77f1fd3313c4f3405bd0d17283d505b81574816767133a", size = 127277244, upload-time = "2026-09-02T13:42:57.855Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/30/eb2f6cf77cb8f2d5e7ce4343882a856783521f51b557673d78d1d7bb8661/torch-2.14.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:4dbea8a10d80b10dff2be1ed467d2617b704fe6bf76bbfad4194774c8f6d886b", size = 453993896, upload-time = "2026-09-02T13:43:29.231Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/be/c0c8a845bf00552960d2f1f6a00b6ac9750fd312f55429c3e8c6c0e3aac4/torch-2.14.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:8d9e232b6376c62f3090237889fb1cb6887c0ece9f73e6c1052e80fc1481f999", size = 554583496, upload-time = "2026-09-02T13:44:10.199Z" },
     { url = "https://files.pythonhosted.org/packages/e3/5b/ed9d177f6a133389d5fa89e298f3e2a879b62952aa928ac6ddd04467f225/torch-2.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:6981872df75eb5409c439050d36b67cb57d88b4e11080516e2aa7410f6730705", size = 124096356, upload-time = "2026-09-02T13:43:02.941Z" },
     { url = "https://files.pythonhosted.org/packages/17/76/bb4770f56cf6d8971671dbcbb7493e5a6a15ad2825f4e359b02c27c38297/torch-2.14.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:c1f844f1c750e87df4b68bc3afbc0e2b0c7ef19d7b8f666e48bdcf6a0c4f0056", size = 127303200, upload-time = "2026-09-02T13:43:20.311Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/7b/ec44bacf2c8886b85ba4ca2285e8b09f2dff5d9c99e6a031326954082cb5/torch-2.14.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:ada340e62591d06a2bcc2d68170f20f45f0b0665d372dc510a8ed7eb3b1d609a", size = 454010251, upload-time = "2026-09-02T13:44:24.927Z" },
+    { url = "https://files.pythonhosted.org/packages/15/71/49399acd41f750a906c686bd23c08a2001ccb8dd25f2971003c2ed89c1dd/torch-2.14.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:fecffb58f51fd643d213acd68da21cc3fc19bea05a3bc64b4ee55128f47a4963", size = 554620488, upload-time = "2026-09-02T13:44:49.442Z" },
     { url = "https://files.pythonhosted.org/packages/be/16/9489b137112040f9911d7527e452854f21cc4e499ce0da79864e6a7451a7/torch-2.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:cad84f41bbdf3dcf333ce394aeeaf25237c4d94fd6b659ba5eb813c829978823", size = 124114011, upload-time = "2026-09-02T13:43:55.034Z" },
-]
-
-[[package]]
-name = "torch"
-version = "2.14.0+cpu"
-source = { registry = "https://download.pytorch.org/whl/cpu" }
-resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform == 'linux'",
-    "python_full_version < '3.12' and sys_platform == 'linux'",
-]
-dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "typing-extensions" },
-]
-wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:3fa39713d13f23563ad11636bfff76b677ab4addbc240c54e6b7e47622e8973d", upload-time = "2026-09-02T18:31:08Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:08894195f84541edcbd09072e6c53b791d4cdd09f650b05473f35718a848fd7b", upload-time = "2026-09-02T18:31:13Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:673dbf5c9bbadfffab7a386b6dd7a0c219f1408a328b7b4e86d0ae551cdafa42", upload-time = "2026-09-02T18:31:19Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:07aefe1a437b6f1b41b0cba15e16583e2f43549ec9d062fcea8e7981a78e014a", upload-time = "2026-09-02T18:31:32Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:da8140c3d4a41500d29710e35bf8e66a4295ec31026487c69f54a3f583310f8d", upload-time = "2026-09-02T18:31:37Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a09987c95ec4cffdb6df798d3d641558110a334cfccce22f2f046d83142bc260", upload-time = "2026-09-02T18:31:42Z" },
 ]
 
 [[package]]
@@ -681,8 +881,7 @@ dependencies = [
     { name = "pandas" },
     { name = "pydantic-settings" },
     { name = "safetensors" },
-    { name = "torch", version = "2.14.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
-    { name = "torch", version = "2.14.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'linux'" },
+    { name = "torch" },
     { name = "uvicorn" },
 ]
 
@@ -701,8 +900,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.2,<3" },
     { name = "pydantic-settings", specifier = ">=2.10,<3" },
     { name = "safetensors", specifier = ">=0.6,<1" },
-    { name = "torch", marker = "sys_platform != 'linux'", specifier = ">=2.6,<3" },
-    { name = "torch", marker = "sys_platform == 'linux'", specifier = ">=2.6,<3", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torch", specifier = ">=2.6,<3" },
     { name = "uvicorn", specifier = ">=0.35,<1" },
 ]
 
@@ -710,6 +908,17 @@ requires-dist = [
 dev = [
     { name = "httpx", specifier = ">=0.28,<1" },
     { name = "pytest", specifier = ">=8.4,<10" },
+]
+
+[[package]]
+name = "triton"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/cf/d21c9b1a4d1df9ba3aed218069f24f762a4b9565c5a362bef6f110c08e72/triton-3.8.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:372285307d4c44ee74cee32de0b4f04bd157e071427e38c6f4ee3e3beb2194f4", size = 226467015, upload-time = "2026-08-28T16:08:05.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/9a/2c3d3823726d5ad5359f7065b02b984925158b74611c1e3987f6a37461fb/triton-3.8.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:68988ac85d5e7086baeda0ddc175af9667db7529b3c5e11a5c0601b8bef2200a", size = 247945226, upload-time = "2026-08-28T15:55:43.795Z" },
+    { url = "https://files.pythonhosted.org/packages/87/07/0f8cd8e8db0472334253efdaaab3d0819fea27aa99bf0e7f1aeea4ceb5ae/triton-3.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a9c404c69ed4a39e8ec632eaf6b9fe058a060bf98979c177f6ef666f06bb8d50", size = 226474486, upload-time = "2026-08-28T16:08:18.29Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/09/b7012e5bfae67640f268aa584caa80fe1674f6b0da949046b679972c33e3/triton-3.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e91ffa46d095b252248297292dd22bcbacd53a125a0c2eefbbbf74925a320bc3", size = 247972921, upload-time = "2026-08-28T15:55:53.157Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Hosted models still proxy to copilot.tradinggoose.ai. Models with the `vllm/`
│ prefix now run the whole turn in-process: inference against a self-hosted
│ OpenAI-compatible endpoint, tool execution, SSE streaming and persistence.
│
│ ### New module: `lib/copilot/local-runtime/`
│ `runtime-models.ts`, `types.ts`, `prompt.ts`, `working-messages.ts`,
│ `persistence.ts`, `tool-execution.ts`, `agent.ts`, `chat-handler.ts`,
│ `title.ts`, plus `check-syntax.ts` (a parser-only pre-build gate).
│
│ ### Patched
│ - `lib/copilot/runtime-models.ts` — accept local ids by prefix
│ - `app/api/copilot/chat/route.ts` — widen model schema, branch to the local loop
│ - `app/api/copilot/tools/mark-complete/route.ts` — local continuation
│ - `app/api/copilot/usage/route.ts` — widen model schema
│ - `lib/copilot/agent/utils.ts` — local title generation
│ - `model-selector.tsx` — list discovered self-hosted models
│ - `lib/system-services/catalog.ts` — relabel the vllm service entry
│
│ ### No schema migration
│ Working state lives in the existing `copilotReviewItems` table, namespaced with a
│ `[[local-working]]` content prefix and `local_*` item ids, so it is filtered from
│ both the user-visible transcript and the model's own message list. An in-memory
│ map was rejected: the route bundle and the client bundle do not share module
│ state, and a restart would lose the conversation.
│
│ ### Access level
│ The chat route carries no `accessLevel`, so local turns execute server tools as
│ `limited`, matching the managed runtime's auto-accepted reviews.
│
│ ### Verified end-to-end
│ - Model emits `function_call`, the agent executes it in-process, the result is
│   fed back, and the model answers (`list_workflows` → `count: 0`)
│ - SSE contract unchanged; the client renders local turns like hosted ones
│ - Two-turn history replay on a persisted session
│ - Tool calling verified against the real 76-tool manifest
│
│ ### Notes for review
│ - The deploy-time local-runtime step is deliberately NOT part of
│   `update-from-github.sh`. That script is shared with another workstream and was
│   replaced wholesale twice, each time silently deleting the step. The step and
│   its parser gate live in a separate entry point an overwrite cannot remove.
│ - No deploy-local files are included (`docker-compose.ibkr.yml`, the
│   `docker/app.Dockerfile` ARG/ENV injection).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Interactive Brokers support for OAuth connections, market data, portfolios, performance, positions, and order placement.
  * Added Kronos forecasting with a dedicated forecast tool, validation, risk controls, and inference service.
  * Added self-hosted Copilot model support, including runtime discovery, streaming responses, tool execution, and local title generation.
  * Added access-token authentication support for market data requests.
* **Documentation**
  * Added IBKR connection setup and capability documentation.
  * Updated provider documentation to include IBKR.
* **Tests**
  * Added coverage for IBKR, Kronos forecasting, risk controls, signal policies, and local inference behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->